### PR TITLE
Switch latitude and the longitude in Bruchköbel and Hanau

### DIFF
--- a/cities/bruchköbel.json
+++ b/cities/bruchköbel.json
@@ -3,8 +3,8 @@
         {
             "geometry": {
                 "coordinates": [
-                    50.17857,
-                    8.92096
+                    8.92096,
+                    50.17857
                 ],
                 "type": "Point"
             },
@@ -23,8 +23,8 @@
         },
         "map_initialization": {
             "coordinates": [
-                50.1847,
-                8.9324
+                8.9324,
+                50.1847
             ],
             "zoom_level": 13
         }

--- a/cities/hanau.json
+++ b/cities/hanau.json
@@ -3,8 +3,8 @@
         {
             "geometry": {
                 "coordinates": [
-                    50.13275,
-                    8.91677
+                    8.91677,
+                    50.13275
                 ],
                 "type": "Point"
             },
@@ -23,8 +23,8 @@
         },
         "map_initialization": {
             "coordinates": [
-                50.1238,
-                8.9391
+                8.9391,
+                50.1238
             ],
             "zoom_level": 13
         }


### PR DESCRIPTION
Fixes #122.