### PR TITLE
Remove double var in piwik code

### DIFF
--- a/index.html
+++ b/index.html
@@ -41,7 +41,7 @@
             _paq.push(['trackPageView']);
             _paq.push(['enableLinkTracking']);
             (function() {
-                var var okfnPiwikIdforWoIstMarkt = 18;
+                var okfnPiwikIdforWoIstMarkt = 18;
                 var u="//piwik.okfn.de/";
                 _paq.push(['setTrackerUrl', u+'piwik.php']);
                 _paq.push(['setSiteId', okfnPiwikIdforWoIstMarkt]);


### PR DESCRIPTION
With the change that @johnjohndoe asked for I accidentally inserted a double `var` which of course is not valid js. 
This PR fixes that. I'm sorry for the messup.