### PR TITLE
Remove GitHub CNAME file.

### DIFF
--- a/CNAME
+++ b/CNAME
@@ -1,1 +1,0 @@
-wo-ist-markt.de


### PR DESCRIPTION
+ This file is used by GitHub to figure out what the additional DNS name
  is under which the GitHub pages results should be made available.
+ Since we dropped GitHub pages in favour of our own server we do not
  need this file anymore.

---

Cherry-picked and updated from 176f7593899b0ea143cf7c9a9b457d1657556459. See #217.