### PR TITLE
Opening hours improvements

### DIFF
--- a/cities/berlin.json
+++ b/cities/berlin.json
@@ -1691,8 +1691,8 @@
             "properties": {
                 "title": "Wochenmarkt Altstadt Spandau - Markt Havelländischer Land- und Bauernmarkt",
                 "location": "Wochenmarkt Altstadt Spandau - Markt Havelländischer Land- und Bauernmarkt",
-                "opening_hours": null,
-                "opening_hours_unclassified": "Mo, Di, Do, Fr ab 09:00"
+                "opening_hours": "Mo,Tu,Th,Fr 09:00+",
+                "opening_hours_unclassified": null
             },
             "type": "Feature"
         },

--- a/cities/berlin.json
+++ b/cities/berlin.json
@@ -1211,8 +1211,8 @@
             "properties": {
                 "title": "Antik- und Buchmarkt am Bodemuseum Am Kupfergraben/ Museumsinsel",
                 "location": "Antik- und Buchmarkt am Bodemuseum Am Kupfergraben/ Museumsinsel",
-                "opening_hours": null,
-                "opening_hours_unclassified": "Sa,So, gesetzliche Feiertage 11:00 - 17:00"
+                "opening_hours": "Sa,Su,PH 11:00-17:00",
+                "opening_hours_unclassified": null
             },
             "type": "Feature"
         },
@@ -1259,8 +1259,8 @@
             "properties": {
                 "title": "Kunstmarkt am Zeughaus",
                 "location": "Kunstmarkt am Zeughaus",
-                "opening_hours": null,
-                "opening_hours_unclassified": "Sa,So, gesetzliche Feiertage 11:00 - 17:00"
+                "opening_hours": "Sa,Su,PH 11:00-17:00",
+                "opening_hours_unclassified": null
             },
             "type": "Feature"
         },

--- a/js/main.js
+++ b/js/main.js
@@ -183,7 +183,12 @@ function getOpeningTimes(openingHoursStrings) {
     }
     var monday = moment().startOf("week").add(shiftBy, 'days').toDate();
     var sunday = moment().endOf("week").add(shiftBy, 'days').toDate();
-    var oh = new opening_hours(openingHoursStrings);
+    var options = {
+        "address" : {
+            "country_code" : "de"
+        }
+    };
+    var oh = new opening_hours(openingHoursStrings, options);
     var intervals = oh.getOpenIntervals(monday, sunday);
     var nextChange = oh.getNextChange();
 

--- a/preprocessing/berlin/compile-berlin-geojson.js
+++ b/preprocessing/berlin/compile-berlin-geojson.js
@@ -69,7 +69,7 @@ function prepareFeatureProperties(feature) {
 	var hours = inputProperties.zeiten;
 	var sanitizedDays = getSanitizeDays(days);
 	var sanitizedHours = getSanitizeHours(hours);
-	var days_hours = days + " " + hours;
+	var days_hours = sanitizedDays + " " + sanitizedHours;
 
 	try {
 		getOpeningRanges(days_hours);

--- a/preprocessing/berlin/compile-berlin-geojson.js
+++ b/preprocessing/berlin/compile-berlin-geojson.js
@@ -153,6 +153,7 @@ function getSanitizeString(hours) {
  * Returns a sanitized days string.
  */
 function getSanitizeDays(days) {
+	days = days.replace(/gesetzliche Feiertage/g, "PH");
 	days = days.replace("Di", "Tu");
 	days = days.replace("Mi", "We");
 	days = days.replace("Do", "Th");
@@ -191,6 +192,11 @@ function getSanitizeHours(hours) {
 function getOpeningRanges(opening_hours_strings) {
     var monday = moment().startOf("week").add(1, 'days').toDate();
     var sunday = moment().endOf("week").add(1, 'days').toDate();
-    var oh = new opening_hours(opening_hours_strings);
+    var options = {
+    	"address" : {
+    		"country_code" : "de"
+    	}
+    };
+    var oh = new opening_hours(opening_hours_strings, options);
     return oh.getOpenIntervals(monday, sunday);
 }

--- a/preprocessing/berlin/compile-berlin-geojson.js
+++ b/preprocessing/berlin/compile-berlin-geojson.js
@@ -174,6 +174,7 @@ function getSanitizeDays(days) {
  * Returns a sanitized hours string.
  */
 function getSanitizeHours(hours) {
+	hours = hours.replace(/ab (\d\d:\d\d)/g, "$1+");
 	hours = hours.replace(/ - /g, "-");
 	hours = hours.replace(/\n\n\n/g, " ");
 	hours = hours.replace(/\n\n/g, " ");

--- a/validation/markets-validator.js
+++ b/validation/markets-validator.js
@@ -331,7 +331,12 @@ function FeatureValidator(feature, cityName) {
         }
         var oh;
         try {
-            oh = new opening_hours(openingHours);
+            var options = {
+                "address" : {
+                    "country_code" : "de"
+                }
+            };
+            oh = new opening_hours(openingHours, options);
             var warnings = oh.getWarnings();
             if (warnings.length > 0) {
                 this.errors.push(warnings);


### PR DESCRIPTION
Looking into the pre-processing script for Berlin I picked a low hanging fruits :pear::
- Fix error in pre-processing script for Berlin - sanitized strings have not been passed to _opening_hours.js_.
- Support opening hours with open end, e.g. `ab 09:00`.
- Support markets happening on public holidays, e.g. `gesetzliche Feiertage`.