### PR TITLE
more precise URL for data

### DIFF
--- a/cities/ulm.json
+++ b/cities/ulm.json
@@ -49,7 +49,7 @@
     "metadata": {
         "data_source": {
             "title": "Stadt Ulm",
-            "url": "http://www.ulm-messe.de"
+            "url": "http://www.ulm.de/marktwesen.97940.21332,97940.htm"
         },
         "map_initialization": {
             "coordinates": [


### PR DESCRIPTION
This is the specific source I used. In a previous version I linked to the PDF under ulm-messe.de (which was probably not available anymore). 