### PR TITLE
Add info and imprint pages.

### DIFF
--- a/css/main.css
+++ b/css/main.css
@@ -97,6 +97,12 @@ html, body {
     margin: 1em 0 0 0;
 }
 
+/*** MAP ATTRIBUTION ***/
+
+.leaflet-control-attribution {
+    text-align: end;
+}
+
 /*** MAP POPUPS ***/
 
 .leaflet-popup-content-wrapper,
@@ -156,3 +162,33 @@ table.times tr.today * {
     font-size: 80%;
 }
 
+
+/*** META PAGES ***/
+
+
+.metapage {
+    background: #F5F5F3;
+    padding: 2em;
+    font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
+}
+
+.metapage header {
+    padding: 0.5em 0 !important;
+}
+
+.metapage h1 {
+    font-size: 2.5em !important;
+}
+
+.metapage h2 {
+    font-size: 1.8em;
+    margin-bottom: 0em;
+}
+
+.metapage p {
+    line-height: 1.5em;
+}
+
+.metapage button {
+    margin: 2em 0;
+}

--- a/impressum.html
+++ b/impressum.html
@@ -1,0 +1,75 @@
+<!DOCTYPE html>
+<html lang="de">
+    <head>
+        <title>Wo ist Markt? - Impressum</title>
+        <meta charset="utf-8">
+        <meta name="viewport" content="initial-scale=1,width=device-width">
+        <meta name="theme-color" content="#ffffff">
+        <meta property="og:title" content="Wo ist Markt?" />
+        <meta property="og:url" content="https://wo-ist-markt.de/info.html" />
+        <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">
+        <link rel="icon" type="image/png" href="/favicon-32x32.png" sizes="32x32">
+        <link rel="icon" type="image/png" href="/favicon-16x16.png" sizes="16x16">
+        <link rel="manifest" href="/manifest.json">
+        <link rel="mask-icon" href="/safari-pinned-tab.svg" color="#5bbad5">
+        <link rel="stylesheet" href="css/main.css"/>
+    </head>
+    <body class="metapage">
+        <header id="header">
+            <h1>Impressum</h1>
+        </header>
+
+        <p>Tobias Preuß<br />Ritterlandweg 54e<br />13409 Berlin<br />tobias PUNKT preuss AT googlemail PUNKT com</p>
+
+        <h2>Software</h2>
+        <p>Die Software dieser Webseite ist frei und quelloffen unter der MIT-Lizenz auf 
+        <a href="https://github.com/wo-ist-markt/wo-ist-markt.github.io" title="GitHub Repository">GitHub</a> verfügbar.</p>
+
+        <h2>Haftung für Inhalte</h2>
+        <p>Die Inhalte unserer Seiten wurden mit größter Sorgfalt erstellt. Für die Richtigkeit, Vollständigkeit
+        und Aktualität der Inhalte können wir jedoch keine Gewähr übernehmen. Als Diensteanbieter sind wir gemäß
+        § 7 Abs.1 TMG für eigene Inhalte auf diesen Seiten nach den allgemeinen Gesetzen verantwortlich. Nach
+        §§ 8 bis 10 TMG sind wir als Diensteanbieter jedoch nicht verpflichtet, übermittelte oder gespeicherte
+        fremde Informationen zu überwachen oder nach Umständen zu forschen, die auf eine rechtswidrige Tätigkeit
+        hinweisen. Verpflichtungen zur Entfernung oder Sperrung der Nutzung von Informationen nach den allgemeinen
+        Gesetzen bleiben hiervon unberührt. Eine diesbezügliche Haftung ist jedoch erst ab dem Zeitpunkt der
+        Kenntnis einer konkreten Rechtsverletzung möglich. Bei Bekanntwerden von entsprechenden Rechtsverletzungen
+        werden wir diese Inhalte umgehend entfernen.</p>
+
+        <h2>Haftung für Links</h2>
+        <p>Unser Angebot enthält Links zu externen Webseiten Dritter, auf deren Inhalte wir keinen Einfluss haben.
+        Deshalb können wir für diese fremden Inhalte auch keine Gewähr übernehmen. Für die Inhalte der verlinkten
+        Seiten ist stets der jeweilige Anbieter oder Betreiber der Seiten verantwortlich. Die verlinkten Seiten
+        wurden zum Zeitpunkt der Verlinkung auf mögliche Rechtsverstöße überprüft. Rechtswidrige Inhalte waren zum
+        Zeitpunkt der Verlinkung nicht erkennbar. Eine permanente inhaltliche Kontrolle der verlinkten Seiten ist
+        jedoch ohne konkrete Anhaltspunkte einer Rechtsverletzung nicht zumutbar. Bei Bekanntwerden von
+        Rechtsverletzungen werden wir derartige Links umgehend entfernen.</p>
+
+        <h2>Datenschutzerklärung</h2>
+        <p>Der Schutz Ihrer personenbezogenen Daten ist uns ein zentrales Anliegen.   Sämtliche Anforderungen des
+        Bundesdatenschutzgesetzes (BDSG), Telemediengesetzes (TMG) sowie alle weiteren datenschutzrechtlichen
+        Vorschriften werden von uns eingehalten. Sie können unsere Seite besuchen, ohne Angaben zu Ihrer Person
+        zu machen. Wir speichern lediglich Zugriffsdaten ohne Personenbezug.</p>
+
+        <h2>Analysedienste</h2>
+        <p>Die Website verwendet Piwik, dabei handelt es sich um einen sogenannten Webanalysedienst. Piwik
+        verwendet sog. "Cookies", dass sind Textdateien, die auf Ihrem Computer gespeichert werden und die
+        unsererseits eine Analyse der Benutzung der Webseite ermöglichen. Zu diesem Zweck werden die durch den
+        Cookie erzeugten Nutzungsinformationen (einschließlich Ihrer gekürzten IP-Adresse) an unseren Server
+        übertragen und zu Nutzungsanalysezwecken gespeichert, was der Webseitenoptimierung unsererseits dient.
+        Ihre IP-Adresse wird bei diesem Vorgang umge­hend anony­mi­siert, so dass Sie als Nutzer für uns anonym
+        bleiben. Die durch den Cookie erzeugten Informationen über Ihre Benutzung dieser Webseite werden nicht
+        an Dritte weitergegeben. Sie können die Verwendung der Cookies durch eine entsprechende Einstellung
+        Ihrer Browser Software verhindern, es kann jedoch sein, dass Sie in diesem Fall gegebenenfalls nicht
+        sämtliche Funktionen dieser Website voll umfänglich nutzen können.</p>
+
+        <h2>Textquellen</h2>
+        <ul>
+            <li>Impressumgenerator von <a href="https://e-recht24.de" title="e-recht24.de">eRecht24</a></li>
+            <li><a href="https://e-recht24.de/muster-disclaimer.htm" title="e-recht24.de Disclaimer">Disclaimer eRecht24</a></li>
+            <li><a href="https://datenschutzbeauftragter-info.de" title="datenschutzbeauftragter-info.de">datenschutzbeauftragter-info.de</a></li>
+        </ul>
+
+        <button onclick="window.history.back()">Zurück zur Karte</button>
+    </body>
+</html>

--- a/info.html
+++ b/info.html
@@ -1,0 +1,50 @@
+<!DOCTYPE html>
+<html lang="de">
+    <head>
+        <title>Wo ist Markt? - Über das Projekt</title>
+        <meta charset="utf-8">
+        <meta name="viewport" content="initial-scale=1,width=device-width">
+        <meta name="theme-color" content="#ffffff">
+        <meta property="og:title" content="Wo ist Markt?" />
+        <meta property="og:url" content="https://wo-ist-markt.de/info.html" />
+        <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">
+        <link rel="icon" type="image/png" href="/favicon-32x32.png" sizes="32x32">
+        <link rel="icon" type="image/png" href="/favicon-16x16.png" sizes="16x16">
+        <link rel="manifest" href="/manifest.json">
+        <link rel="mask-icon" href="/safari-pinned-tab.svg" color="#5bbad5">
+        <link rel="stylesheet" href="css/main.css"/>
+    </head>
+    <body class="metapage">
+        <header id="header">
+            <h1>Über das Projekt</h1>
+        </header>
+        <p>Auf dieser Webseite werden die Wochenmärkte, Gemüsemärkte und Trödelmärkte verschiedener Städte
+        in Deutschland angezeigt.</p>
+
+        <h2>Funktionen</h2>
+        <p>Besucher der Webseite können folgende Funktionen verwenden:</p>
+        <ul>
+            <li>Stadt im Aufklappmenü auswählen</li>
+            <li>Märkte zeitlich filtern (jetzt, heute, alle)</li>
+            <li>Über Marktdetails und Marktzeiten informieren</li>
+            <li>Datenquelle und letzte Aktualisierung nachsehen</li>
+            <li>Quellcode der Webanwendung aufrufen</li>
+        </ul>
+        <p>Die Webseite ist sowohl für die Darstellung auf Smartphones und Tablets als auch auf
+        Desktop-Browsern optimiert.</p>
+
+        <h2>Hintergrund</h2>
+        <p>Das Projekt wurde im Februar 2015 von Florian Brucker für Märkte in Karlsruhe ins Leben gerufen.
+        Im Februar 2016 wurde das Projekt von Tobias Preuß umgebaut, damit weitere Städte dazu kommen können.
+        Seitdem wird das Projekt aktiv weiter entwickelt. Der
+        <a href="https://github.com/wo-ist-markt/wo-ist-markt.github.io" title="GitHub Repository">Quellcode</a>
+        ist frei zugänglich und steht unter der MIT-Lizenz.</p>
+
+        <h2>Marktdaten</h2>
+        <p>Die Marktdaten werden manuell eingepflegt. In jeder Stadt muss es mindestens eine Person geben,
+        die die Daten initial zusammenträgt und dann aktuell hält. Aus diesem Grund sind auch nur die
+        Marktdaten bestimmter Städte abrufbar.</p>
+
+        <button onclick="window.history.back()">Zurück zur Karte</button>
+    </body>
+</html>

--- a/js/main.js
+++ b/js/main.js
@@ -4,9 +4,9 @@
  */
 
 var TILES_URL = '//cartodb-basemaps-a.global.ssl.fastly.net/light_all/{z}/{x}/{y}.png';
-var ATTRIBUTION = 'Map data &copy; <a href="http://openstreetmap.org">OpenStreetMap</a> ' +
-                  'contributors, <a href="http://creativecommons.org/licenses/by-sa/2.0/">' +
-                  'CC-BY-SA</a>. Tiles &copy; <a href="http://cartodb.com/attributions">' +
+var ATTRIBUTION = 'Map data &copy; <a href="http://openstreetmap.org">OpenStreetMap</a> | ' +
+                  'contributors <a href="http://creativecommons.org/licenses/by-sa/2.0/">' +
+                  'CC-BY-SA</a> | Tiles &copy; <a href="http://cartodb.com/attributions">' +
                   'CartoDB</a>';
 
 var DEFAULT_CITY_ID = "karlsruhe";

--- a/js/main.js
+++ b/js/main.js
@@ -497,8 +497,9 @@ $(window).on('hashchange',function() {
 
 
 $(document).ready(function() {
-    var tiles = new L.TileLayer(TILES_URL, {attribution: ATTRIBUTION});
-    map = new L.Map('map').addLayer(tiles);
+    map = new L.map('map');
+    L.tileLayer(TILES_URL, { attribution: ATTRIBUTION }).addTo(map);
+
     var dropDownCitySelection = $('#dropDownCitySelection');
     $("input[name=display]").change(updateLayers);
 

--- a/js/main.js
+++ b/js/main.js
@@ -4,7 +4,10 @@
  */
 
 var TILES_URL = '//cartodb-basemaps-a.global.ssl.fastly.net/light_all/{z}/{x}/{y}.png';
-var ATTRIBUTION = 'Map data &copy; <a href="http://openstreetmap.org">OpenStreetMap</a> | ' +
+var ATTRIBUTION = '<a id="daten" href="info.html">Über Wo ist Markt?</a> | ' +
+                  '<a id="impressum" href="impressum.html">Impressum</a> | ' +
+                  '<a href="http://leafletjs.com" title="A JS library for interactive maps">Leaflet</a> | ' +
+                  'Map data &copy; <a href="http://openstreetmap.org">OpenStreetMap</a> | ' +
                   'contributors <a href="http://creativecommons.org/licenses/by-sa/2.0/">' +
                   'CC-BY-SA</a> | Tiles &copy; <a href="http://cartodb.com/attributions">' +
                   'CartoDB</a>';
@@ -497,7 +500,8 @@ $(window).on('hashchange',function() {
 
 
 $(document).ready(function() {
-    map = new L.map('map');
+    map = new L.map('map', { attributionControl: false });
+    L.control.attribution( { prefix: '' } ).addTo(map);
     L.tileLayer(TILES_URL, { attribution: ATTRIBUTION }).addTo(map);
 
     var dropDownCitySelection = $('#dropDownCitySelection');


### PR DESCRIPTION
I prepend two links to the Leaflet attribution section at the bottom of the page. There is still some unwanted line break for the "Leaflet" link. Help wanted.

![screen](https://user-images.githubusercontent.com/144518/27303183-313b492c-553a-11e7-9ee2-a54f2f0bc614.png)

# Related issue

-  Extended project information: #86 