### PR TITLE
Fix various data source URLs

### DIFF
--- a/cities/erlangen.json
+++ b/cities/erlangen.json
@@ -94,7 +94,7 @@
     "metadata": {
         "data_source": {
             "title": "Stadt Erlangen",
-            "url": "http://www.erlangen.de/Portaldata/1/Resources/030_leben_in_er/dokumente/amt31/070621_Umwelttip.pdf"
+            "url": "http://www.erlangen.de/desktopdefault.aspx"
         },
      "map_initialization": {
             "coordinates": [

--- a/cities/hilden.json
+++ b/cities/hilden.json
@@ -56,7 +56,7 @@
   "metadata": {
     "data_source": {
       "title": "Stadt Hilden",
-      "url": "http://www.hilden.de/sv_hilden/Unsere%20Stadt/Rathaus/Ortsrecht/II-04%20Festsetzung%20Wochenm%C3%A4rkte.pdf"
+      "url": "https://www.hilden.de/sv_hilden/Unsere%20Stadt/Rathaus/Ortsrecht/II-04%20Festsetzung%20Wochenm%C3%A4rkte.pdf"
     },
     "map_initialization": {
       "coordinates": [

--- a/cities/karlsruhe.json
+++ b/cities/karlsruhe.json
@@ -250,7 +250,7 @@
     "metadata": {
         "data_source": {
             "title": "Stadt Karlsruhe",
-            "url": "http://www.karlsruhe.de/b3/maerkte/wochenmarkte.de"
+            "url": "https://www.karlsruhe.de/b3/maerkte/wochenmarkte.de"
         },
         "map_initialization": {
             "coordinates": [

--- a/cities/köln.json
+++ b/cities/köln.json
@@ -559,7 +559,7 @@
     ],
     "metadata": {
         "data_source": {
-            "url": "http://www.offenedaten-koeln.de/dataset/wochenmaerkte-koeln",
+            "url": "https://www.offenedaten-koeln.de/dataset/wochenmaerkte-koeln",
             "title": "Offene Daten Köln"
         },
         "map_initialization": {

--- a/cities/paderborn.json
+++ b/cities/paderborn.json
@@ -80,7 +80,7 @@
     "metadata": {
         "data_source": {
             "title": "Stadt Paderborn",
-            "url": "http://www.paderborn.de/microsite/wochenmarkt/marktinfos/109010100000079411.php?p=5,1"
+            "url": "https://www.paderborn.de/microsite/wochenmarkt/"
         },
         "map_initialization": {
             "coordinates": [

--- a/cities/ulm.json
+++ b/cities/ulm.json
@@ -49,7 +49,7 @@
     "metadata": {
         "data_source": {
             "title": "Stadt Ulm",
-            "url": "http://www.ulm-messe.de/marktwesen.97940.21332,97940.htm"
+            "url": "http://www.ulm-messe.de"
         },
         "map_initialization": {
             "coordinates": [


### PR DESCRIPTION
Most cities simply moved to HTTPS, some restructured their website. It seems that Erlangen and Ulm took all the details offline, at least I couldn't find them anymore.