### PR TITLE
Validate HTTP status of data source URL

### DIFF
--- a/validation/markets-validator.js
+++ b/validation/markets-validator.js
@@ -30,6 +30,8 @@ var MIN_LONGITUDE = -180.0;
 
 var exitCode = 0;
 
+var asyncWarnings = [];
+var asyncErrors = [];
 
 colors.setTheme({
     section: 'blue',
@@ -70,6 +72,14 @@ fs.readdir(MARKETS_DIR_PATH, function (err, files) {
 });
 
 process.on('beforeExit', function () {
+    asyncWarnings.forEach(function (warning) {
+        console.log('Warning: %s', warning.toString());
+    });
+
+    asyncErrors.forEach(function (error) {
+        console.log('Error: %s', error.toString());
+    });
+
     process.exitCode = exitCode;
 });
 

--- a/validation/markets-validator.js
+++ b/validation/markets-validator.js
@@ -108,7 +108,7 @@ function MarketValidator(filePath) {
         this.errorsCount += featuresValidator.getErrorsCount();
         this.warningsCount += featuresValidator.getWarningsCount();
 
-        var metadataValidator = new MetadataValidator(json.metadata);
+        var metadataValidator = new MetadataValidator(json.metadata, cityName);
         metadataValidator.validate();
         metadataValidator.printWarnings();
         metadataValidator.printErrors();
@@ -418,9 +418,10 @@ function FeatureValidator(feature, cityName) {
  *
  * - metadata: The "metadata" attribute
  */
-function MetadataValidator(metadata) {
+function MetadataValidator(metadata, cityName) {
 
     this.metadata = metadata;
+    this.cityName = cityName;
     this.errors = [];
     this.warnings = [];
 

--- a/validation/markets-validator.js
+++ b/validation/markets-validator.js
@@ -66,9 +66,12 @@ fs.readdir(MARKETS_DIR_PATH, function (err, files) {
     });
     console.log(marketCount + " markets validated!");
 
-    process.exit(exitCode);
+    console.log('Waiting for asynchronous tasks to finish ...\n');
 });
 
+process.on('beforeExit', function () {
+    process.exitCode = exitCode;
+});
 
 /**
  * Validator for a market file.


### PR DESCRIPTION
This should fix issues #117 and #166 .

A HTTP HEAD request is started per cities/city.js file and outputs a warning for non-200 response codes.

Those requests are done asynchronously, so I had to change the workflow of the validator script a bit:
- Setting exit code of the validating process has to wait until all requests are finished.
- Errors and warnings from async tasks are collected in lists.
- After all tasks have been finished, the lists are outputted and the exit code gets set.