### PR TITLE
Vertically center markers with associated text.

### DIFF
--- a/css/main.css
+++ b/css/main.css
@@ -78,8 +78,12 @@ html, body {
 
 #header label .awesome-marker {
   display: inline-block;
-  margin-top: -0.5em; /* compensate offset */
+  margin-top: -0.8em; /* compensate offset */
   transform: scale(0.75);
+}
+
+#header label .awesome-marker i {
+    margin-top: 9px;
 }
 
 #header :disabled + span {


### PR DESCRIPTION
+ This also lets the scrollbar in the header disappear.

# Before
![image](https://user-images.githubusercontent.com/144518/90383940-1ec74400-e081-11ea-99e3-6a6766e73a09.png)

# After
![image](https://user-images.githubusercontent.com/144518/90384353-b3ca3d00-e081-11ea-9bf6-9d0d8bb00af0.png)

# Successfully tested on
- Ubuntu 18.04.4, Brave Version 1.11.104 Chromium: 84.0.4147.105 (Official Build) (64-bit)
- Ubuntu 18.04.4, Chromium, Version 84.0.4147.105 (Official Build) Built on Ubuntu , running on Ubuntu 18.04 (64-bit)
- Ubuntu 18.04.4, Firefox 79.0
- Android 10, DuckDuckGo 5.61.2 zf (56102)
- Android 10, Chrome, Version 84.0.4147.125

# Review
- Please test on iOS and MacOS.