### PR TITLE
ISSUE-162 compare key with id

### DIFF
--- a/validation/markets-validator.js
+++ b/validation/markets-validator.js
@@ -43,6 +43,34 @@ colors.setTheme({
     error: 'red'
 });
 
+/**
+ * Reads in the cities.json file and compares the key with the corresponding ids.
+ * If one or more does not match it exits with 1.
+ */
+
+fs.readFile(MARKETS_INDEX_FILE_PATH, function(err, data){
+    if (err){
+        throw err;
+    }
+    else
+    {
+        var errorsCount = 0;
+        var json = JSON.parse(data);
+        Object.getOwnPropertyNames(json).forEach(function(key) {
+            if (key == json[key].id){
+                console.log("Key of ".passed + key.section + " matches id.".passed);
+            }
+            else {
+                console.error("Key of ".error + key.section + " does not match id.".error);
+                errorsCount +=1;
+            }
+
+            if (errorsCount !== 0){
+                exitCode = 1;
+            }
+        });
+    }
+});
 
 /**
  * Reads in the given directory to process market files.


### PR DESCRIPTION
This is a PR for a part of issue #162.
> Validate that citykey and city `id` are identical (see screenshot)

Since this is an older issue I don't know if this is still needed, if not this PR can be closed of course.

This change enables the ```markets-validator.js``` to compare the keys and ids in the ```cities.json``` and exits with an error if thats not the case.