### PR TITLE
Normalize city names for validation on macOS

### DIFF
--- a/spec/citylist-spec.js
+++ b/spec/citylist-spec.js
@@ -28,8 +28,6 @@ describe('CityList', function() {
         it('should have an entry for each city.json file', function() {
             var dirContent = fs.readdirSync('cities'),
                 cities = JSON.parse(fs.readFileSync('cities/cities.json')),
-                fileName,
-                cityId,
                 regexp = /json$/;
 
             var cityNames = Object.keys(cities).map(normalizeString);

--- a/spec/citylist-spec.js
+++ b/spec/citylist-spec.js
@@ -1,6 +1,11 @@
 var fs = require('fs'),
     path = require('path');
 
+
+function normalizeString(string){
+    return string.normalize();
+}
+
 describe('CityList', function() {
 
     describe('cities.json', function() {
@@ -26,15 +31,19 @@ describe('CityList', function() {
                 fileName,
                 cityId,
                 regexp = /json$/;
+
+            var cityNames = Object.keys(cities).map(normalizeString);
+
             var missingCities = dirContent
                 .filter(function(fileName) {
                     return regexp.test(fileName) && fileName !== 'cities.json'
                 })
                 .map(function(fileName) {
-                    return path.basename(fileName, '.json')
+                    var cityName = path.basename(fileName, '.json');
+                    return normalizeString(cityName);
                 })
-                .filter(function(f) {
-                    return !(f in cities)
+                .filter(function(cityName) {
+                    return !(cityNames.includes(cityName))
                 });
             expect(missingCities).toEqual([], "Missing cities in cities.json: " + missingCities.join(", "));
         });


### PR DESCRIPTION
This fixes #204.

It looks like the file content and the output of `readdirSync` return different results even 
though the output reads the same. Normalizing all the strings before comparing solves this problem.

It also removes two unused variables in the same function in a separate commit