### PR TITLE
Use history API to remove `#` from URLS

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,6 +147,8 @@ Tests can be run using [npm][npm]:
 
     $ npm install  # Just once after you've cloned the repo
 
+    $ npm start    # This will start a local server on http://localhost:8080
+
     $ npm test     # Whenever you want to run the tests
 
 

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ in February 2016.
 * The individual market data for supported cities is displayed when the city name is given in the
   address bar of the browser.
 
-  Example: http://wo-ist-markt.de/#karlsruhe.
+  Example: http://wo-ist-markt.de/karlsruhe.
 
   By default or on error *Karlsruhe* is rendered.
 

--- a/_redirects
+++ b/_redirects
@@ -1,0 +1,3 @@
+/impressum.html /impressum.html 200
+/info.html      /info.html      200
+/*              /index.html     200

--- a/js/main.js
+++ b/js/main.js
@@ -462,13 +462,18 @@ function fixMapHeight() {
 $(window).on('resize', fixMapHeight);
 
 
-$(window).on('hashchange',function() {
-    // Don't create a new history state, because the hash change already did
-    setCity(getPathCity(), false);
-});
-
+// we used to pass the city after the `#` in the url.
+// now we simply put it after the `/`
+// so /#berlin becomes /berlin
+function removeHashPrefixInUrl() {
+    var hash = window.location.hash;
+    if (hash) {
+        setCity(hash.slice(1, hash.length));
+    }
+}
 
 $(document).ready(function() {
+    removeHashPrefixInUrl();
     map = new L.map('map', { attributionControl: false });
     L.control.attribution( { prefix: '' } ).addTo(map);
     L.tileLayer(TILES_URL, { attribution: ATTRIBUTION }).addTo(map);

--- a/js/main.js
+++ b/js/main.js
@@ -305,13 +305,13 @@ function initMarker(feature) {
 /*
  * Returns the city ID from the hash of the current URI.
  */
-function getHashCity() {
-    var hash = decodeURIComponent(window.location.hash);
-    if (hash === undefined || hash === "") {
+function getPathCity() {
+    var pathName = decodeURIComponent(window.location.pathname);
+    if (pathName === undefined || pathName === "") {
         return '';
     } else {
-        hash = hash.toLowerCase();
-        return hash.substring(1, hash.length);
+        pathName = pathName.toLowerCase();
+        return pathName.substring(1, pathName.length);
     }
 }
 
@@ -325,42 +325,11 @@ function getHashCity() {
  */
 function updateUrlHash(cityID, createNewHistoryEntry) {
     if (createNewHistoryEntry) {
-        createHistoryEntryWithHash(cityID);
+        history.pushState(null, null, cityID);
     } else {
-        replaceHistoryEntryWithHash(cityID);
+        history.replaceState(null, null, cityID);
     }
 }
-
-
-/*
- * Create a new history entry by changing the URL fragment.
- *
- * `hash` is the new fragment (without `#`).
- */
-function createHistoryEntryWithHash(hash) {
-    if (history.pushState) {
-        history.pushState(null, null, "#" + hash);
-    } else {
-        window.location.hash = hash;
-    }
-}
-
-
-/*
- * Replace the current history entry by changing the URL fragment.
- *
- * `hash` is the new fragment (without `#`).
- */
-function replaceHistoryEntryWithHash(hash) {
-    hash = '#' + hash;
-    if (history.replaceState) {
-        history.replaceState(null, null, hash);
-    } else {
-        // http://stackoverflow.com/a/6945614/857390
-        window.location.replace(('' + window.location).split('#')[0] + hash);
-    }
-}
-
 
 /*
  * Returns the given string in camel case.
@@ -495,7 +464,7 @@ $(window).on('resize', fixMapHeight);
 
 $(window).on('hashchange',function() {
     // Don't create a new history state, because the hash change already did
-    setCity(getHashCity(), false);
+    setCity(getPathCity(), false);
 });
 
 
@@ -542,7 +511,7 @@ $(document).ready(function() {
         dropDownCitySelection.select2('open');
         dropDownCitySelection.select2('close');
 
-        setCity(getHashCity(), false);
+        setCity(getPathCity(), false);
     });
 
     $('#btnToggleHeader').click(toggleHeader);

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "devDependencies": {
     "colors": "~1.1.2",
     "country-language": "^0.1.7",
+    "http-server": "^0.10.0",
     "i18next-client": "^1.11.5",
     "jasmine": "^2.4.1",
     "jshint": "~2.9.5",
@@ -18,6 +19,7 @@
     "lint": "jshint js preprocessing validation",
     "jasmine-tests": "jasmine",
     "test": "npm run lint && npm run jasmine-tests && npm run validate",
-    "validate": "node validation/markets-validator.js"
+    "validate": "node validation/markets-validator.js",
+    "start": "http-server -f index.html"
   }
 }


### PR DESCRIPTION
We were actually using the history api already but falling back if it not supported. According to caniuse[1] all major browsers support it now though so we should be able to just use it for nicer looking urls. 

And thanks to the new netlify deploy we can easily make sure, that the urls will work as expected.

[1] http://caniuse.com/#feat=history