### PR TITLE
Fix data source URLs

### DIFF
--- a/cities/bad-homburg.json
+++ b/cities/bad-homburg.json
@@ -34,7 +34,7 @@
     "metadata": {
         "data_source": {
             "title": "Stadt Bad Homburg ver der Höhe",
-            "url": "http://www.bad-homburg.de/leben-in-bad-homburg/sport-freizeit-ehrenamt/Wochen-_und_Blumenmarkt.php"
+            "url": "https://www.bad-homburg.de/kur-und-tourismus/maerkte-feste/index.php"
         }
     },
     "type": "FeatureCollection"

--- a/cities/basel.json
+++ b/cities/basel.json
@@ -79,7 +79,7 @@
     "metadata": {
         "data_source": {
             "title": "Stadt Basel",
-            "url": "http://www.messenundmaerkte.bs.ch"
+            "url": "https://www.marketing.bs.ch/messen-maerkte"
         }
     },
     "type": "FeatureCollection"

--- a/cities/bonn.json
+++ b/cities/bonn.json
@@ -163,7 +163,7 @@
 	"metadata": {
 		"data_source": {
 			"title": "Stadt Bonn",
-			"url": "http://www.bonn.de/rat_verwaltung_buergerdienste/buergerdienste_online/buergerservice_a_z/00283/index.html?lang=de&download=M3wBUQCu%2F8ulmKDu36WenojQ1NTTjaXZnqWfVpzLhmfhnapmmc7Zi6rZnqCkkIN1fn17bKbXrZ2lhtTN34al3p6YrY7P1oah162apo3X1cjYh2%2BhoJRn6w%3D%3D"
+			"url": "https://www.bonn.de/vv/produkte/Wochenmarkt-Bewerbung.php?lang=de&download=M3wBUQCu%252F8ulmKDu36WenojQ1NTTjaXZnqWfVpzLhmfhnapmmc7Zi6rZnqCkkIN1fn17bKbXrZ2lhtTN34al3p6YrY7P1oah162apo3X1cjYh2%252BhoJRn6w%253D%253D"
 		}
 	},
 	"type": "FeatureCollection"

--- a/cities/bruchköbel.json
+++ b/cities/bruchköbel.json
@@ -34,7 +34,7 @@
     "metadata": {
         "data_source": {
             "title": "Stadtmarketing Bruchköbel GmbH",
-            "url": "http://www.stadtmarketing-bruchkoebel.de/einkaufen-geniessen/wochenmarkt-bruchkoebel/"
+            "url": "https://www.stadtmarketing-bruchkoebel.de/einkaufen-geniessen/wochenmarkt-bruchkoebel/"
         }
     },
     "type": "FeatureCollection"

--- a/cities/chemnitz.json
+++ b/cities/chemnitz.json
@@ -100,7 +100,7 @@
 	"metadata": {
 		"data_source": {
 			"title": "Stadt Chemnitz",
-			"url": "http://www.chemnitz.de/chemnitz/de/aktuelles/ausschreibungen/marktausschreibung/index.html"
+			"url": "https://www.chemnitz.de/chemnitz/de/rathaus/ausschreibungen/marktausschreibungen/index.html"
 		}
 	},
 	"type": "FeatureCollection"

--- a/cities/dortmund.json
+++ b/cities/dortmund.json
@@ -206,7 +206,7 @@
   "metadata": {
     "data_source": {
       "title": "Stadt Dortmund",
-      "url": "https://www.dortmund.de/de/leben_in_dortmund/stadtportraet/einkaufen/wochenmaerkte/"
+      "url": "https://www.dortmund.de/de/leben_in_dortmund/ausunsererstadt/stadtportraet/einkaufen/wochenmaerkte/index.html"
     }
   }
 }

--- a/cities/frankfurtmain.json
+++ b/cities/frankfurtmain.json
@@ -356,7 +356,7 @@
     "metadata": {
         "data_source": {
             "title": "Stadt Frankfurt am Main",
-            "url": "http://frankfurt.de/sixcms/detail.php?id=4623&_ffmpar[_id_eltern]=4622"
+            "url": "https://frankfurt.de/sixcms/detail.php?id=4623&_ffmpar%5B_id_eltern%5D=4622"
         }
     },
     "type": "FeatureCollection"

--- a/cities/freiburg.json
+++ b/cities/freiburg.json
@@ -265,7 +265,7 @@
     "metadata": {
         "data_source": {
             "title": "Stadt Freiburg",
-            "url": "http://www.freiburg.de/pb/,Lde/226390.html"
+            "url": "https://visit.freiburg.de/freiburg-planen/gastronomie-in-freiburg"
         }
     },
     "type": "FeatureCollection"

--- a/cities/hamburg.json
+++ b/cities/hamburg.json
@@ -1159,7 +1159,7 @@
     ],
     "metadata" : {
         "data_source" : {
-            "url" : "http://www.hamburg.de/wochenmarkt-hamburg",
+            "url" : "https://www.hamburg.de/wochenmarkt-hamburg",
             "title" : "Stadt Hamburg"
         }
     }

--- a/cities/herne.json
+++ b/cities/herne.json
@@ -131,7 +131,7 @@
   "metadata": {
     "data_source": {
       "title": "Stadt Herne",
-      "url": "http://www.herne.de/Rathaus/Buergerservice/Wochenm%C3%A4rkte/index.html"
+      "url": "https://www.herne.de/Rathaus/Buergerservice/Wochenm%C3%A4rkte/index.html"
     }
   }
 }

--- a/cities/kaiserslautern.json
+++ b/cities/kaiserslautern.json
@@ -50,7 +50,7 @@
     "metadata": {
         "data_source": {
             "title": "Kaiserslauterer Wochenmarktverein",
-            "url": "http://www.wochenmarkt-kaiserslautern.de/"
+            "url": "https://www.wochenmarkt-kaiserslautern.de/"
         }
     },
     "type": "FeatureCollection"

--- a/cities/kassel.json
+++ b/cities/kassel.json
@@ -55,7 +55,7 @@
     "metadata": {
         "data_source": {
             "title": "Stadt Kassel",
-            "url": "http://www.serviceportal-kassel.de/cms05/dienstleistungen/029907/index.html"
+            "url": "https://www.serviceportal-kassel.de/cms05/dienstleistungen/029907/index.html"
         }
     },
     "type": "FeatureCollection"

--- a/cities/konstanz.json
+++ b/cities/konstanz.json
@@ -40,7 +40,7 @@
     "metadata": {
         "data_source": {
             "title": "Stadt Konstanz",
-            "url": "http://www.konstanz.de/umwelt/00706/01031/01037/index.html"
+            "url": "https://www.konstanz-tourismus.de/erleben-entdecken/shopping/maerkte/wochenmaerkte.html"
         }
     },
     "type": "FeatureCollection"

--- a/cities/langenfeld_rhld.json
+++ b/cities/langenfeld_rhld.json
@@ -26,7 +26,7 @@
   "metadata": {
     "data_source": {
       "title": "Stadt Langenfeld (Rhld.)",
-      "url": "http://langenfeld.active-city.net/city_info/display/dokument/show.cfm?region_id=138&id=4240&design_id=3340&type_id=0&titletext=1"
+      "url": "https://www.langenfeld.de/city_info/display/dokument/show.cfm?region_id=138&id=4240&design_id=3340&type_id=0&titletext=1"
     }
   }
 }

--- a/cities/oberursel.json
+++ b/cities/oberursel.json
@@ -79,7 +79,7 @@
     "metadata": {
         "data_source": {
             "title": "Stadt Oberursel",
-            "url": "http://www.oberursel.de/tourismus/bildung-kultur/veranstaltungen/maerkte/"
+            "url": "https://www.oberursel.de/de/slider-artikel/wochenmarkt/"
         }
     },
     "type": "FeatureCollection"

--- a/cities/oldenburg.json
+++ b/cities/oldenburg.json
@@ -115,7 +115,7 @@
     "metadata": {
         "data_source": {
             "title": "Stadt Oldenburg",
-            "url": "http://www.oldenburg.de/microsites/wochenmaerkte.html"
+            "url": "https://www.oldenburg.de/startseite/kultur/wochenmaerkte.html"
         }
     },
     "type": "FeatureCollection"

--- a/cities/rostock.json
+++ b/cities/rostock.json
@@ -260,7 +260,7 @@
   "metadata": {
     "data_source": {
       "title": "Hansestadt Rostock, aktualisiert am 04.06.2016",
-      "url": "http://www.rostocker-wochenmaerkte.de/standorte-angebote/"
+      "url": "https://www.rostocker-wochenmaerkte.de/standorte-angebote/"
     }
   }
 }

--- a/cities/schleswig.json
+++ b/cities/schleswig.json
@@ -49,7 +49,7 @@
     "metadata": {
         "data_source": {
             "title": "Stadt Schleswig",
-            "url": "http://schleswig.de/start.php?op=adressen&Abteilung=422"
+            "url": "https://www.schleswig.de/index.php?object=tx|3075.1.1&ModID=9&FID=3075.47.1"
         }
     },
     "type": "FeatureCollection"

--- a/cities/stralsund.json
+++ b/cities/stralsund.json
@@ -41,7 +41,7 @@
   "metadata": {
     "data_source": {
       "title": "Stadt Stralsund",
-      "url": "http://www.rostocker-wochenmaerkte.de/standorte-angebote/"
+      "url": "https://www.rostocker-wochenmaerkte.de/standorte-angebote/"
     }
   }
 }

--- a/cities/suhl.json
+++ b/cities/suhl.json
@@ -25,7 +25,7 @@
     "metadata": {
         "data_source": {
             "title": "Stadt Suhl",
-            "url": "http://suhltrifft.de/content/view/5059/2190/"
+            "url": "https://www.suhltrifft.de/content/view/5059/2190/"
         }
     },
     "type": "FeatureCollection"

--- a/cities/ulm.json
+++ b/cities/ulm.json
@@ -49,7 +49,7 @@
     "metadata": {
         "data_source": {
             "title": "Stadt Ulm",
-            "url": "http://www.ulm.de/marktwesen.97940.21332,97940.htm"
+            "url": "https://www.ulm.de/leben-in-ulm/umwelt-energie-entsorgung/energie-und-klimaschutz/tipps/wochenmarkt"
         }
     },
     "type": "FeatureCollection"


### PR DESCRIPTION
This updates the URLs for which the servers responded with `HTTP 301`, `HTTP 302`, `HTTP 303` or `HTTP 400`. Some servers still responds strangely:

```
Warning: brühl: HTTP response status of data source url was: 301
 New location: https://www.bruehl.de/wirtschaft/wirtschaftsfoerderung/wochenmaerkte.php
Warning: solingen: HTTP response status of data source url was: 403
Warning: hamburg: HTTP response status of data source url was: 500
Warning: basel: HTTP response status of data source url was: 303
 New location: /error_path/400.html?al_req_id=XLZGxbSA1u@ZjZ91Acqj-gAABX8
```

---

Relates to issue #281.