### PR TITLE
adding missing 3 markets in frankfurt

### DIFF
--- a/cities/frankfurtmain.json
+++ b/cities/frankfurtmain.json
@@ -346,7 +346,7 @@
             },
             "properties": {
                 "location": "Mörfelder Landstraße 129-131",
-                "opening_hours": "Sa 08:30 - 14:00",
+                "opening_hours": "Sa 8:30 - 14:00",
                 "title": "Wochenmarkt Sachsenhausen Ziegelhüttenplatz"
             },
             "type": "Feature"

--- a/cities/frankfurtmain.json
+++ b/cities/frankfurtmain.json
@@ -305,6 +305,51 @@
                 "title": "Wochenmarkt und Markthalle Höchst"
             },
             "type": "Feature"
+        },
+        {
+            "geometry": {
+                "coordinates": [
+                    8.7224664,
+                    50.0972815
+                ],
+                "type": "Point"
+            },
+            "properties": {
+                "location": "Buchrainstraße",
+                "opening_hours": "Sa 09:00 - 16:00",
+                "title": "Wochenmarkt Oberrad Buchrainplatz"
+            },
+            "type": "Feature"
+        },
+        {
+            "geometry": {
+                "coordinates": [
+                    8.7311201,
+                    50.1299471
+                ],
+                "type": "Point"
+            },
+            "properties": {
+                "location": "Schäfflestraße 12",
+                "opening_hours": "Sa 08:00 - 12:00",
+                "title": "Wochenmarkt Riederwald"
+            },
+            "type": "Feature"
+        },
+        {
+            "geometry": {
+                "coordinates": [
+                    8.6807097,
+                    50.0949514
+                ],
+                "type": "Point"
+            },
+            "properties": {
+                "location": "Mörfelder Landstraße 129-131",
+                "opening_hours": "Sa 08:30 - 14:00",
+                "title": "Wochenmarkt Sachsenhausen Ziegelhüttenplatz"
+            },
+            "type": "Feature"
         }
 
     ],


### PR DESCRIPTION
added missing markets in frankfurt: Wochenmarkt Oberrad Buchrainplatz, Wochenmarkt Riederwald, Wochenmarkt Sachsenhausen Ziegelhüttenplatz from new branch fra