### PR TITLE
Decrypt variables on master only

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,4 +11,4 @@ script:
   - npm test
 
 after_success:
-  - deploy.sh
+  - bash deploy.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,11 +3,6 @@ language: python
 python:
     - '2.7'
 
-before_install:
-    # decrypt the ssh key that is used for deployment
-    - openssl aes-256-cbc -K $encrypted_02f86fe65d47_key -iv $encrypted_02f86fe65d47_iv
-      -in markt_deploy_id_rsa.enc -out markt_deploy_id_rsa -d
-
 install:
   - pip install -r requirements.txt
   - npm install
@@ -16,5 +11,4 @@ script:
   - npm test
 
 after_success:
-  # Run fabric for deployment but only if we are on the master branch and not on a pull request
-  - test $TRAVIS_PULL_REQUEST == "false" && test $TRAVIS_BRANCH == "master" && fab deploy -i markt_deploy_id_rsa -H deploy@kiesinger.okfn.de:2207
+  - deploy.sh

--- a/deploy.sh
+++ b/deploy.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+if [[ $TRAVIS_PULL_REQUEST == "false" &&  $TRAVIS_BRANCH == "master" ]]; then
+  openssl aes-256-cbc -K $encrypted_02f86fe65d47_key -iv $encrypted_02f86fe65d47_iv -in markt_deploy_id_rsa.enc -out markt_deploy_id_rsa -d
+  fab deploy -i markt_deploy_id_rsa -H deploy@kiesinger.okfn.de:2207
+else 
+  echo "not a push to master, so not deploying"
+  exit 0
+fi
+

--- a/deploy.sh
+++ b/deploy.sh
@@ -1,8 +1,10 @@
 #!/usr/bin/env bash
 if [[ $TRAVIS_PULL_REQUEST == "false" &&  $TRAVIS_BRANCH == "master" ]]; then
+  # Decrypt the SSH key that is used for authentication at our server
   openssl aes-256-cbc -K $encrypted_02f86fe65d47_key -iv $encrypted_02f86fe65d47_iv -in markt_deploy_id_rsa.enc -out markt_deploy_id_rsa -d
+  # Deploy to our server using Fabric
   fab deploy -i markt_deploy_id_rsa -H deploy@kiesinger.okfn.de:2207
-else 
+else
   echo "not a push to master, so not deploying"
   exit 0
 fi


### PR DESCRIPTION
This moves all of the deployment related things into a separate script called `deploy.sh`. It checks if we are on a push to the master branch, decodes the ssh key and deploys.

It works if the branch is not master, I am quite confident that it will also work on master but we will only see that when it is merged ;)

Fixes #136 