### PR TITLE
Add details URL for each market

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -53,7 +53,8 @@ This section describes the file format which is used to store the market data fo
           "location": "Vor der Christ-König-Kirche",
           "opening_hours": "We, Sa 07:30-14:00",
           "opening_hours_unclassified": null,
-          "title": "Rüppurr"
+          "title": "Rüppurr",
+          "details_url" : "https://www.karlsruhe.de/b3/maerkte/wochenmarkte/rueppurr.de"
       },
       "type": "Feature"
   }
@@ -62,6 +63,7 @@ This section describes the file format which is used to store the market data fo
 * The opening hours use the [OpenStreetMap opening hours format][osm-openinghours].
 * Opening hours which cannot be expressed in that format can use the `opening_hours_unclassified`
   property. In that case set the `opening_hours` property to `null`.
+* `details_url` is an optional field. If it exists, it'll be shown as a link with text `weitere Informationen` in market popup.
 * Besides the actual market data the file contains a `metadata` block as shown in this example excerpt:
 
   ``` json

--- a/cities/hamburg.json
+++ b/cities/hamburg.json
@@ -1160,7 +1160,8 @@
             "properties" : {
                 "opening_hours" : "Sa 08:00-16:00",
                 "title" : "Flohschanze",
-                "location" : "Neuer Kamp 30"
+                "location" : "Neuer Kamp 30",
+                "details_url" : "https://www.hamburg.de/flohmarkt/4245446/flohschanze/"
             },
             "type" : "Feature",
             "geometry" : {
@@ -1175,7 +1176,8 @@
             "properties" : {
                 "opening_hours" : "We 09:00-15:00; Sa 07:00-15:00",
                 "title" : "Flea Dome Bahrenfelder Trabrennbahn",
-                "location" : "Bahrenfelder Trabrennbahn"
+                "location" : "Bahrenfelder Trabrennbahn",
+                "details_url" : "https://www.hamburg.de/flohmarkt/4245510/flohdom-bahrenfelder-trabrennbahn/"
             },
             "type" : "Feature",
             "geometry" : {

--- a/css/main.css
+++ b/css/main.css
@@ -146,6 +146,13 @@ html, body {
     margin: 0;
 }
 
+.leaflet-popup-content a {
+    /* display: block along with line-height is use to make the 
+    clickable/touchable area bigger. This provides a better experience on touch interfaces */
+    display: block;
+    line-height: 2em;
+}
+
 .leaflet-popup-content p.unclassified {
     margin-top: 0.5em;
     font-style: italic;

--- a/js/main.js
+++ b/js/main.js
@@ -264,6 +264,10 @@ function initMarker(feature) {
     } else {
         where = '';
     }
+
+    var additionalInformationLink = properties.details_url ?
+        '<span><a href='+properties.details_url+'> weitere Informationen </a></span>' : '';
+
     var title = properties.title;
     if (title === undefined) {
         throw "Missing property 'title'.";
@@ -271,7 +275,7 @@ function initMarker(feature) {
     if (title === null || title.length === 0) {
         title = DEFAULT_MARKET_TITLE;
     }
-    var popupHtml = '<h1>' + title + '</h1>' + where;
+    var popupHtml = '<h1>' + title + '</h1>' + where + additionalInformationLink;
     if (openingHoursUnclassified !== undefined) {
         popupHtml += '<p class="unclassified">' + openingHoursUnclassified + '</p>';
     } else {


### PR DESCRIPTION
Address #318

I wasn't able to get jasmine running. 

I've only added links for two market entries

![image](https://user-images.githubusercontent.com/8488446/95119298-094ecc00-074c-11eb-8bdb-d07fa43a3984.png)


You can find it in https://deploy-preview-337--wo-ist-markt.netlify.app/#hamburg