### PR TITLE
update url and market data for duisburg

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,7 +205,7 @@ The command to deploy manually is: `fab deploy -H deploy@kiesinger.okfn.de:2207`
 [dresden-wikipedia]: https://en.wikipedia.org/wiki/Dresden
 [dresden-markets]: https://www.dresden.de/de/leben/sport-und-freizeit/maerkte-in-dresden.php
 [duisburg-wikipedia]: https://en.wikipedia.org/wiki/Duisburg
-[duisburg-markets]: https://www.duisburg.de/leben/maerkte_in_duisburg/index.php
+[duisburg-markets]: https://www.duisburgkontor.de/frischemaerkte/wochenmaerkte/
 [duesseldorf-wikipedia]: https://de.wikipedia.org/wiki/D%C3%BCsseldorf
 [duesseldorf-markets]: https://www.duesseldorf.de/verbraucherschutz/marktverwaltung/wochen.shtml
 [erlangen-wikipedia]: https://en.wikipedia.org/wiki/Erlangen

--- a/cities/duisburg.json
+++ b/cities/duisburg.json
@@ -304,7 +304,7 @@
       "properties": {
         "title": "Duissern",
         "location": "Königsberger Allee, 47058 Duisburg",
-        "opening_hours": "Tu, Fr 14:00 - 18:30"
+        "opening_hours": "Tu, Fr 14:00 - 17:30"
       }
     },
     {
@@ -446,7 +446,7 @@
   "metadata": {
     "data_source": {
       "title": "Duisburg Kontor GmbH",
-      "url": "https://www.duisburg.de/leben/maerkte_in_duisburg/index.php"
+      "url": "https://www.duisburgkontor.de/frischemaerkte/wochenmaerkte/"
     }
   }
 }


### PR DESCRIPTION
I researched the new url for Duisburg market data and – while at it – updated the market data itself as well. 