### PR TITLE
Moved Wochenmarkt and corrected typo

### DIFF
--- a/cities/düsseldorf.json
+++ b/cities/düsseldorf.json
@@ -260,15 +260,15 @@
 		"geometry": {
 		   "type": "Point",
 		   "coordinates": [
-			  6.7329260,
-			  51.2409100
+			  6.7285300,
+			  51.2405700
 		   ]
 		},
 		"type": "Feature",
 		"properties": {
 		   "opening_hours": "We 07:00-18:00; Sa 07:00-14:00",
 		   "location": "Niederkassler Lohweg",
-		   "title": "Wochenmarkt Niederkassler Lohweg"
+		   "title": "Wochenmarkt Niederkasseler Lohweg"
 		}
 	  },
 	  {

--- a/cities/düsseldorf.json
+++ b/cities/düsseldorf.json
@@ -267,7 +267,7 @@
 		"type": "Feature",
 		"properties": {
 		   "opening_hours": "We 07:00-18:00; Sa 07:00-14:00",
-		   "location": "Niederkassler Lohweg",
+		   "location": "Niederkasseler Lohweg",
 		   "title": "Wochenmarkt Niederkasseler Lohweg"
 		}
 	  },


### PR DESCRIPTION
The wochenmarkt on Niederkasseler Lohweg in Düsseldorf is in front of the church, I moved the location slightly.
Additionally, there was a small spelling mistake in Niederkasseler (an e was missing). I corrected the typo.