### PR TITLE
Always show all markets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 /node_modules/
+/build/
 
 .*.swp
 

--- a/cities/cities.json
+++ b/cities/cities.json
@@ -7,7 +7,7 @@
         "id": "bochum",
         "label": "Bochum"
     },
-"bonn": {
+    "bonn": {
         "id": "bonn",
         "label": "Bonn"
     },

--- a/dev/aggregate.js
+++ b/dev/aggregate.js
@@ -15,42 +15,45 @@ var CITIES_DIR = path.join(__dirname, '..', 'cities');
 var CITIES_FILE = path.join(CITIES_DIR, 'cities.json');
 
 var BUILD_DIR = path.join(__dirname, '..', 'build');
+var AGGREGATED_CITIES_FILE = path.join(BUILD_DIR, 'cities.json');
 var AGGREGATED_MARKETS_FILE = path.join(BUILD_DIR, 'markets.json');
 
 
 /*
- * Merge two or more GeoJSON objects.
+ * Merge the features of GeoJSON objects.
  *
- * Takes a `target` GeoJSON object and one or more source GeoJSON objects and
- * merges the features from the source objects into the target object. Note
- * that other GeoJSON data from the sources (e.g. `metadata`) is *not* copied.
+ * Takes a `target` GeoJSON object and a list `sources` of one or more source
+ * GeoJSON objects and merges the features from the source objects into the
+ * target object. Note that other GeoJSON data from the sources is *not*
+ * copied.
  *
  * The target object is returned.
  */
-function mergeGeoJSONFeatures(target /* , args */) {
+function mergeFeatures(target, sources) {
     if (target.features === undefined) {
         target.features = [];
     }
-    for (let i = 1; i < arguments.length; i++) {
-        Array.prototype.push.apply(target.features, arguments[i].features);
+    for (let source of sources) {
+        Array.prototype.push.apply(target.features, source.features);
     }
     return target;
 }
 
 
 /*
- * Aggregate markets data from all cities.
+ * Aggregate data from all cities.
  *
  * Loads each city's GeoJSON data and merges all GeoJSON features into a single
- * file (`AGGREGATED_MARKETS_FILE`).
+ * file (`AGGREGATED_MARKETS_FILE`). All metadata is merged into a separate
+ * file (`AGGREGATED_CITIES_FILE`).
  *
- * Returns a promise that resolves to the output filename once all data has
+ * Returns two promises that resolve to the output filenames once all data has
  * been aggregated and written to disk.
  */
-function aggregateMarketsData() {
+function aggregate() {
     return utils.loadJSON(CITIES_FILE)
-        .then(json => {
-            let aggregated = {
+        .then(citiesJSON => {
+            let marketsJSON = {
                 "crs": {
                     "properties": {
                         "name": "urn:ogc:def:crs:OGC:1.3:CRS84"
@@ -61,22 +64,34 @@ function aggregateMarketsData() {
                 "features": []
             };
             let promises = [];
-            for (let city in json) {
-                let p = utils.loadJSON(path.join(CITIES_DIR, city + '.json'))
-                    .then(cityJSON => mergeGeoJSONFeatures(aggregated, cityJSON));
-                promises.push(p);
+            for (let city in citiesJSON) {
+                let p = utils.loadJSON(path.join(CITIES_DIR, city + '.json'));
+                promises.push(p.then(cityJSON => {
+                    for (let key in cityJSON.metadata) {
+                        citiesJSON[city][key] = cityJSON.metadata[key];
+                    }
+                }));
+                promises.push(p.then(cityJSON =>
+                    mergeFeatures(marketsJSON, [cityJSON])));
             }
             promises.push(utils.ensureDir(BUILD_DIR));
-            return Promise.all(promises)
-                .then(values => utils.saveJSON(aggregated, AGGREGATED_MARKETS_FILE));
+            let p = Promise.all(promises);
+            return [
+                p.then(_ => utils.saveJSON(citiesJSON, AGGREGATED_CITIES_FILE)),
+                p.then(_ => utils.saveJSON(marketsJSON, AGGREGATED_MARKETS_FILE))
+            ];
         });
 }
 
 
 if (require.main === module) {
-    aggregateMarketsData()
-        .then(filename => console.log('Markets data has been aggregated to ' +
-                                      filename))
+    aggregate()
+        .then(_ => {
+            console.log('Markets data has been aggregated to ' +
+                        AGGREGATED_MARKETS_FILE);
+            console.log('Cities metadata has been aggregated to ' +
+                        AGGREGATED_CITIES_FILE);
+        })
         .catch(err => console.error(err));
 }
 

--- a/dev/aggregate.js
+++ b/dev/aggregate.js
@@ -1,0 +1,82 @@
+'use strict';
+
+/*
+ * Node script to aggregate markets data.
+ */
+
+/* jslint node: true */
+
+var path = require('path');
+
+var utils = require('./utils');
+
+
+var CITIES_DIR = path.join(__dirname, '..', 'cities');
+var CITIES_FILE = path.join(CITIES_DIR, 'cities.json');
+
+var BUILD_DIR = path.join(__dirname, '..', 'build');
+var AGGREGATED_MARKETS_FILE = path.join(BUILD_DIR, 'markets.json');
+
+
+/*
+ * Merge two or more GeoJSON objects.
+ *
+ * Takes a `target` GeoJSON object and one or more source GeoJSON objects and
+ * merges the features from the source objects into the target object. Note
+ * that other GeoJSON data from the sources (e.g. `metadata`) is *not* copied.
+ *
+ * The target object is returned.
+ */
+function mergeGeoJSONFeatures(target /* , args */) {
+    if (target.features === undefined) {
+        target.features = [];
+    }
+    for (let i = 1; i < arguments.length; i++) {
+        Array.prototype.push.apply(target.features, arguments[i].features);
+    }
+    return target;
+}
+
+
+/*
+ * Aggregate markets data from all cities.
+ *
+ * Loads each city's GeoJSON data and merges all GeoJSON features into a single
+ * file (`AGGREGATED_MARKETS_FILE`).
+ *
+ * Returns a promise that resolves to the output filename once all data has
+ * been aggregated and written to disk.
+ */
+function aggregateMarketsData() {
+    return utils.loadJSON(CITIES_FILE)
+        .then(json => {
+            let aggregated = {
+                "crs": {
+                    "properties": {
+                        "name": "urn:ogc:def:crs:OGC:1.3:CRS84"
+                    },
+                    "type": "name"
+                },
+                "type": "FeatureCollection",
+                "features": []
+            };
+            let promises = [];
+            for (let city in json) {
+                let p = utils.loadJSON(path.join(CITIES_DIR, city + '.json'))
+                    .then(cityJSON => mergeGeoJSONFeatures(aggregated, cityJSON));
+                promises.push(p);
+            }
+            promises.push(utils.ensureDir(BUILD_DIR));
+            return Promise.all(promises)
+                .then(values => utils.saveJSON(aggregated, AGGREGATED_MARKETS_FILE));
+        });
+}
+
+
+if (require.main === module) {
+    aggregateMarketsData()
+        .then(filename => console.log('Markets data has been aggregated to ' +
+                                      filename))
+        .catch(err => console.error(err));
+}
+

--- a/dev/utils.js
+++ b/dev/utils.js
@@ -1,0 +1,99 @@
+'use strict';
+
+/*
+ * Node module with development utilities for wo-ist-markt.
+ */
+
+/* jslint node: true */
+
+var e = module.exports = {};
+
+
+var fs = require('fs');
+
+
+/*
+ * Wrap a callback-style async function in a Promise.
+ *
+ * `f` is an async function that takes a callback as the last parameter. It
+ * is called inside a newly created Promise with the arguments from the list
+ * `args` (the callback argument is automatically added). If `f` returns an
+ * error (by calling the callback with a first, true argument) then the promise
+ * is rejected. Otherwise it is resolved with the value passed to the callback
+ * by `f`.
+ *
+ * If `f` calls the callback with two or more values (excluding the error flag)
+ * then the promise is resolved with a list of these values. If `f` calls the
+ * callback with a single value then the Promise is resolved with that value.
+ * Finally, if `f` calls the callback with just the error flag then the Promise
+ * is resolved with `undefined`.
+ *
+ * Returns the promise.
+ */
+e.promisify = function(f, args) {
+    return new Promise((resolve, reject) => {
+        args = args.slice();
+        args.push(function (err /* , args */) {
+            // Cannot be an arrow function, since those don't have `arguments`
+            if (err) {
+                reject(err);
+            } else {
+                switch (arguments.length) {
+                    case 1:
+                        resolve(undefined);
+                        break;
+                    case 2:
+                        resolve(arguments[1]);
+                        break;
+                    default:
+                        resolve(Array.prototype.slice.call(arguments, 1));
+                }
+            }
+        });
+        f.apply(f, args);
+    });
+};
+
+
+/*
+ * Load JSON from a file.
+ *
+ * Returns a promise that resolves to the parsed JSON data.
+ */
+e.loadJSON = function(filename) {
+    return e.promisify(fs.readFile, [filename])
+        .then(data => JSON.parse(data));
+};
+
+
+/*
+ * Write data to a file as JSON.
+ *
+ * Returns a promise that resolves to the filename when the data has been
+ * written.
+ */
+e.saveJSON = function(data, filename) {
+    return e.promisify(fs.writeFile, [filename, JSON.stringify(data)])
+        .then(value => filename);
+};
+
+
+/*
+ * Make sure that a directory exists.
+ *
+ * If the directory doesn't exist it is created. If it already exists nothing
+ * is done.
+ *
+ * Returns a promise that resolves to the directory's path once the directory
+ * exists.
+ */
+e.ensureDir = function(dirname) {
+    return e.promisify(fs.mkdir, [dirname])
+        .catch(err => {
+            if (err.code !== 'EEXIST') {
+                throw err;
+            }
+        })
+        .then(value => dirname);
+};
+

--- a/index.html
+++ b/index.html
@@ -21,12 +21,12 @@
         <script src="lib/moment/moment.min.js"></script>
         <script src="lib/moment-range/moment-range.min.js"></script>
         <script src="js/main.js"></script>
-	<link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">
-	<link rel="icon" type="image/png" href="/favicon-32x32.png" sizes="32x32">
-	<link rel="icon" type="image/png" href="/favicon-16x16.png" sizes="16x16">
-	<link rel="manifest" href="/manifest.json">
-	<link rel="mask-icon" href="/safari-pinned-tab.svg" color="#5bbad5">
-	<meta name="theme-color" content="#ffffff">
+        <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">
+        <link rel="icon" type="image/png" href="/favicon-32x32.png" sizes="32x32">
+        <link rel="icon" type="image/png" href="/favicon-16x16.png" sizes="16x16">
+        <link rel="manifest" href="/manifest.json">
+        <link rel="mask-icon" href="/safari-pinned-tab.svg" color="#5bbad5">
+        <meta name="theme-color" content="#ffffff">
     </head>
     <body>
         <header id="header">

--- a/package.json
+++ b/package.json
@@ -11,7 +11,15 @@
   "scripts": {
     "lint": "jshint js preprocessing validation",
     "jasmine-tests": "jasmine",
+    "aggregate": "node dev/aggregate.js",
+    "build": "npm run aggregate",
+    "jasmine-tests": "jasmine",
+    "lint": "jshint js preprocessing dev validation",
     "test": "npm run lint & npm run jasmine-tests & npm run validate",
     "validate": "node validation/markets-validator.js"
+  },
+  "jshintConfig": {
+    "esversion": 6,
+    "loopfunc": true
   }
 }


### PR DESCRIPTION
Our current approach of only showing a single city's markets is starting to fail as more and more cities are added, see #116. This PR will provide the necessary changes to instead show all markets all the time. It is a work in progress and discussions on the best way to go forward are absolutely welcome!

My current plan for the design is as follows:
1. Keep data from separate cities in separate files. This eases maintenance, since each city's markets can be updated independently.
2. Use a build step that is executed after content has been updated and which aggregates all market data into a single file. The first commit in this PR provides this functionality, simply run `npm run build`. The plan is to run this via CI so nobody has to do it manually.
3. In the app, always show all markets. To keep things clean and fast we should probably use some kind of marker clustering so that individual markets are only shown once the zoom level is high enough.

The city navigation via the dropdown is also reaching its limits (see e.g. #40), but that's a topic for another PR.
