### PR TITLE
Markt Blumen Dahlmann

### DIFF
--- a/cities/münster.json
+++ b/cities/münster.json
@@ -270,6 +270,21 @@
           51.9159
         ]
       }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "location": "Markt bei Blumen Dahlmann",
+        "title": "Markt bei Blumen Dahlmann",
+        "opening_hours": "Sa 08:00-14:00"
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          7.68856,
+          51.9093
+        ]
+      }
     }
   ],
     "metadata": {


### PR DESCRIPTION
Samstagsmarkt bei Blumen Dahlmann, Hiltrup Ost

Ich kann keine Online Quelle geben, der Markt wird auch nicht auf der Seite der Stadt geführt.
Folgende Stände gibt es:
Gemüse / Fisch / Fleisch / Brot&Käse / Oliven / http://www.flotte-bohne.de/