### PR TITLE
Validate filter

### DIFF
--- a/validation/markets-validator.js
+++ b/validation/markets-validator.js
@@ -54,7 +54,7 @@ fs.readdir(MARKETS_DIR_PATH, function (err, files) {
     }).filter(function(file) {
         return fs.statSync(file).isFile();
     }).forEach(function(file) {
-        if (file === MARKETS_INDEX_FILE_PATH) {
+        if (file === MARKETS_INDEX_FILE_PATH || file.substr(-5) !== ".json") {
             return;
         }
         console.log("\n===> Validating %s ...".section, file);

--- a/validation/markets-validator.js
+++ b/validation/markets-validator.js
@@ -49,6 +49,7 @@ fs.readdir(MARKETS_DIR_PATH, function (err, files) {
         throw err;
     }
 
+    var marketCount = 0;
     files.map(function(file) {
         return path.join(MARKETS_DIR_PATH, file);
     }).filter(function(file) {
@@ -60,8 +61,10 @@ fs.readdir(MARKETS_DIR_PATH, function (err, files) {
         console.log("\n===> Validating %s ...".section, file);
         var marketValidator = new MarketValidator(file);
         marketValidator.validate();
+        marketCount++;
         console.log("\n");
     });
+    console.log(marketCount + " markets validated!");
 
     process.exit(exitCode);
 });


### PR DESCRIPTION
Da ich nur in vim arbeite hat es mich gestört, dass ich keine Test ausführen kann solange ich meinen Editor geöffnet habe (da vim swap files natürlich kein gültiges JSON sind).

Dieser PR sorgt dafür, dass nur noch "<market>.json"-Dateien validiert werden. Außerdem habe ich mit eingeführt, dass beim validate die Anzahl der überprüften Dateien mit ausgegeben wird, damit (durch den Filter) keine Dateien übersehen werden - der Entwickler hat dann schon dort die Möglichkeit das zu bemerken.