### PR TITLE
Remove Gemnasium badge. RIP!

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Build Status](https://travis-ci.org/wo-ist-markt/wo-ist-markt.github.io.svg?branch=master)](https://travis-ci.org/wo-ist-markt/wo-ist-markt.github.io) [![Dependency Status](https://gemnasium.com/badges/github.com/wo-ist-markt/wo-ist-markt.github.io.svg)](https://gemnasium.com/github.com/wo-ist-markt/wo-ist-markt.github.io) [![devDependencies Status](https://david-dm.org/wo-ist-markt/wo-ist-markt.github.io/dev-status.svg)](https://david-dm.org/wo-ist-markt/wo-ist-markt.github.io?type=dev) [![Greenkeeper badge](https://badges.greenkeeper.io/wo-ist-markt/wo-ist-markt.github.io.svg)](https://greenkeeper.io/)
+[![Build Status](https://travis-ci.org/wo-ist-markt/wo-ist-markt.github.io.svg?branch=master)](https://travis-ci.org/wo-ist-markt/wo-ist-markt.github.io) [![devDependencies Status](https://david-dm.org/wo-ist-markt/wo-ist-markt.github.io/dev-status.svg)](https://david-dm.org/wo-ist-markt/wo-ist-markt.github.io?type=dev) [![Greenkeeper badge](https://badges.greenkeeper.io/wo-ist-markt/wo-ist-markt.github.io.svg)](https://greenkeeper.io/)
 
 # Wo ist Markt?
 


### PR DESCRIPTION
+ Gemnasium has been acquired by GitLab in January 2018. Since
  May 15, 2018, the services provided by Gemnasium are no longer
  available. See [here](https://docs.gitlab.com/ee/user/project/import/gemnasium.html).