### PR TITLE
Temporary move of market in Karlsruhe Nordweststadt

### DIFF
--- a/cities/karlsruhe.json
+++ b/cities/karlsruhe.json
@@ -159,14 +159,29 @@
         {
             "geometry": {
                 "coordinates": [
-                    8.3700837,
-                    49.0291955
+                    8.3714946,
+                    49.0312032
                 ],
                 "type": "Point"
             },
             "properties": {
-                "location": "Auf dem Walther-Rathenau-Platz",
-                "opening_hours": "Tu, Sa 07:30-14:00",
+                "location": "Schulhof der Werner-von-Siemens-Schule",
+                "opening_hours": "Sa 07:30-14:00",
+                "title": "Nordweststadt"
+            },
+            "type": "Feature"
+        },
+        {
+            "geometry": {
+                "coordinates": [
+                    8.37004,
+                    49.03014
+                ],
+                "type": "Point"
+            },
+            "properties": {
+                "location": "Parkplatz der ehemaligen Neuapostolischen Kirche",
+                "opening_hours": "Tu 07:30-14:00",
                 "title": "Nordweststadt"
             },
             "type": "Feature"


### PR DESCRIPTION
The [market is temporarily moved due to construction works](https://presse.karlsruhe.de/db/meldungen/karlsruhe/wochenmarkt_nordweststadt_zieht_um.html).

The new locations are valid starting from Saturday, October 7th. Since the market is open on Tuesdays and Saturdays this means that the last time the current location would be used is Tuesday, October 3rd. However, that is a public holiday and hence the market will not be open. So actually the last market at the current location is on Saturday, September 30th. 

:exclamation: **Please do not merge this PR earlier than Sunday, October 1st.**
