### PR TITLE
Add piwik tracking

### DIFF
--- a/index.html
+++ b/index.html
@@ -35,6 +35,20 @@
             des <a href="http://codefor.de/berlin">Open Knowledge Lab Berlin</a>.
             <span id="dataSource">Datenquelle</span>. <a href="https://github.com/wo-ist-markt/wo-ist-markt.github.io">Code</a> auf GitHub.</p>
         </div>
+        <!-- Piwik -->
+        <script type="text/javascript">
+          var _paq = _paq || [];
+          _paq.push(['trackPageView']);
+          _paq.push(['enableLinkTracking']);
+          (function() {
+            var u="//piwik.okfn.de/";
+            _paq.push(['setTrackerUrl', u+'piwik.php']);
+            _paq.push(['setSiteId', 18]);
+            var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0];
+            g.type='text/javascript'; g.async=true; g.defer=true; g.src=u+'piwik.js'; s.parentNode.insertBefore(g,s);
+          })();
+        </script>
+        <!-- End Piwik Code -->
     </body>
 </html>
 

--- a/index.html
+++ b/index.html
@@ -37,16 +37,17 @@
         </div>
         <!-- Piwik -->
         <script type="text/javascript">
-          var _paq = _paq || [];
-          _paq.push(['trackPageView']);
-          _paq.push(['enableLinkTracking']);
-          (function() {
-            var u="//piwik.okfn.de/";
-            _paq.push(['setTrackerUrl', u+'piwik.php']);
-            _paq.push(['setSiteId', 18]);
-            var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0];
-            g.type='text/javascript'; g.async=true; g.defer=true; g.src=u+'piwik.js'; s.parentNode.insertBefore(g,s);
-          })();
+            var _paq = _paq || [];
+            _paq.push(['trackPageView']);
+            _paq.push(['enableLinkTracking']);
+            (function() {
+                var var okfnPiwikIdforWoIstMarkt = 18;
+                var u="//piwik.okfn.de/";
+                _paq.push(['setTrackerUrl', u+'piwik.php']);
+                _paq.push(['setSiteId', okfnPiwikIdforWoIstMarkt]);
+                var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0];
+                g.type='text/javascript'; g.async=true; g.defer=true; g.src=u+'piwik.js'; s.parentNode.insertBefore(g,s);
+            })();
         </script>
         <!-- End Piwik Code -->
     </body>


### PR DESCRIPTION
This PR lets us track usage so we can see if people are interested in this at all and which cities are the most active. We could also for example see if people are searching for cities that are not available and try to add those.

The tool we are using is [Piwik](https://piwik.org/) which is hosted with the Open Knowledge Foundation Germany so we do not have to fear that our users data is exposed to some kind of search giant.

I will share the credentials to piwik with anyone who is interested in private.