### PR TITLE
Link Liberapay team profile in this repository.

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,1 +1,2 @@
 github: [johnjohndoe]
+liberapay: Wo-ist-Markt


### PR DESCRIPTION
I set up a **team profile** for this project on Liberapay: https://liberapay.com/Wo-ist-Markt/.
With this change the Liberapay link will show up next to the GitHub sponsors link.

If you are contributing to this project and have a personal Liberapay account please let me know. I will be happy to add you to the team.