### PR TITLE
fix(Witten): fix opening_hours

### DIFF
--- a/cities/witten.json
+++ b/cities/witten.json
@@ -64,7 +64,7 @@
       "properties": {
         "title": "Karl-Legien-Straße",
         "location": "Karl-Legien-Straße",
-        "opening_hours": "Mi 09:00-14:00"
+        "opening_hours": "We 09:00-14:00"
       }
     },
     {
@@ -79,7 +79,7 @@
       "properties": {
         "title": "Auf dem Schnee 1",
         "location": "Auf dem Schnee 1",
-        "opening_hours": "Mi 09:00-14:00"
+        "opening_hours": "We 09:00-14:00"
       }
     }
   ],


### PR DESCRIPTION
fix typo in opening_hours (`Mi` becomes `We`)

thanks to [@reclus23](https://twitter.com/reclus23/status/723489623964561408)