### PR TITLE
Let travis always send notifications to slack

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,8 @@ after_success:
   - bash deploy.sh
 notifications:
   slack:
+    on_success: always
+    on_failure: always
     secure: tL/2Zq47CK4YPvNEee/BVHvst4idXPjhsM1jFylEaD3f5S4mNjlxnEZmC75c1uNPhQ56ZRkpSSA6qVdHVWs9qECeDQUK0z1sWcpFhT09+MvrIxREy9dtX+a2iKBYgyWwZiBOv2WOKYB2I3lu+qZ7uhxxj4a5aLN3ijgcFfKR4sehRFf793Y2U+x2coMLoUwyThMUMYZGXqYhG41dbkGHvIecFa69RjHD89v/b5Q1nlpLlqLbC6xWVQt8ADfu8Y7mDbaFJ9/U2pV1E24OrI7f84Htt2TQknVQQfhWc8Q+LI30o4wftlwwbLMmP/m3yPiKEkThxmEpoX0PvlQN7HbCAOFm7W4VqO96B7Gn9YhAc8fksJs08sV0BVVNEDkKZs5amCZvTaD0QqwkIJ/Ky1c1Slezj2jpF/814L1Hj2PAN7TQ4BUHAzs/JZpRK/Qa4fUSxTk7AG2xnLDZVYQ1OJkyqZCjgfjJXS0ZWjZRmdnup+iPRPI7njK2d3/rIGWXNksZliqcBMSL9fVjaNb33ftiIIGOVsgmbdY8+0eEVxTWFxrE2GPv8bItWVcB1HSWi5WMI2D9Z5SOCp+YnORVZVy8dupZeMGyYPoW/FxuWGX4Nm05DDR1etzo08k3afjJTYwTZghxhVlxJ7L2MpanyE73cbHXbN0E3iK4tBf4UqSxY0g=
     template:
       - "%{repository} (%{commit}) : %{message}"


### PR DESCRIPTION
I hope that by setting the `on_success` and `on_failure` toggles to `always` we will always be notified on slack now whenever travis finishes.

See also the [documentation](https://docs.travis-ci.com/user/notifications#Notifications)