### PR TITLE
 Fix data source URLs

### DIFF
--- a/cities/brühl.json
+++ b/cities/brühl.json
@@ -49,7 +49,7 @@
     "metadata": {
         "data_source": {
             "title": "Stadt Brühl - Wochenmärkte",
-            "url": "http://www.bruehl.de/wirtschaft/wirtschaftsfoerderung/wochenmaerkte.php"
+            "url": "https://www.bruehl.de/veranstaltungen.aspx"
         }
     },
     "type": "FeatureCollection"

--- a/cities/cottbus.json
+++ b/cities/cottbus.json
@@ -116,7 +116,7 @@
 	"metadata": {
 		"data_source": {
 			"title": "Stadt Cottbus",
-			"url": "http://www.cottbuser-wochenmarkt.de/wochenm%C3%A4rkte/"
+			"url": "https://www.cottbuser-wochenmarkt.de/wochenm%C3%A4rkte/"
 		}
 	},
 	"type": "FeatureCollection"

--- a/cities/hanau.json
+++ b/cities/hanau.json
@@ -19,7 +19,7 @@
     "metadata": {
         "data_source": {
             "title": "Stadt Hanau",
-            "url": "http://www.hanau.de/lih/sport/maerkte/woma/010241/"
+            "url": "https://www.hanau.de/lih/sport/maerkte/woma/010241/"
         }
     },
     "type": "FeatureCollection"

--- a/cities/wiesbaden.json
+++ b/cities/wiesbaden.json
@@ -68,7 +68,7 @@
     "metadata": {
         "data_source": {
             "title": "Wiesbaden Marketing GmbH",
-            "url": "http://www.wiesbaden.de/microsite/wochenmarkt/index.php"
+            "url": "https://www.wiesbaden.de/microsite/wochenmarkt/index.php"
         }
     },
     "type": "FeatureCollection",

--- a/cities/witten.json
+++ b/cities/witten.json
@@ -71,7 +71,7 @@
   "metadata": {
     "data_source": {
       "title": "Stadtmarketing Witten GmbH",
-      "url": "http://www.stadtmarketing-witten.de/einkaufen/wochenmaerkte.html"
+      "url": "https://www.stadtmarketing-witten.de/einkaufen/wochenmaerkte.html"
     }
   }
 }


### PR DESCRIPTION
This updates the URLs for which the servers responded with `HTTP 301` or `HTTP 302`. Some servers still respond strangely - which still need to be fixed:

```
Warning: bretten: HTTP response status of data source url was: 403
Warning: hamburg: HTTP response status of data source url was: 500
Warning: basel: HTTP response status of data source url was: 303
 New location: /error_path/400.html?al_req_id=XSTjWndQ7zGCHfVYILK1UQAABfM
Warning: kassel: HTTP response status of data source url was: 302
 New location: https://www.kassel.de/service
Warning: hanau: HTTP response status of data source url was: 404
Warning: konstanz: HTTP response status of data source url was: 301
 New location: https://www.konstanz-tourismus.de/wochenmaerkte.html
Warning: hamm: HTTP response status of data source url was: 500
Warning: solingen: HTTP response status of data source url was: 403
Warning: kaiserslautern: HTTP response status of data source url was: 301
 New location: https://www.wochenmarkt-kl.de/
Warning: wuppertal: HTTP response status of data source url was: 404
Warning: oberursel: HTTP response status of data source url was: 404
```

# How to check

- Run `npm test` locally and read the output in the console.
- Check if the suggested website is actually listing market data and is not a redirect, default page or such.