### PR TITLE
Change opening hours for one market, which is currently closed due to corona

### DIFF
--- a/cities/bielefeld.json
+++ b/cities/bielefeld.json
@@ -91,8 +91,8 @@
       "type": "Feature",
       "properties": {
         "location": "Klosterplatz",
-        "opening_hours": "Apr-Oct Th 16:00-20:00",
-        "opening_hours_unclassified": null,
+        "opening_hours": null,
+        "opening_hours_unclassified": "Momentan ausgesetzt.",
         "title": "Abendmarkt"
       },
       "geometry": {


### PR DESCRIPTION
see https://www.bielefeld.de/de/pressedienst/detail.html?id=bm-1086

Should the time specification be more accurate (e.g. linking to the press statement), or should I maybe remove the market completely? I'm not sure, I decided to use this short mention, so people looking for this market would get the info and it's not too much text in the info box.