### PR TITLE
Update data source URL for Kiel

### DIFF
--- a/cities/kiel.json
+++ b/cities/kiel.json
@@ -184,7 +184,7 @@
     "metadata": {
         "data_source": {
             "title": "Stadt Kiel",
-            "url": "https://www.kiel.de/touristik/maerkte/wochenmarkt.php"
+            "url": "https://www.kiel.de/de/kultur_freizeit/maerkte/wochenmarkt.php"
         }
     },
     "type": "FeatureCollection"


### PR DESCRIPTION
see also https://github.com/wo-ist-markt/wo-ist-markt.github.io/pull/114#issuecomment-314552488

Kiel has a new website, so the link for the markets has changed.