### PR TITLE
Update node.js in Travis CI to version 14

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: python
 
 env:
-  - TRAVIS_NODE_VERSION="7"
+  - TRAVIS_NODE_VERSION="14"
 
 python:
     - '2.7'


### PR DESCRIPTION
14 is the latest long term support release. We were still using
version 7 which is no longer supported. This change was caused
by the observation that test suddenly started failing [1]. Updating
node to a supported verison resolved this.

[1]: https://travis-ci.org/github/wo-ist-markt/wo-ist-markt.github.io/jobs/744637188