### PR TITLE
Fix #25: Replace legend with togglable header.

### DIFF
--- a/cities/berlin.json
+++ b/cities/berlin.json
@@ -2595,7 +2595,7 @@
     ],
     "metadata": {
         "data_source": {
-            "title": "Daten von der Stadt Berlin, CC BY 3.0 DE, aktualisiert am 10.06.2016",
+            "title": "Stadt Berlin, CC BY 3.0 DE, aktualisiert am 10.05.2016",
             "url": "http://daten.berlin.de/datensaetze/wochen-und-tr%C3%B6delm%C3%A4rkte"
         },
         "map_initialization": {

--- a/cities/bochum.json
+++ b/cities/bochum.json
@@ -190,7 +190,7 @@
   ],
   "metadata": {
     "data_source": {
-      "title": "Daten von der Stadt Bochum",
+      "title": "Stadt Bochum",
       "url": "https://www.bochum.de/amt32/wochenmaerkte"
     },
     "map_initialization": {

--- a/cities/chemnitz.json
+++ b/cities/chemnitz.json
@@ -93,7 +93,7 @@
 	],
 	"metadata": {
 		"data_source": {
-			"title": "Daten von der Stadt Chemnitz",
+			"title": "Stadt Chemnitz",
 			"url": "http://www.chemnitz.de/chemnitz/de/aktuelles/ausschreibungen/marktausschreibung/index.html"
 		},
 		"map_initialization": {

--- a/cities/dortmund.json
+++ b/cities/dortmund.json
@@ -205,7 +205,7 @@
   ],
   "metadata": {
     "data_source": {
-      "title": "Daten von der Stadt Dortmund",
+      "title": "Stadt Dortmund",
       "url": "https://www.dortmund.de/de/leben_in_dortmund/stadtportraet/einkaufen/wochenmaerkte/"
     },
     "map_initialization": {

--- a/cities/dresden.json
+++ b/cities/dresden.json
@@ -145,7 +145,7 @@
     ],
     "metadata": {
         "data_source": {
-            "title": "Daten der Stadt Dresden",
+            "title": "Stadt Dresden",
             "url": "https://www.dresden.de/de/leben/sport-und-freizeit/maerkte-in-dresden.php"
         },
         "map_initialization": {

--- a/cities/duisburg.json
+++ b/cities/duisburg.json
@@ -445,7 +445,7 @@
   ],
   "metadata": {
     "data_source": {
-      "title": "Daten von Duisburg Kontor GmbH",
+      "title": "Duisburg Kontor GmbH",
       "url": "https://www.duisburg.de/leben/maerkte_in_duisburg/index.php"
     },
     "map_initialization": {

--- a/cities/düsseldorf.json
+++ b/cities/düsseldorf.json
@@ -395,7 +395,7 @@
     "metadata": {
         "data_source": {
             "url": "https://www.duesseldorf.de/verbraucherschutz/marktverwaltung/wochen.shtml",
-            "title": "Amt für Verbraucherschutz - Landeshauptstadt Düsseldorf"
+            "title": "Amt für Verbraucherschutz Düsseldorf"
         },
         "map_initialization": {
             "zoom_level": 11,

--- a/cities/erlangen.json
+++ b/cities/erlangen.json
@@ -93,7 +93,7 @@
     ],
     "metadata": {
         "data_source": {
-            "title": "Daten von Stadt Erlangen",
+            "title": "Stadt Erlangen",
             "url": "http://www.erlangen.de/Portaldata/1/Resources/030_leben_in_er/dokumente/amt31/070621_Umwelttip.pdf"
         },
      "map_initialization": {

--- a/cities/essen.json
+++ b/cities/essen.json
@@ -400,7 +400,7 @@
   ],
   "metadata": {
     "data_source": {
-      "title": "Daten von der EVB",
+      "title": "EVB",
       "url": "https://www.essen.de/rathaus/aemter/ordner_32/Wochenmaerkte.de.html"
     },
     "map_initialization": {

--- a/cities/hilden.json
+++ b/cities/hilden.json
@@ -55,7 +55,7 @@
   ],
   "metadata": {
     "data_source": {
-      "title": "Daten der Stadt Hilden",
+      "title": "Stadt Hilden",
       "url": "http://www.hilden.de/sv_hilden/Unsere%20Stadt/Rathaus/Ortsrecht/II-04%20Festsetzung%20Wochenm%C3%A4rkte.pdf"
     },
     "map_initialization": {

--- a/cities/karlsruhe.json
+++ b/cities/karlsruhe.json
@@ -249,7 +249,7 @@
     ],
     "metadata": {
         "data_source": {
-            "title": "Daten von der Stadt Karlsruhe",
+            "title": "Stadt Karlsruhe",
             "url": "http://www.karlsruhe.de/b3/maerkte/wochenmarkte.de"
         },
         "map_initialization": {

--- a/cities/langenfeld_rhld.json
+++ b/cities/langenfeld_rhld.json
@@ -25,7 +25,7 @@
   ],
   "metadata": {
     "data_source": {
-      "title": "Daten der Stadt Langenfeld (Rhld.)",
+      "title": "Stadt Langenfeld (Rhld.)",
       "url": "http://langenfeld.active-city.net/city_info/display/dokument/show.cfm?region_id=138&id=4240&design_id=3340&type_id=0&titletext=1"
     },
     "map_initialization": {

--- a/cities/leipzig.json
+++ b/cities/leipzig.json
@@ -228,7 +228,7 @@
     ],
     "metadata": {
         "data_source": {
-            "title": "Daten der Stadt Leipzig",
+            "title": "Stadt Leipzig",
             "url": "https://www.leipzig.de/freizeit-kultur-und-tourismus/einkaufen-und-ausgehen/maerkte/"
         },
         "map_initialization": {

--- a/cities/mülheim-an-der-ruhr.json
+++ b/cities/mülheim-an-der-ruhr.json
@@ -85,7 +85,7 @@
   ],
   "metadata": {
     "data_source": {
-      "title": "Daten von der Stadt Mülheim an der Ruhr",
+      "title": "Stadt Mülheim an der Ruhr",
       "url": "https://www.muelheim-ruhr.de/cms/muelheimer_wochenmaerkte1.html"
     },
     "map_initialization": {

--- a/cities/münchen.json
+++ b/cities/münchen.json
@@ -2,7 +2,7 @@
    "type": "FeatureCollection",
    "metadata": {
       "data_source": {
-         "title": "Daten von der Stadt München, CC BY 2.0 DE, aktualisiert am 27.02.2015",
+         "title": "Stadt München, CC BY 2.0 DE, aktualisiert am 27.02.2015",
          "url": "https://www.opengov-muenchen.de/dataset/maerkte"
       },
       "map_initialization": {

--- a/cities/münster.json
+++ b/cities/münster.json
@@ -274,7 +274,7 @@
   ],
     "metadata": {
         "data_source": {
-            "title": "Daten von der Stadt Münster",
+            "title": "Stadt Münster",
             "url": "http://www.muenster.de/stadt/maerkte/markt.html"
         },
         "map_initialization": {

--- a/cities/neu-ulm.json
+++ b/cities/neu-ulm.json
@@ -18,7 +18,7 @@
     ],
     "metadata": {
         "data_source": {
-            "title": "Daten von der Stadt Neu-Ulm",
+            "title": "Stadt Neu-Ulm",
             "url": "http://nu.neu-ulm.de/de/neu-ulm-erleben/veranstaltungen/feste-maerkte/wochenmarkt/"
         },
         "map_initialization": {

--- a/cities/paderborn.json
+++ b/cities/paderborn.json
@@ -79,7 +79,7 @@
   ],
     "metadata": {
         "data_source": {
-            "title": "Daten von der Stadt Paderborn",
+            "title": "Stadt Paderborn",
             "url": "http://www.paderborn.de/microsite/wochenmarkt/marktinfos/109010100000079411.php?p=5,1"
         },
         "map_initialization": {

--- a/cities/rostock.json
+++ b/cities/rostock.json
@@ -259,7 +259,7 @@
   "type": "FeatureCollection",
   "metadata": {
     "data_source": {
-      "title": "Daten von der Hansestadt Rostock, aktualisiert am 04.06.2016",
+      "title": "Hansestadt Rostock, aktualisiert am 04.06.2016",
       "url": "http://www.rostocker-wochenmaerkte.de/standorte-angebote/"
       },
     "map_initialization": {

--- a/cities/schwerin.json
+++ b/cities/schwerin.json
@@ -124,7 +124,7 @@
   "type": "FeatureCollection",
   "metadata": {
     "data_source": {
-      "title": "Webseite der Stadtmarketing Gesellschaft Schwerin mbH",
+      "title": "Stadtmarketing Gesellschaft Schwerin mbH",
       "url": "http://marketing.schwerin.info/stadtmarketing/aufgaben/Flaeche_Maerkte.html"
       },
     "map_initialization": {

--- a/cities/ulm.json
+++ b/cities/ulm.json
@@ -48,7 +48,7 @@
     ],
     "metadata": {
         "data_source": {
-            "title": "Daten von der Stadt Ulm",
+            "title": "Stadt Ulm",
             "url": "http://www.ulm-messe.de/marktwesen.97940.21332,97940.htm"
         },
         "map_initialization": {

--- a/cities/witten.json
+++ b/cities/witten.json
@@ -85,7 +85,7 @@
   ],
   "metadata": {
     "data_source": {
-      "title": "Daten von Stadtmarketing Witten GmbH",
+      "title": "Stadtmarketing Witten GmbH",
       "url": "http://www.stadtmarketing-witten.de/einkaufen/wochenmaerkte.html"
     },
     "map_initialization": {

--- a/cities/wuppertal.json
+++ b/cities/wuppertal.json
@@ -169,7 +169,7 @@
   ],
     "metadata": {
         "data_source": {
-            "title": "Daten von der Stadt Wuppertal",
+            "title": "Stadt Wuppertal",
             "url": "https://www.wuppertal.de/tourismus-freizeit/einkaufen/102370100000204430.php"
         },
         "map_initialization": {

--- a/css/main.css
+++ b/css/main.css
@@ -2,6 +2,7 @@
 
 html {
   box-sizing: border-box;
+  color: #555;
 }
 
 *, *:before, *:after {
@@ -11,52 +12,89 @@ html {
 
 /*** GLOBAL ***/
 
-html, body, #map {
+html, body {
     height: 100%;
     width: 100%;
     padding: 0;
     margin: 0;
 }
 
-#legend {
-    margin: 3em;
-    border: 1px solid #555;
-    background-color: #fafafa;
-    padding: 1em;
-    border-radius: 6px;
-    -o-border-radius: 6px;
-    -moz-border-radius: 6px;
-    -webkit-border-radius: 6px;
-    color: #555;
-    width: 22em;
-    cursor: text;
-}
-
-#legend p {
+#map {
+    width: 100%;
+    /* Map height is adjusted dynamically via JS */
+    padding: 0;
     margin: 0;
 }
 
-#legend h1 {
-    margin-top: 0;
-    font-size: 120%;
+.nowrap {
+    display: inline-block;
 }
 
-#legend form {
-    margin-bottom: 0.5em;
+/*** HEADER ***/
+
+#header {
+    /* Required so that full height is reported for calculation of the
+     * map height. See http://stackoverflow.com/a/19235907/857390.
+     */
+    overflow: auto;
+
+    margin: 0;
+    padding: 0.5em;
+    position: relative;
+
+    border-bottom: 1px solid #aaa;
 }
 
-#legend input {
-    margin: 0 5px 0 0;
+#header h1 {
+    font-size: 110%;
+    margin: 0 1em 0 0;
+    display: inline;
+}
+
+#header label > * {
     vertical-align: middle;
 }
 
-#legend label {
-    margin-right:1em;
-    font-weight: bold;
+#header label input {
+    margin: 0 2px 0 0;
 }
 
-:disabled + span {
+#header label span {
+    margin: 0 10px 0 0;
+}
+
+#header :disabled + span {
     color: #999;
+}
+
+#header form {
+    margin: 0.25em 0 0 0;
+    display: inline-block;
+}
+
+#btnToggleHeader {
+    float: right;
+    position: relative;
+    top: -0.1em;
+    outline: none;
+    margin: 0 0 0 0.5em;
+
+    /* The styling matches that of the select2 dropdown box */
+    background: none;
+    border: 1px solid #aaa;
+    border-radius: 4px;
+    padding: 0.2em 0.5em;
+}
+
+#details {
+    clear: both;
+    display: none;
+    overflow: auto;
+    margin: 0;
+}
+
+#details p {
+    margin: 1em 0 0 0;
 }
 
 /*** MAP POPUPS ***/
@@ -108,6 +146,10 @@ table.times tr.today * {
 .select2 {
     top: -2px;
     margin: 0 4px 0 2px;
+}
+
+.select2-container--default .select2-selection--single .select2-selection__rendered {
+    color: #555;
 }
 
 .select2-dropdown {

--- a/index.html
+++ b/index.html
@@ -23,18 +23,17 @@
         <script src="js/main.js"></script>
     </head>
     <body>
-        <div id="map"></div>
-        <div id="legend">
-            <h1>Wo ist Markt in <select id="dropDownCitySelection"></select>?</h1>
+        <header id="header">
+            <button id="btnToggleHeader"><i class="fa fa-bars"></i></button>
+            <h1>Wo ist Markt in <span class="nowrap"><select id="dropDownCitySelection"></select>?</span></h1>
             <form>
                 <label><input type="radio" name="display" id="now" value="now"><span>jetzt</span></label>
                 <label><input type="radio" name="display" id="today" value="today"><span>heute</span></label>
                 <label><input type="radio" name="display" id="other" value="other"><span>alle</span></label>
             </form>
-            <p>Ein Projekt des <a href="http://codefor.de/karlsruhe">Open Knowledge Lab Karlsruhe</a> und
-            des <a href="http://codefor.de/berlin">Open Knowledge Lab Berlin</a>.
-            <span id="dataSource">Datenquelle</span>. <a href="https://github.com/wo-ist-markt/wo-ist-markt.github.io">Code</a> auf GitHub.</p>
-        </div>
+            <div id="details"><p>Ein Projekt des <a href="http://codefor.de/karlsruhe">Open Knowledge Lab Karlsruhe</a> und des <a href="http://codefor.de/berlin">Open Knowledge Lab Berlin</a>.</p><p>Daten: <span id="dataSource">Datenquelle</span>.</p><p><a href="https://github.com/wo-ist-markt/wo-ist-markt.github.io">Code</a> auf GitHub.</p></div>
+        </header>
+        <div id="map"></div>
         <!-- Piwik -->
         <script type="text/javascript">
             var _paq = _paq || [];

--- a/js/main.js
+++ b/js/main.js
@@ -334,10 +334,10 @@ function toCamelCase(str) {
 /*
  * Updates the legend data source.
  */
-function updateLegendDataSource(dataSource) {
+function updateDataSource(dataSource) {
     var title = dataSource.title;
     var url = dataSource.url;
-    $("#legend #dataSource").html('<a href="' + url + '">' + title + '</a>');
+    $("#dataSource").html('<a href="' + url + '">' + title + '</a>');
 }
 
 /*
@@ -366,7 +366,7 @@ function setCity(cityID, createNewHistoryEntry) {
     }
     $.getJSON(filename, function(json) {
         positionMap(json.metadata.map_initialization);
-        updateLegendDataSource(json.metadata.data_source);
+        updateDataSource(json.metadata.data_source);
         updateMarkers(json);
         updateControls();
         updateLayers();
@@ -415,6 +415,44 @@ function loadCities() {
 }
 
 
+/*
+ * Collapse the header so that it only shows the most important information.
+ */
+function collapseHeader() {
+    $('#details').slideUp({progress: fixMapHeight});
+}
+
+/*
+ * Expand the header so that it shows all information.
+ */
+function expandHeader() {
+    $('#details').slideDown({progress: fixMapHeight});
+}
+
+
+/*
+ * Toggle collapsed/expanded header state.
+ */
+function toggleHeader() {
+    if ($('#details').is(':visible')) {
+        collapseHeader();
+    } else {
+        expandHeader();
+    }
+}
+
+
+/*
+ * Fix the height of #map so that it covers the whole viewport minus the
+ * header.
+ */
+function fixMapHeight() {
+    $('#map').outerHeight($(window).height() - $('#header').outerHeight(true));
+}
+
+$(window).on('resize', fixMapHeight);
+
+
 $(window).on('hashchange',function() {
     // Don't create a new history state, because the hash change already did
     setCity(getHashCity(), false);
@@ -424,9 +462,7 @@ $(window).on('hashchange',function() {
 $(document).ready(function() {
     var tiles = new L.TileLayer(TILES_URL, {attribution: ATTRIBUTION});
     map = new L.Map('map').addLayer(tiles);
-    var legend = L.control({position: 'bottomright'});
     var dropDownCitySelection = $('#dropDownCitySelection');
-    legend.onAdd = function () { return L.DomUtil.get('legend'); };
     $("input[name=display]").change(updateLayers);
 
     // add locator
@@ -467,10 +503,7 @@ $(document).ready(function() {
         setCity(getHashCity(), false);
     });
 
-    // Stop map movement by mouse events in legend.
-    // See https://gis.stackexchange.com/a/106777/48264.
-    L.DomEvent.disableClickPropagation(L.DomUtil.get('legend'));
-
-    legend.addTo(map);
+    $('#btnToggleHeader').click(toggleHeader);
+    fixMapHeight();
 });
 


### PR DESCRIPTION
Here's a prototype of how we could replace the legend.

My idea was that the title (including the dropdown) and the time selection controls are so important that we want to always show them. However, a legend inside the map takes up a lot of unnecessary space, especially on small screens. I've therefore moved everything into a header which can be expanded using a button.

Right now the additional information shown in the expanded header is just what we had in the legend. See #86 for a discussion of what other stuff we could put there.

There was also the suggestion by @johnjohndoe of moving the detailed content to a separate page. I don't think that a separate page is a good place for information tied to the map's state (e.g. information about the current city's data), but it could work for the general project information. Nevertheless I'd prefer to keep things in one place.

I'd love to get feedback on the prototype. Especially:

* Does the layout work on your favourite browsers/devices/screen sizes?
* Do you agree with which information is shown by default? For example, license information is currently only available once the header has been expanded.