### PR TITLE
Update markets for Berlin (published 10.03.2021).

### DIFF
--- a/cities/berlin.json
+++ b/cities/berlin.json
@@ -6,16 +6,16 @@
             "geometry": {
                 "type": "Point",
                 "coordinates": [
-                    13.31054,
-                    52.46746
+                    13.05696,
+                    52.40311
                 ]
             },
             "properties": {
-                "title": "< 164 Markt, Breitenbachplatz",
-                "location": "Breitenbachplatz 1, 14195",
-                "opening_hours": null,
-                "opening_hours_unclassified": "14.06., 12.07.,  09.08., 13.09., 11.10., 01.11.2020 10:00 - 14:00",
-                "details_url": "http://www.markttag-berlin.de"
+                "title": "Wochenmarkt Am Nauener Tor 14467 Potsdam",
+                "location": "Hegelallee 55, 14467",
+                "opening_hours": "We,Sa 09:00-16:00",
+                "opening_hours_unclassified": null,
+                "details_url": "http://www.markt-am-nauener-tor.de"
             }
         },
         {
@@ -23,99 +23,14 @@
             "geometry": {
                 "type": "Point",
                 "coordinates": [
-                    13.31894,
-                    52.52798
+                    13.05868,
+                    52.40114
                 ]
             },
             "properties": {
-                "title": "10. Design.Börse_Berlin im LOEWE-SAAL",
-                "location": "Wiebestraße 42, 10553",
-                "opening_hours": null,
-                "opening_hours_unclassified": "13. - 15.11.2020 Fr 16:30 - 21:00 Sa 12:00 - 20:00 So 11:00-19:00",
-                "details_url": "http://www.oldthing.de"
-            }
-        },
-        {
-            "type": "Feature",
-            "geometry": {
-                "type": "Point",
-                "coordinates": [
-                    13.29531,
-                    52.51911
-                ]
-            },
-            "properties": {
-                "title": "11. Berliner Kunstallee",
-                "location": "Schloßstr. 1, 14059",
-                "opening_hours": null,
-                "opening_hours_unclassified": "05.-06.09.2020 11:00 - 18:00",
-                "details_url": "http://www.kunsthand-berlin.de"
-            }
-        },
-        {
-            "type": "Feature",
-            "geometry": {
-                "type": "Point",
-                "coordinates": [
-                    13.56643,
-                    52.53795
-                ]
-            },
-            "properties": {
-                "title": "15. Kunst- und Keramikmarkt",
-                "location": "Alt Marzahn, 12685",
-                "opening_hours": null,
-                "opening_hours_unclassified": "07./08.11.2020 10:00 - 18:00",
-                "details_url": "http://www.agrar-boerse-ev.de/kulturgut.html"
-            }
-        },
-        {
-            "type": "Feature",
-            "geometry": {
-                "type": "Point",
-                "coordinates": [
-                    13.28996,
-                    52.63267
-                ]
-            },
-            "properties": {
-                "title": "17. Gartenlust & Kunstgenuss Frohnau",
-                "location": "S-Bahnhof Frohnau, 13465",
-                "opening_hours": null,
-                "opening_hours_unclassified": "12.-13.09.2020 11:00 - 18:00",
-                "details_url": "http://www.kunsthand-berlin.de"
-            }
-        },
-        {
-            "type": "Feature",
-            "geometry": {
-                "type": "Point",
-                "coordinates": [
-                    13.29527,
-                    52.50781
-                ]
-            },
-            "properties": {
-                "title": "19. ANTIKMEILE Suarezstraße",
-                "location": "Suarezstraße, 14057",
-                "opening_hours": null,
-                "opening_hours_unclassified": "05.09.2020 12:00 - 20:00",
-                "details_url": "http://www.oldthing.de"
-            }
-        },
-        {
-            "type": "Feature",
-            "geometry": {
-                "type": "Point",
-                "coordinates": [
-                    13.39519,
-                    52.5203
-                ]
-            },
-            "properties": {
-                "title": "Antik- und Buchmarkt am Bode Museum",
-                "location": "Am Kupfergraben, 10117",
-                "opening_hours": "Sa,Su,PH 11:00-17:00",
+                "title": "Wochenmarkt Potsdam Bassinplatz",
+                "location": "Am Bassin 6, 14467",
+                "opening_hours": "Mo-Fr 07:00-16:00;Sa 07:00-13:00",
                 "opening_hours_unclassified": null
             }
         },
@@ -124,235 +39,14 @@
             "geometry": {
                 "type": "Point",
                 "coordinates": [
-                    13.29812,
-                    52.5161
+                    13.39153,
+                    52.50189
                 ]
             },
             "properties": {
-                "title": "Antik- und Kunstmarkt an der Villa Oppenheim",
-                "location": "Schloßstraße 55, 14059",
-                "opening_hours": null,
-                "opening_hours_unclassified": "19.09.2020 20.09.2020 11:00 - 18:00 10:00 - 18:00 11:00 - 18:00 10:00 - 18:00",
-                "details_url": "http://www.markt-rix.de"
-            }
-        },
-        {
-            "type": "Feature",
-            "geometry": {
-                "type": "Point",
-                "coordinates": [
-                    13.43401,
-                    52.51038
-                ]
-            },
-            "properties": {
-                "title": "Antikmarkt Ostbahnhof Pfingst-Spezial",
-                "location": "Koppenstraße 3, 10243",
-                "opening_hours": null,
-                "opening_hours_unclassified": "31.05./01.06.2020 09:00 - 17:00",
-                "details_url": "http://www.oldthing.de"
-            }
-        },
-        {
-            "type": "Feature",
-            "geometry": {
-                "type": "Point",
-                "coordinates": [
-                    13.43429,
-                    52.5115
-                ]
-            },
-            "properties": {
-                "title": "Antikmarkt am Berliner Ostbahnhof",
-                "location": "Erich-Steinfurth-Straße, 10243",
-                "opening_hours": null,
-                "opening_hours_unclassified": "So 09:00 - 16:00 (Winter) 09.00 - 17:00 (Sommer)",
-                "details_url": "http://www.oldthing.de"
-            }
-        },
-        {
-            "type": "Feature",
-            "geometry": {
-                "type": "Point",
-                "coordinates": [
-                    13.35989,
-                    52.54752
-                ]
-            },
-            "properties": {
-                "title": "Bauernmarkt Leopoldplatz",
-                "location": "Leopoldplatz, 13353",
-                "opening_hours": "Tu,Fr 10:00-17:00",
-                "opening_hours_unclassified": null,
-                "details_url": "http://www.bbm-maerkte.de"
-            }
-        },
-        {
-            "type": "Feature",
-            "geometry": {
-                "type": "Point",
-                "coordinates": [
-                    13.40799,
-                    52.51674
-                ]
-            },
-            "properties": {
-                "title": "Berlin-Brandenburger-Bauernmarkt -  Saisonmarkt auf dem Nikolaikirchplatz",
-                "location": "Nikolaikirchplatz, 10178",
-                "opening_hours": null,
-                "opening_hours_unclassified": "März - Oktober 10:00 - 17:00",
-                "details_url": "http://www.bbm-maerkte.de"
-            }
-        },
-        {
-            "type": "Feature",
-            "geometry": {
-                "type": "Point",
-                "coordinates": [
-                    13.09485,
-                    52.39426
-                ]
-            },
-            "properties": {
-                "title": "Floh- und Bauernmarkt in Potsdam",
-                "location": "Weberplatz, 14482",
-                "opening_hours": "Sa 07:00-13:00",
-                "opening_hours_unclassified": null,
-                "details_url": "http://www.koscholke.de"
-            }
-        },
-        {
-            "type": "Feature",
-            "geometry": {
-                "type": "Point",
-                "coordinates": [
-                    13.17722,
-                    52.54832
-                ]
-            },
-            "properties": {
-                "title": "Flohmarkt Falkenseer Chaussee, Siegener Straße",
-                "location": "Falkenseer Chaussee 239, 13583",
-                "opening_hours": "Su 08:00-16:00",
-                "opening_hours_unclassified": null,
-                "details_url": "http://www.troedelmarkt.berlin"
-            }
-        },
-        {
-            "type": "Feature",
-            "geometry": {
-                "type": "Point",
-                "coordinates": [
-                    13.37904,
-                    52.43085
-                ]
-            },
-            "properties": {
-                "title": "Flohmarkt Marienfelde, Hornbach-Parkplatz",
-                "location": "Großbeerenstr. 133, 12107",
-                "opening_hours": "Su 09:00-15:00",
-                "opening_hours_unclassified": null,
-                "details_url": "http://www.ayvaz.de"
-            }
-        },
-        {
-            "type": "Feature",
-            "geometry": {
-                "type": "Point",
-                "coordinates": [
-                    13.54541,
-                    52.39736
-                ]
-            },
-            "properties": {
-                "title": "Flohmarkt Schönefeld",
-                "location": "Grünbergallee 279, 12526",
-                "opening_hours": "Su 09:00-15:00",
-                "opening_hours_unclassified": null,
-                "details_url": "http://www.ayvaz.de"
-            }
-        },
-        {
-            "type": "Feature",
-            "geometry": {
-                "type": "Point",
-                "coordinates": [
-                    13.6266,
-                    52.45784
-                ]
-            },
-            "properties": {
-                "title": "Flohmarkt am S-Bhf. Friedrichshagen",
-                "location": "Schöneicher Str. 1, 12587",
-                "opening_hours": "Su 08:00-16:00",
-                "opening_hours_unclassified": null,
-                "details_url": "http://www.oldthing.de"
-            }
-        },
-        {
-            "type": "Feature",
-            "geometry": {
-                "type": "Point",
-                "coordinates": [
-                    13.4019,
-                    52.54192
-                ]
-            },
-            "properties": {
-                "title": "Flohmarkt im Mauerpark",
-                "location": "Bernauer Straße 63-64, 13355",
-                "opening_hours": "Su 10:00-18:00",
-                "opening_hours_unclassified": null,
-                "details_url": "http://www.flohmarktimmauerpark.de"
-            }
-        },
-        {
-            "type": "Feature",
-            "geometry": {
-                "type": "Point",
-                "coordinates": [
-                    12.86189,
-                    52.29768
-                ]
-            },
-            "properties": {
-                "title": "Großer Familien-Flohmarkt in Klaistow",
-                "location": "Glindower Str. 28, 14547",
-                "opening_hours": null,
-                "opening_hours_unclassified": "23.08., 08.11. 10:00 - 16:00",
-                "details_url": "http://www.spargelhof-klaistow.de"
-            }
-        },
-        {
-            "type": "Feature",
-            "geometry": {
-                "type": "Point",
-                "coordinates": [
-                    13.40073,
-                    52.53735
-                ]
-            },
-            "properties": {
-                "title": "Großer Trödelmarkt am Arkonaplatz",
-                "location": "Arkonaplatz, 10435",
-                "opening_hours": null,
-                "opening_hours_unclassified": "So 10:00 - 16:00 (Winter) 10:00 - 17:00 (Sommer)",
-                "details_url": "http://www.troedelmarkt-arkonaplatz.de"
-            }
-        },
-        {
-            "type": "Feature",
-            "geometry": {
-                "type": "Point",
-                "coordinates": [
-                    13.44196,
-                    52.51754
-                ]
-            },
-            "properties": {
-                "title": "KMA93?Karl-Marx-Allee vor Nr. 93",
-                "location": "Karl-Marx-Allee 93, 10243",
-                "opening_hours": "Tu,Th 10:00-16:00",
+                "title": "Wochenmarkt Friedrichstraße Erkner",
+                "location": "Friedrichstraße, 15537",
+                "opening_hours": "Th 09:00-14:00",
                 "opening_hours_unclassified": null
             }
         },
@@ -361,16 +55,15 @@
             "geometry": {
                 "type": "Point",
                 "coordinates": [
-                    13.23279,
-                    52.43756
+                    13.70327,
+                    52.48223
                 ]
             },
             "properties": {
-                "title": "KUNST trifft HANDWERK",
-                "location": "Mexikoplatz, 14163",
-                "opening_hours": null,
-                "opening_hours_unclassified": "20.09.2020 11:00 - 18:00",
-                "details_url": "http://www.kunsthand-berlin.de"
+                "title": "Wochenmarkt Dorfaue Schöneiche",
+                "location": "Dorfaue, 15566",
+                "opening_hours": "Th 09:00-14:00",
+                "opening_hours_unclassified": null
             }
         },
         {
@@ -378,16 +71,159 @@
             "geometry": {
                 "type": "Point",
                 "coordinates": [
-                    13.36855,
-                    52.51564
+                    13.30586,
+                    52.51732
                 ]
             },
             "properties": {
-                "title": "Kunst- und Trödelmarkt  Straße des 17. Juni",
-                "location": "Straße des 17. Juni, 10785",
-                "opening_hours": "Sa,Su 10:00-17:00",
-                "opening_hours_unclassified": null,
-                "details_url": "http://www.berliner-troedelmarkt.de"
+                "title": "Wochenmarkt Richard-Wagner-Platz",
+                "location": "Richard-Wagner-Platz, 10585",
+                "opening_hours": "Mo,Th 08:00-13:00",
+                "opening_hours_unclassified": null
+            }
+        },
+        {
+            "type": "Feature",
+            "geometry": {
+                "type": "Point",
+                "coordinates": [
+                    13.29097,
+                    52.51768
+                ]
+            },
+            "properties": {
+                "title": "Wochenmarkt Klausenerplatz",
+                "location": "Klausenerplatz, 14059",
+                "opening_hours": "Tu,Fr 08:00-13:00",
+                "opening_hours_unclassified": null
+            }
+        },
+        {
+            "type": "Feature",
+            "geometry": {
+                "type": "Point",
+                "coordinates": [
+                    13.25946,
+                    52.51111
+                ]
+            },
+            "properties": {
+                "title": "Wochenmarkt Preußenallee",
+                "location": "Preußenallee, 14052",
+                "opening_hours": "Tu,Fr 08:00-13:00",
+                "opening_hours_unclassified": null
+            }
+        },
+        {
+            "type": "Feature",
+            "geometry": {
+                "type": "Point",
+                "coordinates": [
+                    13.31036,
+                    52.50848
+                ]
+            },
+            "properties": {
+                "title": "Wochenmarkt Karl-August-Platz",
+                "location": "Karl-August-Platz, 10625",
+                "opening_hours": "We 08:00-13:00;Sa 08:00-14:00",
+                "opening_hours_unclassified": null
+            }
+        },
+        {
+            "type": "Feature",
+            "geometry": {
+                "type": "Point",
+                "coordinates": [
+                    13.30481,
+                    52.52533
+                ]
+            },
+            "properties": {
+                "title": "Wochenmarkt Mierendorffplatz",
+                "location": "Mierendorffplatz, 10589",
+                "opening_hours": "We,Sa 08:00-13:00",
+                "opening_hours_unclassified": null
+            }
+        },
+        {
+            "type": "Feature",
+            "geometry": {
+                "type": "Point",
+                "coordinates": [
+                    13.2938,
+                    52.48862
+                ]
+            },
+            "properties": {
+                "title": "Wochenmarkt Charlottenbrunner Straße",
+                "location": "Charlottenbrunner Straße, 14193",
+                "opening_hours": "Mo,Th 09:00-14:00",
+                "opening_hours_unclassified": null
+            }
+        },
+        {
+            "type": "Feature",
+            "geometry": {
+                "type": "Point",
+                "coordinates": [
+                    13.31246,
+                    52.47323
+                ]
+            },
+            "properties": {
+                "title": "Wochenmarkt Eberbacher Straße",
+                "location": "Eberbacher Straße, 14197",
+                "opening_hours": "Tu,Fr 08:00-13:00",
+                "opening_hours_unclassified": null
+            }
+        },
+        {
+            "type": "Feature",
+            "geometry": {
+                "type": "Point",
+                "coordinates": [
+                    13.29989,
+                    52.49695
+                ]
+            },
+            "properties": {
+                "title": "Wochenmarkt Nestorstraße",
+                "location": "Nestorstraße, 10709",
+                "opening_hours": "Tu,Fr 08:00-13:00",
+                "opening_hours_unclassified": null
+            }
+        },
+        {
+            "type": "Feature",
+            "geometry": {
+                "type": "Point",
+                "coordinates": [
+                    13.19463,
+                    52.43114
+                ]
+            },
+            "properties": {
+                "title": "Wochenmarkt Hohenzollernplatz",
+                "location": "Hohenzollernplatz, 14129",
+                "opening_hours": "We,Sa 08:00-13:00",
+                "opening_hours_unclassified": null
+            }
+        },
+        {
+            "type": "Feature",
+            "geometry": {
+                "type": "Point",
+                "coordinates": [
+                    13.32889,
+                    52.4779
+                ]
+            },
+            "properties": {
+                "title": "Wochenmarkt Bundesplatz",
+                "location": "Bundesplatz, 10715",
+                "opening_hours": "Mo,Th 08:00-13:00",
+                "opening_hours_unclassified": null
             }
         },
         {
@@ -400,11 +236,10 @@
                 ]
             },
             "properties": {
-                "title": "Kunst- und Trödelmarkt Fehrbelliner Platz",
+                "title": "Wochenmarkt Fehrbelliner Platz",
                 "location": "Fehrbelliner Platz, 10707",
-                "opening_hours": "Sa,Su 10:00-16:00",
-                "opening_hours_unclassified": null,
-                "details_url": "http://www.burdack-maerkte.de"
+                "opening_hours": "Mo,Tu,Th 11:00-16:00",
+                "opening_hours_unclassified": null
             }
         },
         {
@@ -412,16 +247,63 @@
             "geometry": {
                 "type": "Point",
                 "coordinates": [
-                    13.35138,
-                    52.49091
+                    13.29048,
+                    52.47695
                 ]
             },
             "properties": {
-                "title": "Kunst-Kreativ-Markt Kiezoase Schöneberg",
-                "location": "Karl-Schrader-Straße 7-8, 10781",
+                "title": "Wochenmarkt Kolberger Platz",
+                "location": "Kolberger Platz, 14199",
+                "opening_hours": "We,Sa 06:00-15:00",
+                "opening_hours_unclassified": null
+            }
+        },
+        {
+            "type": "Feature",
+            "geometry": {
+                "type": "Point",
+                "coordinates": [
+                    13.44196,
+                    52.51754
+                ]
+            },
+            "properties": {
+                "title": "KMA93 Karl-Marx-Allee vor Nr. 93",
+                "location": "Karl-Marx-Allee 93, 10243",
+                "opening_hours": "Tu,Th 10:00-16:00",
+                "opening_hours_unclassified": null
+            }
+        },
+        {
+            "type": "Feature",
+            "geometry": {
+                "type": "Point",
+                "coordinates": [
+                    13.45871,
+                    52.51119
+                ]
+            },
+            "properties": {
+                "title": "Wochenmarkt Boxhagener Platz",
+                "location": "Boxhagener Platz, 10245",
+                "opening_hours": "Sa 09:00-15:30",
+                "opening_hours_unclassified": null
+            }
+        },
+        {
+            "type": "Feature",
+            "geometry": {
+                "type": "Point",
+                "coordinates": [
+                    13.43387,
+                    52.50975
+                ]
+            },
+            "properties": {
+                "title": "Wochenmarkt Am Kaufhof Ostbahnhof (Erich-Steinfurth-Straße)",
+                "location": "Ostbahnhof, 10243",
                 "opening_hours": null,
-                "opening_hours_unclassified": "06.06.2020 14:00 - 18:00",
-                "details_url": "http://www.kiezoase.de"
+                "opening_hours_unclassified": "Mo - Sa (Sommer) 09:00 - 18:00"
             }
         },
         {
@@ -429,32 +311,16 @@
             "geometry": {
                 "type": "Point",
                 "coordinates": [
-                    13.39703,
-                    52.51772
+                    13.39078,
+                    52.48846
                 ]
             },
             "properties": {
-                "title": "Kunstmarkt am Zeughaus",
-                "location": "Unter den Linden 2, 10117",
-                "opening_hours": "Sa,Su,PH 11:00-17:00",
-                "opening_hours_unclassified": null
-            }
-        },
-        {
-            "type": "Feature",
-            "geometry": {
-                "type": "Point",
-                "coordinates": [
-                    13.32701,
-                    52.42806
-                ]
-            },
-            "properties": {
-                "title": "Landmarkt DIE DICKE LINDA",
-                "location": "Kranoldplatz, 12209",
-                "opening_hours": "Sa 10:00-16:00",
+                "title": "Ökomarkt - Chamissoplatz",
+                "location": "Chamissoplatz, 10965",
+                "opening_hours": "Sa 09:00-15:00",
                 "opening_hours_unclassified": null,
-                "details_url": "http://www.dicke-linda-markt.de"
+                "details_url": "http://www.oekomarkt-chamissoplatz.de"
             }
         },
         {
@@ -462,24 +328,8 @@
             "geometry": {
                 "type": "Point",
                 "coordinates": [
-                    13.21667,
-                    52.43872
-                ]
-            },
-            "properties": {
-                "title": "Markt Schlachtensee (Wochenmarkt)",
-                "location": "Matterhornstr. 52/54, 14129",
-                "opening_hours": "Tu,Fr 08:00-14:00",
-                "opening_hours_unclassified": null
-            }
-        },
-        {
-            "type": "Feature",
-            "geometry": {
-                "type": "Point",
-                "coordinates": [
-                    13.43172,
-                    52.50198
+                    13.43202,
+                    52.50199
                 ]
             },
             "properties": {
@@ -512,545 +362,6 @@
             "geometry": {
                 "type": "Point",
                 "coordinates": [
-                    13.43125,
-                    52.49248
-                ]
-            },
-            "properties": {
-                "title": "Neuköllner Stoff am Maybachufer",
-                "location": "Maybachufer 31, 12047",
-                "opening_hours": "Sa 11:00-17:00",
-                "opening_hours_unclassified": null,
-                "details_url": "http://www.mv-perske.de"
-            }
-        },
-        {
-            "type": "Feature",
-            "geometry": {
-                "type": "Point",
-                "coordinates": [
-                    13.44918,
-                    52.43757
-                ]
-            },
-            "properties": {
-                "title": "Neuköllner Wochenmärkte Britz-Süd",
-                "location": "Gutschmidtstraße, 12359",
-                "opening_hours": null,
-                "opening_hours_unclassified": "Mo, Do Sa 08:00 - 13:00 08:00 - 14:00",
-                "details_url": "http://www.diemarktplaner.de"
-            }
-        },
-        {
-            "type": "Feature",
-            "geometry": {
-                "type": "Point",
-                "coordinates": [
-                    13.42438,
-                    52.48727
-                ]
-            },
-            "properties": {
-                "title": "Neuköllner Wochenmärkte Hermannplatz",
-                "location": "Hermannplatz, 10967",
-                "opening_hours": "Mo-Fr 10:00-18:00",
-                "opening_hours_unclassified": null,
-                "details_url": "http://www.diemarktplaner.de"
-            }
-        },
-        {
-            "type": "Feature",
-            "geometry": {
-                "type": "Point",
-                "coordinates": [
-                    13.43125,
-                    52.49248
-                ]
-            },
-            "properties": {
-                "title": "Neuköllner Wochenmärkte Maybachufer",
-                "location": "Maybachufer 31, 12047",
-                "opening_hours": "Tu,Fr 11:00-18:30",
-                "opening_hours_unclassified": null,
-                "details_url": "http://www.diemarktplaner.de"
-            }
-        },
-        {
-            "type": "Feature",
-            "geometry": {
-                "type": "Point",
-                "coordinates": [
-                    13.4502,
-                    52.44593
-                ]
-            },
-            "properties": {
-                "title": "Neuköllner Wochenmärkte Parchimer Allee",
-                "location": "Fritz-Reuter-Allee 73, 12359",
-                "opening_hours": "Fr 10:00-18:00",
-                "opening_hours_unclassified": null,
-                "details_url": "http://www.diemarktplaner.de"
-            }
-        },
-        {
-            "type": "Feature",
-            "geometry": {
-                "type": "Point",
-                "coordinates": [
-                    13.44206,
-                    52.4737
-                ]
-            },
-            "properties": {
-                "title": "Neuköllner Wochenmärkte Rixdorf",
-                "location": "Karl-Marx-Platz, 12043",
-                "opening_hours": "We 11:00-18:00;Sa 08:00-15:00",
-                "opening_hours_unclassified": null,
-                "details_url": "http://www.diemarktplaner.de"
-            }
-        },
-        {
-            "type": "Feature",
-            "geometry": {
-                "type": "Point",
-                "coordinates": [
-                    13.4927,
-                    52.42258
-                ]
-            },
-            "properties": {
-                "title": "Neuköllner Wochenmärkte Rudow",
-                "location": "Prierosser Straße, 12357",
-                "opening_hours": "We,Sa 08:00-13:00",
-                "opening_hours_unclassified": null,
-                "details_url": "http://www.diemarktplaner.de"
-            }
-        },
-        {
-            "type": "Feature",
-            "geometry": {
-                "type": "Point",
-                "coordinates": [
-                    13.47461,
-                    52.4233
-                ]
-            },
-            "properties": {
-                "title": "Neuköllner Wochenmärkte Wutzkyallee",
-                "location": "Rotraut-Richter-Platz, 12353",
-                "opening_hours": "We 08:00-14:00;Sa 08:00-13:00",
-                "opening_hours_unclassified": null,
-                "details_url": "http://www.diemarktplaner.de"
-            }
-        },
-        {
-            "type": "Feature",
-            "geometry": {
-                "type": "Point",
-                "coordinates": [
-                    13.43125,
-                    52.49248
-                ]
-            },
-            "properties": {
-                "title": "Nowkoelln Flowmarkt",
-                "location": "Maybachufer 31, 12047",
-                "opening_hours": null,
-                "opening_hours_unclassified": "24.05., 07.06., 21.06., 05.07.,  19.07., 02.08., 16.08., 30.08., 13.09.,  27.09., 11.10., 25.10., 08.11., 29.11.2020 10:00 - 17:00",
-                "details_url": "http://www.flowmarkt.de/nowkoelln.de"
-            }
-        },
-        {
-            "type": "Feature",
-            "geometry": {
-                "type": "Point",
-                "coordinates": [
-                    13.52483,
-                    52.47843
-                ]
-            },
-            "properties": {
-                "title": "Riesenflohmarkt Trabrennbahn Karlshorst",
-                "location": "Treskowallee 129, 10318",
-                "opening_hours": null,
-                "opening_hours_unclassified": "03. - 04.10.2020 09:00 - 17:00",
-                "details_url": "http://www.oldthing.de"
-            }
-        },
-        {
-            "type": "Feature",
-            "geometry": {
-                "type": "Point",
-                "coordinates": [
-                    13.52483,
-                    52.47843
-                ]
-            },
-            "properties": {
-                "title": "Sammlerbörse Trabrennbahn Karlshorst, Tribünenhalle",
-                "location": "Treskowallee 129, 10318",
-                "opening_hours": null,
-                "opening_hours_unclassified": "03.10.2020 09:00 - 17:00",
-                "details_url": "http://www.oldthing.de"
-            }
-        },
-        {
-            "type": "Feature",
-            "geometry": {
-                "type": "Point",
-                "coordinates": [
-                    13.39514,
-                    52.48959
-                ]
-            },
-            "properties": {
-                "title": "Trödelmarkt Bergmannstraße",
-                "location": "Marheinekeplatz, 10961",
-                "opening_hours": "Sa 10:00-16:00;Su 11:00-17:00",
-                "opening_hours_unclassified": null
-            }
-        },
-        {
-            "type": "Feature",
-            "geometry": {
-                "type": "Point",
-                "coordinates": [
-                    13.45999,
-                    52.51172
-                ]
-            },
-            "properties": {
-                "title": "Trödelmarkt Boxhagener Platz",
-                "location": "Grünberger Straße 75, 10245",
-                "opening_hours": "Su 10:00-18:00",
-                "opening_hours_unclassified": null
-            }
-        },
-        {
-            "type": "Feature",
-            "geometry": {
-                "type": "Point",
-                "coordinates": [
-                    13.42199,
-                    52.45337
-                ]
-            },
-            "properties": {
-                "title": "Trödelmarkt Hornbach Neukölln",
-                "location": "Gradestraße 100, 12347",
-                "opening_hours": "Su 07:00-14:00",
-                "opening_hours_unclassified": null,
-                "details_url": "http://www.hoefges.de"
-            }
-        },
-        {
-            "type": "Feature",
-            "geometry": {
-                "type": "Point",
-                "coordinates": [
-                    13.51498,
-                    52.53494
-                ]
-            },
-            "properties": {
-                "title": "Trödelmarkt Landsberger Allee auf dem IKEA Parkplatz",
-                "location": "Landsberger Allee 364, 10365",
-                "opening_hours": "Su 09:00-15:00",
-                "opening_hours_unclassified": null,
-                "details_url": "http://www.bbm-maerkte.de"
-            }
-        },
-        {
-            "type": "Feature",
-            "geometry": {
-                "type": "Point",
-                "coordinates": [
-                    13.39007,
-                    52.41248
-                ]
-            },
-            "properties": {
-                "title": "Trödelmarkt METRO Marienfelde",
-                "location": "Buckower Chaussee 25-35, 12277",
-                "opening_hours": "Su 07:00-14:00",
-                "opening_hours_unclassified": null,
-                "details_url": "http://www.hoefges.de"
-            }
-        },
-        {
-            "type": "Feature",
-            "geometry": {
-                "type": "Point",
-                "coordinates": [
-                    13.2453,
-                    52.53982
-                ]
-            },
-            "properties": {
-                "title": "Trödelmarkt METRO Spandau",
-                "location": "Nonnendammallee 135, 13599",
-                "opening_hours": "Su 07:00-14:00",
-                "opening_hours_unclassified": null,
-                "details_url": "http://www.hoefges.de"
-            }
-        },
-        {
-            "type": "Feature",
-            "geometry": {
-                "type": "Point",
-                "coordinates": [
-                    13.36583,
-                    52.56079
-                ]
-            },
-            "properties": {
-                "title": "Trödelmarkt Markstraße",
-                "location": "Markstraße 32-34, 13409",
-                "opening_hours": "Su 07:00-15:30",
-                "opening_hours_unclassified": null,
-                "details_url": "http://www.troedelmarkt.berlin"
-            }
-        },
-        {
-            "type": "Feature",
-            "geometry": {
-                "type": "Point",
-                "coordinates": [
-                    13.32806,
-                    52.57014
-                ]
-            },
-            "properties": {
-                "title": "Trödelmarkt Ollenhauerstraße",
-                "location": "Ollenhauerstraße 107, 13403",
-                "opening_hours": "Su 08:00-16:00",
-                "opening_hours_unclassified": null,
-                "details_url": "http://www.troedelmarkt.berlin"
-            }
-        },
-        {
-            "type": "Feature",
-            "geometry": {
-                "type": "Point",
-                "coordinates": [
-                    13.36355,
-                    52.56023
-                ]
-            },
-            "properties": {
-                "title": "Trödelmarkt Schuhcenter Siemes Wedding, Parkplatz",
-                "location": "Markstr. 17 - 18, 13409",
-                "opening_hours": "Su 07:00-14:00",
-                "opening_hours_unclassified": null,
-                "details_url": "http://www.hoefges.de"
-            }
-        },
-        {
-            "type": "Feature",
-            "geometry": {
-                "type": "Point",
-                "coordinates": [
-                    13.31586,
-                    52.48215
-                ]
-            },
-            "properties": {
-                "title": "Trödelmarkt an der Mecklenburgischen Straße",
-                "location": "Mecklenburgische Straße, 14197",
-                "opening_hours": "Su 08:00-16:00",
-                "opening_hours_unclassified": null,
-                "details_url": "http://www.der-mecklenburger-troedelmarkt.de"
-            }
-        },
-        {
-            "type": "Feature",
-            "geometry": {
-                "type": "Point",
-                "coordinates": [
-                    13.32166,
-                    52.45685
-                ]
-            },
-            "properties": {
-                "title": "Trödelmarkt auf dem Hermann-Ehlers-Platz",
-                "location": "Hermann-Ehlers-Platz, 12165",
-                "opening_hours": "Su 07:00-16:00",
-                "opening_hours_unclassified": null
-            }
-        },
-        {
-            "type": "Feature",
-            "geometry": {
-                "type": "Point",
-                "coordinates": [
-                    13.34306,
-                    52.48535
-                ]
-            },
-            "properties": {
-                "title": "Trödelmarkt auf dem John-F.-Kennedy-Platz",
-                "location": "John-F.-Kennedy-Platz 1, 10825",
-                "opening_hours": "Sa,Su 08:00-16:00",
-                "opening_hours_unclassified": null,
-                "details_url": "http://www.berlin-flohmaerkte.de"
-            }
-        },
-        {
-            "type": "Feature",
-            "geometry": {
-                "type": "Point",
-                "coordinates": [
-                    13.35989,
-                    52.54752
-                ]
-            },
-            "properties": {
-                "title": "Trödelmarkt auf dem Leopoldplatz",
-                "location": "Leopoldplatz, 13353",
-                "opening_hours": null,
-                "opening_hours_unclassified": "Sa 10:00 - 16:00 (Sommer) 10:00 - 15:00 (Winter)",
-                "details_url": "http://www.bbm-maerkte.de"
-            }
-        },
-        {
-            "type": "Feature",
-            "geometry": {
-                "type": "Point",
-                "coordinates": [
-                    13.20388,
-                    52.53726
-                ]
-            },
-            "properties": {
-                "title": "WeinSommer in Verbindung mit dem Spandauer Altstadtfest",
-                "location": "Markt 1, 13597",
-                "opening_hours": null,
-                "opening_hours_unclassified": "27.08.2020 28.08.2020 29.08.2020 30.09.2020 15:00-23:00 11:00-24:00 11:00-24:00 11:00-20:00",
-                "details_url": "http://www.partner-fuer-spandau.de"
-            }
-        },
-        {
-            "type": "Feature",
-            "geometry": {
-                "type": "Point",
-                "coordinates": [
-                    13.34328,
-                    52.50267
-                ]
-            },
-            "properties": {
-                "title": "Wittenbergplatz (Nordseite) Brandenburger Bauernmarkt",
-                "location": "Wittenbergplatz 5, 10789",
-                "opening_hours": "Th 09:00-17:00",
-                "opening_hours_unclassified": null,
-                "details_url": "http://www.bbm-maerkte.de"
-            }
-        },
-        {
-            "type": "Feature",
-            "geometry": {
-                "type": "Point",
-                "coordinates": [
-                    13.54325,
-                    52.43632
-                ]
-            },
-            "properties": {
-                "title": "Wochenmarkt Adlershof",
-                "location": "Dörpfeldstraße, 12489",
-                "opening_hours": "We,Th 08:00-16:00",
-                "opening_hours_unclassified": null,
-                "details_url": "http://www.gakenholz-gellesch.de"
-            }
-        },
-        {
-            "type": "Feature",
-            "geometry": {
-                "type": "Point",
-                "coordinates": [
-                    13.20435,
-                    52.53702
-                ]
-            },
-            "properties": {
-                "title": "Wochenmarkt Altstadt Spandau - Markt Havelländischer Land- und Bauernmarkt",
-                "location": "Markt 3, 13597",
-                "opening_hours": "Mo,Tu,Th,Fr 09:00+",
-                "opening_hours_unclassified": null,
-                "details_url": "http://www.wirtschaftshof-spandau.de"
-            }
-        },
-        {
-            "type": "Feature",
-            "geometry": {
-                "type": "Point",
-                "coordinates": [
-                    13.43387,
-                    52.50975
-                ]
-            },
-            "properties": {
-                "title": "Wochenmarkt Am Kaufhof Ostbahnhof (Erich-Steinfurth-Straße)",
-                "location": "Ostbahnhof, 10243",
-                "opening_hours": null,
-                "opening_hours_unclassified": "Mo - Sa (Sommer) 09:00 - 18:00"
-            }
-        },
-        {
-            "type": "Feature",
-            "geometry": {
-                "type": "Point",
-                "coordinates": [
-                    13.05696,
-                    52.40311
-                ]
-            },
-            "properties": {
-                "title": "Wochenmarkt Am Nauener Tor 14467 Potsdam",
-                "location": "Hegelallee 55, 14467",
-                "opening_hours": "We,Sa 09:00-16:00",
-                "opening_hours_unclassified": null,
-                "details_url": "http://www.markt-am-nauener-tor.de"
-            }
-        },
-        {
-            "type": "Feature",
-            "geometry": {
-                "type": "Point",
-                "coordinates": [
-                    13.5801,
-                    52.45824
-                ]
-            },
-            "properties": {
-                "title": "Wochenmarkt Am S-Bhf. Köpenick",
-                "location": "Elcknerplatz, 12555",
-                "opening_hours": "Mo-Fr 09:00-18:00;Sa 09:00-16:00",
-                "opening_hours_unclassified": null,
-                "details_url": "http://www.mv-perske.de"
-            }
-        },
-        {
-            "type": "Feature",
-            "geometry": {
-                "type": "Point",
-                "coordinates": [
-                    13.26197,
-                    52.41225
-                ]
-            },
-            "properties": {
-                "title": "Wochenmarkt Andrézeile (Ladiusmarkt)",
-                "location": "Andrézeile, 14165",
-                "opening_hours": "Sa 08:00-13:00",
-                "opening_hours_unclassified": null
-            }
-        },
-        {
-            "type": "Feature",
-            "geometry": {
-                "type": "Point",
-                "coordinates": [
                     13.47016,
                     52.52859
                 ]
@@ -1067,156 +378,8 @@
             "geometry": {
                 "type": "Point",
                 "coordinates": [
-                    13.45159,
-                    52.54848
-                ]
-            },
-            "properties": {
-                "title": "Wochenmarkt Antonplatz",
-                "location": "Antonplatz, 13086",
-                "opening_hours": null,
-                "opening_hours_unclassified": "Di, Fr Do* 09:00 - 18:00 11:00 - 16:00",
-                "details_url": "http://www.mv-perske.de"
-            }
-        },
-        {
-            "type": "Feature",
-            "geometry": {
-                "type": "Point",
-                "coordinates": [
-                    13.52801,
-                    52.46095
-                ]
-            },
-            "properties": {
-                "title": "Wochenmarkt Berlin-Oberschöneweide",
-                "location": "Rathenauplatz, 12459",
-                "opening_hours": "We 09:00-16:00",
-                "opening_hours_unclassified": null,
-                "details_url": "http://www.brandenburger-wochenmaerkte.de"
-            }
-        },
-        {
-            "type": "Feature",
-            "geometry": {
-                "type": "Point",
-                "coordinates": [
-                    13.45871,
-                    52.51119
-                ]
-            },
-            "properties": {
-                "title": "Wochenmarkt Boxhagener Platz",
-                "location": "Boxhagener Platz, 10245",
-                "opening_hours": "Sa 09:00-15:30",
-                "opening_hours_unclassified": null
-            }
-        },
-        {
-            "type": "Feature",
-            "geometry": {
-                "type": "Point",
-                "coordinates": [
-                    13.40528,
-                    52.57019
-                ]
-            },
-            "properties": {
-                "title": "Wochenmarkt Breite Straße",
-                "location": "Breite Str. 17, 13187",
-                "opening_hours": "Tu 08:00-14:00;We 09:00-17:00;Fr 08:00-16:00;Sa 08:00-15:00",
-                "opening_hours_unclassified": null
-            }
-        },
-        {
-            "type": "Feature",
-            "geometry": {
-                "type": "Point",
-                "coordinates": [
-                    13.33542,
-                    52.47185
-                ]
-            },
-            "properties": {
-                "title": "Wochenmarkt Breslauer Platz",
-                "location": "Breslauer Platz, 12159",
-                "opening_hours": "We 08:00-13:00;Th 12:00-18:00;Sa 08:00-14:00",
-                "opening_hours_unclassified": null,
-                "details_url": "http://www.berlin.de/ba-tempelhof-schoeneberg/politik-und-verwaltung/aemter/ordnungsamt/maerkte"
-            }
-        },
-        {
-            "type": "Feature",
-            "geometry": {
-                "type": "Point",
-                "coordinates": [
-                    13.15637,
-                    52.53258
-                ]
-            },
-            "properties": {
-                "title": "Wochenmarkt Brunsbütteler Damm 265",
-                "location": "Brunsbütteler Damm 265, 13591",
-                "opening_hours": "Fr 08:00-15:00",
-                "opening_hours_unclassified": null,
-                "details_url": "http://www.brandenburger-wochenmaerkte.de"
-            }
-        },
-        {
-            "type": "Feature",
-            "geometry": {
-                "type": "Point",
-                "coordinates": [
-                    13.48707,
-                    52.61747
-                ]
-            },
-            "properties": {
-                "title": "Wochenmarkt Bucher Chaussee / Achillesstraße",
-                "location": "Bucher Chaussee, 13125",
-                "opening_hours": "Th 08:00-16:30;Sa 08:00-14:30",
-                "opening_hours_unclassified": null
-            }
-        },
-        {
-            "type": "Feature",
-            "geometry": {
-                "type": "Point",
-                "coordinates": [
-                    13.32889,
-                    52.4779
-                ]
-            },
-            "properties": {
-                "title": "Wochenmarkt Bundesplatz",
-                "location": "Bundesplatz, 10715",
-                "opening_hours": "Mo,Th 08:00-13:00",
-                "opening_hours_unclassified": null
-            }
-        },
-        {
-            "type": "Feature",
-            "geometry": {
-                "type": "Point",
-                "coordinates": [
-                    13.29291,
-                    52.63119
-                ]
-            },
-            "properties": {
-                "title": "Wochenmarkt Burgfrauenstraße",
-                "location": "Burgfrauenstraße, 13465",
-                "opening_hours": "Th-Sa 08:00-13:00",
-                "opening_hours_unclassified": null
-            }
-        },
-        {
-            "type": "Feature",
-            "geometry": {
-                "type": "Point",
-                "coordinates": [
-                    13.51854,
-                    52.508
+                    13.526,
+                    52.49554
                 ]
             },
             "properties": {
@@ -1232,143 +395,14 @@
             "geometry": {
                 "type": "Point",
                 "coordinates": [
-                    13.62469,
-                    52.44836
+                    13.48408,
+                    52.52633
                 ]
             },
             "properties": {
-                "title": "Wochenmarkt Bölschestraße",
-                "location": "Bölschestraße, 12587",
-                "opening_hours": null,
-                "opening_hours_unclassified": "Mo, Mi, Fr Sa 10:00 - 16:00 09:00 - 13:00"
-            }
-        },
-        {
-            "type": "Feature",
-            "geometry": {
-                "type": "Point",
-                "coordinates": [
-                    13.4305,
-                    52.55254
-                ]
-            },
-            "properties": {
-                "title": "Wochenmarkt Caligariplatz",
-                "location": "Caligariplatz, 10119",
-                "opening_hours": "We,Fr 08:00-18:00",
-                "opening_hours_unclassified": null
-            }
-        },
-        {
-            "type": "Feature",
-            "geometry": {
-                "type": "Point",
-                "coordinates": [
-                    13.58978,
-                    52.51901
-                ]
-            },
-            "properties": {
-                "title": "Wochenmarkt Cecilienplatz",
-                "location": "Ernst-Bloch-Straße, 12619",
-                "opening_hours": "Mo,We,Fr 09:00-18:00",
-                "opening_hours_unclassified": null
-            }
-        },
-        {
-            "type": "Feature",
-            "geometry": {
-                "type": "Point",
-                "coordinates": [
-                    13.29292,
-                    52.48874
-                ]
-            },
-            "properties": {
-                "title": "Wochenmarkt Charlottenbrunner Straße",
-                "location": "Charlottenbrunner Straße, 14193",
-                "opening_hours": "Mo,Th 09:00-14:00",
-                "opening_hours_unclassified": null
-            }
-        },
-        {
-            "type": "Feature",
-            "geometry": {
-                "type": "Point",
-                "coordinates": [
-                    13.36544,
-                    52.49104
-                ]
-            },
-            "properties": {
-                "title": "Wochenmarkt Crellestraße",
-                "location": "Crellestraße 24, 10827",
-                "opening_hours": "We,Sa 10:00-15:00",
-                "opening_hours_unclassified": null,
-                "details_url": "http://www.berlin.de/ba-tempelhof-schoeneberg/politik-und-verwaltung/aemter/ordnungsamt/maerkte"
-            }
-        },
-        {
-            "type": "Feature",
-            "geometry": {
-                "type": "Point",
-                "coordinates": [
-                    13.70327,
-                    52.48223
-                ]
-            },
-            "properties": {
-                "title": "Wochenmarkt Dorfaue Schöneiche",
-                "location": "Dorfaue, 15566",
-                "opening_hours": "Th 09:00-14:00",
-                "opening_hours_unclassified": null
-            }
-        },
-        {
-            "type": "Feature",
-            "geometry": {
-                "type": "Point",
-                "coordinates": [
-                    13.31246,
-                    52.47323
-                ]
-            },
-            "properties": {
-                "title": "Wochenmarkt Eberbacher Straße",
-                "location": "Eberbacher Straße, 14197",
-                "opening_hours": "Tu,Fr 08:00-13:00",
-                "opening_hours_unclassified": null
-            }
-        },
-        {
-            "type": "Feature",
-            "geometry": {
-                "type": "Point",
-                "coordinates": [
-                    13.16508,
-                    52.52162
-                ]
-            },
-            "properties": {
-                "title": "Wochenmarkt Einkaufscenter Staaken",
-                "location": "Obstallee 28, 13593",
-                "opening_hours": "Tu,Fr 09:00-15:00",
-                "opening_hours_unclassified": null
-            }
-        },
-        {
-            "type": "Feature",
-            "geometry": {
-                "type": "Point",
-                "coordinates": [
-                    13.31343,
-                    52.49083
-                ]
-            },
-            "properties": {
-                "title": "Wochenmarkt Fehrbelliner Platz",
-                "location": "Fehrbelliner Platz, 10707",
-                "opening_hours": "Tu,Th 11:00-16:00",
+                "title": "Wochenmarkt Herzbergstraße / Weißenseer Weg (Roedernplatz)",
+                "location": "Herzbergstraße, 10367",
+                "opening_hours": "Tu,Fr 08:00-17:00",
                 "opening_hours_unclassified": null
             }
         },
@@ -1394,216 +428,6 @@
             "geometry": {
                 "type": "Point",
                 "coordinates": [
-                    13.52228,
-                    52.51325
-                ]
-            },
-            "properties": {
-                "title": "Wochenmarkt Friedrichsfelde Ost",
-                "location": "Seddiner Straße, 10315",
-                "opening_hours": "Mo-Fr 08:00-18:00",
-                "opening_hours_unclassified": null
-            }
-        },
-        {
-            "type": "Feature",
-            "geometry": {
-                "type": "Point",
-                "coordinates": [
-                    13.39153,
-                    52.50189
-                ]
-            },
-            "properties": {
-                "title": "Wochenmarkt Friedrichstraße Erkner",
-                "location": "Friedrichstraße, 15537",
-                "opening_hours": "Th 09:00-14:00",
-                "opening_hours_unclassified": null
-            }
-        },
-        {
-            "type": "Feature",
-            "geometry": {
-                "type": "Point",
-                "coordinates": [
-                    13.44073,
-                    52.54321
-                ]
-            },
-            "properties": {
-                "title": "Wochenmarkt Greifswalder Straße / Thomas-Mann-Straße",
-                "location": "Greifswalder Straße 157, 10409",
-                "opening_hours": null,
-                "opening_hours_unclassified": "Di, Do Sa 08:00 - 18:00 08:00 - 14:00"
-            }
-        },
-        {
-            "type": "Feature",
-            "geometry": {
-                "type": "Point",
-                "coordinates": [
-                    13.2061,
-                    52.55916
-                ]
-            },
-            "properties": {
-                "title": "Wochenmarkt Hakenfelde",
-                "location": "Michelstadter Weg, 13587",
-                "opening_hours": "Th 08:00-13:00",
-                "opening_hours_unclassified": null
-            }
-        },
-        {
-            "type": "Feature",
-            "geometry": {
-                "type": "Point",
-                "coordinates": [
-                    13.36725,
-                    52.58554
-                ]
-            },
-            "properties": {
-                "title": "Wochenmarkt Hauptstraße / Goethestraße Wilhelmsruh",
-                "location": "Hauptstraße, 13158",
-                "opening_hours": "We,Fr 08:00-14:00",
-                "opening_hours_unclassified": null
-            }
-        },
-        {
-            "type": "Feature",
-            "geometry": {
-                "type": "Point",
-                "coordinates": [
-                    13.54258,
-                    52.52643
-                ]
-            },
-            "properties": {
-                "title": "Wochenmarkt Helene-Weigel-Platz",
-                "location": "Helene-Weigel-Platz, 12681",
-                "opening_hours": "Mo-Sa 09:00-17:00",
-                "opening_hours_unclassified": null,
-                "details_url": "http://www.markt-veranstaltungen.de"
-            }
-        },
-        {
-            "type": "Feature",
-            "geometry": {
-                "type": "Point",
-                "coordinates": [
-                    13.60735,
-                    52.53841
-                ]
-            },
-            "properties": {
-                "title": "Wochenmarkt Helle Mitte",
-                "location": "Peter-Weiss-Gasse, 12627",
-                "opening_hours": "We,Fr 08:00-17:00",
-                "opening_hours_unclassified": null
-            }
-        },
-        {
-            "type": "Feature",
-            "geometry": {
-                "type": "Point",
-                "coordinates": [
-                    13.32166,
-                    52.45685
-                ]
-            },
-            "properties": {
-                "title": "Wochenmarkt Hermann-Ehlers-Platz",
-                "location": "Hermann-Ehlers-Platz, 12165",
-                "opening_hours": null,
-                "opening_hours_unclassified": "Di, Sa Do 08:00 - 14:00 08:00 - 18:00"
-            }
-        },
-        {
-            "type": "Feature",
-            "geometry": {
-                "type": "Point",
-                "coordinates": [
-                    13.48408,
-                    52.52635
-                ]
-            },
-            "properties": {
-                "title": "Wochenmarkt Herzbergstraße / Weißenseer Weg (Roedernplatz)",
-                "location": "Herzbergstraße, 10367",
-                "opening_hours": "Tu,Fr 08:00-17:00",
-                "opening_hours_unclassified": null
-            }
-        },
-        {
-            "type": "Feature",
-            "geometry": {
-                "type": "Point",
-                "coordinates": [
-                    13.19463,
-                    52.43114
-                ]
-            },
-            "properties": {
-                "title": "Wochenmarkt Hohenzollernplatz",
-                "location": "Hohenzollernplatz, 14129",
-                "opening_hours": "We,Sa 08:00-13:00",
-                "opening_hours_unclassified": null
-            }
-        },
-        {
-            "type": "Feature",
-            "geometry": {
-                "type": "Point",
-                "coordinates": [
-                    13.33415,
-                    52.5219
-                ]
-            },
-            "properties": {
-                "title": "Wochenmarkt Jagowstraße",
-                "location": "Jagowstraße, 10555",
-                "opening_hours": "We,Sa 08:00-13:00",
-                "opening_hours_unclassified": null
-            }
-        },
-        {
-            "type": "Feature",
-            "geometry": {
-                "type": "Point",
-                "coordinates": [
-                    13.34306,
-                    52.48535
-                ]
-            },
-            "properties": {
-                "title": "Wochenmarkt John-F.-Kennedy-Platz",
-                "location": "John-F.-Kennedy-Platz 1, 10825",
-                "opening_hours": "Tu,Fr 08:00-13:00",
-                "opening_hours_unclassified": null,
-                "details_url": "http://www.berlin.de/ba-tempelhof-schoeneberg/politik-und-verwaltung/aemter/ordnungsamt/maerkte"
-            }
-        },
-        {
-            "type": "Feature",
-            "geometry": {
-                "type": "Point",
-                "coordinates": [
-                    13.31036,
-                    52.50848
-                ]
-            },
-            "properties": {
-                "title": "Wochenmarkt Karl-August-Platz",
-                "location": "Karl-August-Platz, 10625",
-                "opening_hours": "We 08:00-13:00;Sa 08:00-14:00",
-                "opening_hours_unclassified": null
-            }
-        },
-        {
-            "type": "Feature",
-            "geometry": {
-                "type": "Point",
-                "coordinates": [
                     13.52866,
                     52.48119
                 ]
@@ -1621,14 +445,14 @@
             "geometry": {
                 "type": "Point",
                 "coordinates": [
-                    13.29097,
-                    52.51768
+                    13.52228,
+                    52.51325
                 ]
             },
             "properties": {
-                "title": "Wochenmarkt Klausenerplatz",
-                "location": "Klausenerplatz, 14059",
-                "opening_hours": "Tu,Fr 08:00-13:00",
+                "title": "Wochenmarkt Friedrichsfelde Ost",
+                "location": "Seddiner Straße, 10315",
+                "opening_hours": "Mo-Fr 08:00-18:00",
                 "opening_hours_unclassified": null
             }
         },
@@ -1637,275 +461,14 @@
             "geometry": {
                 "type": "Point",
                 "coordinates": [
-                    13.29058,
-                    52.47681
+                    13.50242,
+                    52.5649
                 ]
             },
             "properties": {
-                "title": "Wochenmarkt Kolberger Platz",
-                "location": "Kolberger Platz, 14199",
-                "opening_hours": "We,Sa 06:00-15:00",
-                "opening_hours_unclassified": null
-            }
-        },
-        {
-            "type": "Feature",
-            "geometry": {
-                "type": "Point",
-                "coordinates": [
-                    13.35989,
-                    52.54752
-                ]
-            },
-            "properties": {
-                "title": "Wochenmarkt Leopoldplatz",
-                "location": "Leopoldplatz, 13353",
-                "opening_hours": "Th 11:00-17:00",
-                "opening_hours_unclassified": null,
-                "details_url": "http://www.bbm-maerkte.de"
-            }
-        },
-        {
-            "type": "Feature",
-            "geometry": {
-                "type": "Point",
-                "coordinates": [
-                    13.32701,
-                    52.42806
-                ]
-            },
-            "properties": {
-                "title": "Wochenmarkt Lichterfelde, Kranoldplatz",
-                "location": "Kranoldplatz, 12209",
-                "opening_hours": "We,Sa 08:00-14:00",
-                "opening_hours_unclassified": null
-            }
-        },
-        {
-            "type": "Feature",
-            "geometry": {
-                "type": "Point",
-                "coordinates": [
-                    13.31202,
-                    52.44286
-                ]
-            },
-            "properties": {
-                "title": "Wochenmarkt Ludwig-Beck-Platz",
-                "location": "Ludwig-Beck-Platz, 12203",
-                "opening_hours": "Fr,Sa 08:00-13:00",
-                "opening_hours_unclassified": null
-            }
-        },
-        {
-            "type": "Feature",
-            "geometry": {
-                "type": "Point",
-                "coordinates": [
-                    13.59146,
-                    52.48463
-                ]
-            },
-            "properties": {
-                "title": "Wochenmarkt Mahlsdorf Roedernstraße / Hultschiner Damm",
-                "location": "Roedernstraße, 12623",
-                "opening_hours": "Th 07:00-15:00",
-                "opening_hours_unclassified": null
-            }
-        },
-        {
-            "type": "Feature",
-            "geometry": {
-                "type": "Point",
-                "coordinates": [
-                    13.38109,
-                    52.4436
-                ]
-            },
-            "properties": {
-                "title": "Wochenmarkt Mariendorfer Damm / Prinzenstraße",
-                "location": "Prinzenstraße, 12109",
-                "opening_hours": "We,Sa 08:00-13:00",
-                "opening_hours_unclassified": null,
-                "details_url": "http://www.berlin.de/ba-tempelhof-schoeneberg/politik-und-verwaltung/aemter/ordnungsamt/maerkte"
-            }
-        },
-        {
-            "type": "Feature",
-            "geometry": {
-                "type": "Point",
-                "coordinates": [
-                    13.41965,
-                    52.54313
-                ]
-            },
-            "properties": {
-                "title": "Wochenmarkt Markt am Helmholtzplatz",
-                "location": "Helmholtzplatz, 10437",
-                "opening_hours": "Sa 09:00-16:00",
-                "opening_hours_unclassified": null
-            }
-        },
-        {
-            "type": "Feature",
-            "geometry": {
-                "type": "Point",
-                "coordinates": [
-                    13.42012,
-                    52.60728
-                ]
-            },
-            "properties": {
-                "title": "Wochenmarkt Markt am Hugenottenplatz",
-                "location": "Hugenottenplatz, 13127",
-                "opening_hours": "Sa 09:00-13:00",
-                "opening_hours_unclassified": null
-            }
-        },
-        {
-            "type": "Feature",
-            "geometry": {
-                "type": "Point",
-                "coordinates": [
-                    13.40218,
-                    52.51233
-                ]
-            },
-            "properties": {
-                "title": "Wochenmarkt Markt am Spittelmarkt",
-                "location": "Spittelmarkt, 10179",
-                "opening_hours": "We,Fr 10:00-15:00",
-                "opening_hours_unclassified": null,
-                "details_url": "http://www.bbm-maerkte.de"
-            }
-        },
-        {
-            "type": "Feature",
-            "geometry": {
-                "type": "Point",
-                "coordinates": [
-                    13.43583,
-                    52.5323
-                ]
-            },
-            "properties": {
-                "title": "Wochenmarkt Markt am Stierbrunnen",
-                "location": "Pasteurstraße 32, 10407",
-                "opening_hours": "Sa 09:00-15:00",
-                "opening_hours_unclassified": null
-            }
-        },
-        {
-            "type": "Feature",
-            "geometry": {
-                "type": "Point",
-                "coordinates": [
-                    13.54895,
-                    52.54366
-                ]
-            },
-            "properties": {
-                "title": "Wochenmarkt Marzahner Promenade",
-                "location": "Marzahner Promenade 30-33, 12679",
-                "opening_hours": "Mo,We,Fr 08:30-17:00",
-                "opening_hours_unclassified": null,
-                "details_url": "http://www.markt-veranstaltungen.de"
-            }
-        },
-        {
-            "type": "Feature",
-            "geometry": {
-                "type": "Point",
-                "coordinates": [
-                    13.23279,
-                    52.43756
-                ]
-            },
-            "properties": {
-                "title": "Wochenmarkt Mexikoplatz",
-                "location": "Mexikoplatz, 14163",
-                "opening_hours": "Sa 09:00-15:00",
-                "opening_hours_unclassified": null
-            }
-        },
-        {
-            "type": "Feature",
-            "geometry": {
-                "type": "Point",
-                "coordinates": [
-                    13.30481,
-                    52.52533
-                ]
-            },
-            "properties": {
-                "title": "Wochenmarkt Mierendorffplatz",
-                "location": "Mierendorffplatz, 10589",
-                "opening_hours": "We,Sa 08:00-13:00",
-                "opening_hours_unclassified": null
-            }
-        },
-        {
-            "type": "Feature",
-            "geometry": {
-                "type": "Point",
-                "coordinates": [
-                    13.29989,
-                    52.49695
-                ]
-            },
-            "properties": {
-                "title": "Wochenmarkt Nestorstraße",
-                "location": "Nestorstraße, 10709",
-                "opening_hours": "Tu,Fr 08:00-13:00",
-                "opening_hours_unclassified": null
-            }
-        },
-        {
-            "type": "Feature",
-            "geometry": {
-                "type": "Point",
-                "coordinates": [
-                    13.41693,
-                    52.53632
-                ]
-            },
-            "properties": {
-                "title": "Wochenmarkt Neuer Markt am Kollwitzplatz",
-                "location": "Kollwitzplatz, 10435",
-                "opening_hours": "Sa 10:30-16:30",
-                "opening_hours_unclassified": null
-            }
-        },
-        {
-            "type": "Feature",
-            "geometry": {
-                "type": "Point",
-                "coordinates": [
-                    13.25189,
-                    52.44959
-                ]
-            },
-            "properties": {
-                "title": "Wochenmarkt Onkel-Toms-Hütte",
-                "location": "Onkel-Tom-Str. 99, 14169",
-                "opening_hours": "Th 12:00-18:30",
-                "opening_hours_unclassified": null,
-                "details_url": "http://www.diemarktplaner.de"
-            }
-        },
-        {
-            "type": "Feature",
-            "geometry": {
-                "type": "Point",
-                "coordinates": [
-                    13.05868,
-                    52.40114
-                ]
-            },
-            "properties": {
-                "title": "Wochenmarkt Potsdam Bassinplatz",
-                "location": "Am Bassin 6, 14467",
-                "opening_hours": "Mo-Fr 07:00-16:00;Sa 07:00-13:00",
+                "title": "Wochenmarkt Zingster Straße",
+                "location": "Zingster Straße, 13051",
+                "opening_hours": "Sa 08:00-13:00",
                 "opening_hours_unclassified": null
             }
         },
@@ -1931,14 +494,14 @@
             "geometry": {
                 "type": "Point",
                 "coordinates": [
-                    13.25946,
-                    52.51111
+                    13.60735,
+                    52.53841
                 ]
             },
             "properties": {
-                "title": "Wochenmarkt Preußenallee",
-                "location": "Preußenallee, 14052",
-                "opening_hours": "Tu,Fr 08:00-13:00",
+                "title": "Wochenmarkt Helle Mitte",
+                "location": "Peter-Weiss-Gasse, 12627",
+                "opening_hours": "We,Fr 08:00-17:00",
                 "opening_hours_unclassified": null
             }
         },
@@ -1947,14 +510,14 @@
             "geometry": {
                 "type": "Point",
                 "coordinates": [
-                    13.33838,
-                    52.44451
+                    13.59143,
+                    52.48475
                 ]
             },
             "properties": {
-                "title": "Wochenmarkt Rathaus Lankwitz",
-                "location": "Leonorenstraße, 12247",
-                "opening_hours": "Mo,Fr 08:00-13:00",
+                "title": "Wochenmarkt Mahlsdorf Roedernstraße / Hultschiner Damm",
+                "location": "Roedernstraße, 12623",
+                "opening_hours": "Th 07:00-15:00",
                 "opening_hours_unclassified": null
             }
         },
@@ -1963,48 +526,16 @@
             "geometry": {
                 "type": "Point",
                 "coordinates": [
-                    13.20435,
-                    52.53702
+                    13.54258,
+                    52.52643
                 ]
             },
             "properties": {
-                "title": "Wochenmarkt Rathausvorplatz",
-                "location": "Markt 3, 13597",
-                "opening_hours": "We 08:00-18:00;Sa 08:00-16:00",
-                "opening_hours_unclassified": null
-            }
-        },
-        {
-            "type": "Feature",
-            "geometry": {
-                "type": "Point",
-                "coordinates": [
-                    13.30586,
-                    52.51732
-                ]
-            },
-            "properties": {
-                "title": "Wochenmarkt Richard-Wagner-Platz",
-                "location": "Richard-Wagner-Platz, 10585",
-                "opening_hours": "Mo,Th 08:00-13:00",
-                "opening_hours_unclassified": null
-            }
-        },
-        {
-            "type": "Feature",
-            "geometry": {
-                "type": "Point",
-                "coordinates": [
-                    13.50249,
-                    52.46139
-                ]
-            },
-            "properties": {
-                "title": "Wochenmarkt Schellerstraße Ecke Spreestraße",
-                "location": "Schnellerstraße, 12439",
-                "opening_hours": "Th 08:00-16:00",
+                "title": "Wochenmarkt Helene-Weigel-Platz",
+                "location": "Helene-Weigel-Platz, 12681",
+                "opening_hours": "Mo-Sa 09:00-17:00",
                 "opening_hours_unclassified": null,
-                "details_url": "http://www.gakenholz-gellesch.e"
+                "details_url": "http://www.markt-veranstaltungen.de"
             }
         },
         {
@@ -2012,16 +543,16 @@
             "geometry": {
                 "type": "Point",
                 "coordinates": [
-                    13.42302,
-                    52.47697
+                    13.54895,
+                    52.54366
                 ]
             },
             "properties": {
-                "title": "Wochenmarkt Schillermarkt am Herrfurthplatz",
-                "location": "Herrfurthplatz, 12049",
-                "opening_hours": "Sa 10:00-16:00",
+                "title": "Wochenmarkt Marzahner Promenade",
+                "location": "Marzahner Promenade 30-33, 12679",
+                "opening_hours": "Mo,We,Fr 08:30-17:00",
                 "opening_hours_unclassified": null,
-                "details_url": "http://www.mv-perske.de"
+                "details_url": "http://www.markt-veranstaltungen.de"
             }
         },
         {
@@ -2029,14 +560,14 @@
             "geometry": {
                 "type": "Point",
                 "coordinates": [
-                    13.57441,
-                    52.44469
+                    13.58979,
+                    52.51901
                 ]
             },
             "properties": {
-                "title": "Wochenmarkt Schlossplatz Alt-Köpenick",
-                "location": "Grünstraße 1, 12555",
-                "opening_hours": "Tu,Th 08:30-17:00",
+                "title": "Wochenmarkt Cecilienplatz",
+                "location": "Ernst-Bloch-Straße, 12619",
+                "opening_hours": "Mo,We,Fr 09:00-18:00",
                 "opening_hours_unclassified": null
             }
         },
@@ -2045,16 +576,16 @@
             "geometry": {
                 "type": "Point",
                 "coordinates": [
-                    13.50249,
-                    52.46139
+                    13.55901,
+                    52.50632
                 ]
             },
             "properties": {
-                "title": "Wochenmarkt Schnellerstraße",
-                "location": "Schnellerstraße, 12439",
-                "opening_hours": "Th 08:00-16:00",
+                "title": "Wochenmarkt am Biesdorf-Center",
+                "location": "Weißenhöher Straße 88-108, 12683",
+                "opening_hours": "Tu,Th 09:00-17:00",
                 "opening_hours_unclassified": null,
-                "details_url": "http://www.brandenburger-wochenmaerkte.de"
+                "details_url": "http://www.markt-veranstaltungen.de"
             }
         },
         {
@@ -2062,14 +593,31 @@
             "geometry": {
                 "type": "Point",
                 "coordinates": [
-                    13.41078,
-                    52.55216
+                    13.40798,
+                    52.51674
                 ]
             },
             "properties": {
-                "title": "Wochenmarkt Seelower Straße",
-                "location": "Seelower Straße, 10439",
-                "opening_hours": "Sa 09:00-16:00",
+                "title": "Berlin-Brandenburger-Bauernmarkt -  Saisonmarkt auf dem Nikolaikirchplatz",
+                "location": "Nikolaikirchplatz, 10178",
+                "opening_hours": null,
+                "opening_hours_unclassified": "März - Oktober 10:00 - 17:00",
+                "details_url": "http://www.bbm-maerkte.de"
+            }
+        },
+        {
+            "type": "Feature",
+            "geometry": {
+                "type": "Point",
+                "coordinates": [
+                    13.35989,
+                    52.54752
+                ]
+            },
+            "properties": {
+                "title": "Bauernmarkt Leopoldplatz",
+                "location": "Leopoldplatz, 13353",
+                "opening_hours": "Tu,Fr 10:00-17:00",
                 "opening_hours_unclassified": null,
                 "details_url": "http://www.bbm-maerkte.de"
             }
@@ -2079,32 +627,16 @@
             "geometry": {
                 "type": "Point",
                 "coordinates": [
-                    13.29527,
-                    52.50781
+                    13.35989,
+                    52.54752
                 ]
             },
             "properties": {
-                "title": "Wochenmarkt Suarezstraße",
-                "location": "Suarezstraße, 14057",
-                "opening_hours": "Th 09:00-15:00",
-                "opening_hours_unclassified": null
-            }
-        },
-        {
-            "type": "Feature",
-            "geometry": {
-                "type": "Point",
-                "coordinates": [
-                    13.35113,
-                    52.40863
-                ]
-            },
-            "properties": {
-                "title": "Wochenmarkt Waldsassener Straße",
-                "location": "Waldsassener Straße 47 - 49, 12279",
-                "opening_hours": "Th 12:00-17:00",
+                "title": "Wochenmarkt Leopoldplatz",
+                "location": "Leopoldplatz, 13353",
+                "opening_hours": "Th 11:00-17:00",
                 "opening_hours_unclassified": null,
-                "details_url": "http://www.berlin.de/ba-tempelhof-schoeneberg/politik-und-verwaltung/aemter/ordnungsamt/maerkte"
+                "details_url": "http://www.bbm-maerkte.de"
             }
         },
         {
@@ -2112,81 +644,16 @@
             "geometry": {
                 "type": "Point",
                 "coordinates": [
-                    13.14119,
-                    52.41207
+                    13.33983,
+                    52.52605
                 ]
             },
             "properties": {
-                "title": "Wochenmarkt Wilhelmplatz",
-                "location": "Wilhelmplatz, 14109",
-                "opening_hours": "Fr 12:00-18:00",
-                "opening_hours_unclassified": null
-            }
-        },
-        {
-            "type": "Feature",
-            "geometry": {
-                "type": "Point",
-                "coordinates": [
-                    13.3556,
-                    52.59896
-                ]
-            },
-            "properties": {
-                "title": "Wochenmarkt Wilhelmsruher Damm / Senftenberger Ring",
-                "location": "Senftenberger Ring 5A, 13439",
-                "opening_hours": "Th,Sa 08:00-14:00",
-                "opening_hours_unclassified": null
-            }
-        },
-        {
-            "type": "Feature",
-            "geometry": {
-                "type": "Point",
-                "coordinates": [
-                    13.35982,
-                    52.49638
-                ]
-            },
-            "properties": {
-                "title": "Wochenmarkt Winterfeldtplatz",
-                "location": "Winterfeldtplatz, 10781",
-                "opening_hours": "We 08:00-14:00;Sa 08:00-16:00",
-                "opening_hours_unclassified": null,
-                "details_url": "http://www.berlin.de/ba-tempelhof-schoeneberg/politik-und-verwaltung/aemter/ordnungsamt/maerkte"
-            }
-        },
-        {
-            "type": "Feature",
-            "geometry": {
-                "type": "Point",
-                "coordinates": [
-                    13.34328,
-                    52.50267
-                ]
-            },
-            "properties": {
-                "title": "Wochenmarkt Wittenbergplatz (Nordseite)",
-                "location": "Wittenbergplatz 5, 10789",
-                "opening_hours": "Tu 09:00-15:00;Fr 08:00-15:00",
-                "opening_hours_unclassified": null,
-                "details_url": "http://www.berlin.de/ba-tempelhof-schoeneberg/politik-und-verwaltung/aemter/ordnungsamt/maerkte"
-            }
-        },
-        {
-            "type": "Feature",
-            "geometry": {
-                "type": "Point",
-                "coordinates": [
-                    13.50242,
-                    52.5649
-                ]
-            },
-            "properties": {
-                "title": "Wochenmarkt Zingster Straße",
-                "location": "Zingster Straße, 13051",
-                "opening_hours": "Sa 08:00-13:00",
-                "opening_hours_unclassified": null
+                "title": "Ökomarkt & mehr an der Thusnelda-Allee",
+                "location": "Thusnelda-Allee 1, 10555",
+                "opening_hours": null,
+                "opening_hours_unclassified": "Mi 12:00 - 18:00 (Winter) 12:00 - 19:00 (Sommer)",
+                "details_url": "http://www.marktzeit.berlin/"
             }
         },
         {
@@ -2211,16 +678,49 @@
             "geometry": {
                 "type": "Point",
                 "coordinates": [
-                    13.55901,
-                    52.50632
+                    13.40218,
+                    52.51233
                 ]
             },
             "properties": {
-                "title": "Wochenmarkt am Biesdorf-Center",
-                "location": "Weißenhöher Straße 88-108, 12683",
-                "opening_hours": "Tu,Th 09:00-17:00",
+                "title": "Wochenmarkt Markt am Spittelmarkt",
+                "location": "Spittelmarkt, 10179",
+                "opening_hours": "We,Fr 10:00-15:00",
                 "opening_hours_unclassified": null,
-                "details_url": "http://www.markt-veranstaltungen.de"
+                "details_url": "http://www.bbm-maerkte.de"
+            }
+        },
+        {
+            "type": "Feature",
+            "geometry": {
+                "type": "Point",
+                "coordinates": [
+                    13.35159,
+                    52.54622
+                ]
+            },
+            "properties": {
+                "title": "Wochenmarkt am Rathaus Wedding",
+                "location": "Ostender Straße, 13353",
+                "opening_hours": "We,Sa 07:00-16:00",
+                "opening_hours_unclassified": null,
+                "details_url": "http://www.brandenburger-wochenmaerkte.de"
+            }
+        },
+        {
+            "type": "Feature",
+            "geometry": {
+                "type": "Point",
+                "coordinates": [
+                    13.33415,
+                    52.5219
+                ]
+            },
+            "properties": {
+                "title": "Wochenmarkt Jagowstraße",
+                "location": "Jagowstraße, 10555",
+                "opening_hours": "We,Sa 08:00-13:00",
+                "opening_hours_unclassified": null
             }
         },
         {
@@ -2260,135 +760,16 @@
             "geometry": {
                 "type": "Point",
                 "coordinates": [
-                    13.35159,
-                    52.54622
+                    13.34425,
+                    52.51775
                 ]
             },
             "properties": {
-                "title": "Wochenmarkt am Rathaus Wedding",
-                "location": "Ostender Straße, 13353",
-                "opening_hours": "We,Sa 07:00-16:00",
+                "title": "Ökomarkt im Hansaviertel",
+                "location": "Altonaer Straße, 10557",
+                "opening_hours": "Fr 12:00-18:30",
                 "opening_hours_unclassified": null,
-                "details_url": "http://www.brandenburger-wochenmaerkte.de"
-            }
-        },
-        {
-            "type": "Feature",
-            "geometry": {
-                "type": "Point",
-                "coordinates": [
-                    13.25867,
-                    52.4311
-                ]
-            },
-            "properties": {
-                "title": "Zehlendorf Frische Markt zwischen Teltower Damm und Postplatz direkt am S-Bahnhof Zehlendorf",
-                "location": "S-Bahnhof Zehlendorf, 14163",
-                "opening_hours": "Sa 09:00-16:00",
-                "opening_hours_unclassified": null,
-                "details_url": "http://www.zehlendorfer-wochenmarkt.de"
-            }
-        },
-        {
-            "type": "Feature",
-            "geometry": {
-                "type": "Point",
-                "coordinates": [
-                    13.30911,
-                    52.46705
-                ]
-            },
-            "properties": {
-                "title": "anZiehmarkt, Breitenbachplatz",
-                "location": "Breitenbachplatz 2, 14195",
-                "opening_hours": null,
-                "opening_hours_unclassified": "21.06., 19.07.,  16.08., 20.09., 18.10., 08.11.2020 10:30 - 15:00",
-                "details_url": "http://www.markttag-berlin.de"
-            }
-        },
-        {
-            "type": "Feature",
-            "geometry": {
-                "type": "Point",
-                "coordinates": [
-                    13.2884,
-                    52.45871
-                ]
-            },
-            "properties": {
-                "title": "Öko-Wochenmarkt Domäne Dahlem",
-                "location": "Königin-Luise-Str. 49, 14195",
-                "opening_hours": "Sa 08:00-13:00",
-                "opening_hours_unclassified": null,
-                "details_url": "http://www.domaene-dahlem.de"
-            }
-        },
-        {
-            "type": "Feature",
-            "geometry": {
-                "type": "Point",
-                "coordinates": [
-                    13.3537,
-                    52.48908
-                ]
-            },
-            "properties": {
-                "title": "Ökomarkt & mehr an der Akazienstraße",
-                "location": "Akazienstraße 15, 10823",
-                "opening_hours": "Th 12:00-18:00",
-                "opening_hours_unclassified": null,
-                "details_url": "http://www.marktzeit.berlin/"
-            }
-        },
-        {
-            "type": "Feature",
-            "geometry": {
-                "type": "Point",
-                "coordinates": [
-                    13.33983,
-                    52.52605
-                ]
-            },
-            "properties": {
-                "title": "Ökomarkt & mehr an der Thusnelda-Allee",
-                "location": "Thusnelda-Allee 1, 10555",
-                "opening_hours": null,
-                "opening_hours_unclassified": "Mi 12:00 - 18:00 (Winter) 12:00 - 19:00 (Sommer)",
-                "details_url": "http://www.marktzeit.berlin/"
-            }
-        },
-        {
-            "type": "Feature",
-            "geometry": {
-                "type": "Point",
-                "coordinates": [
-                    13.39078,
-                    52.48846
-                ]
-            },
-            "properties": {
-                "title": "Ökomarkt - Chamissoplatz",
-                "location": "Chamissoplatz, 10965",
-                "opening_hours": "Sa 09:00-15:00",
-                "opening_hours_unclassified": null,
-                "details_url": "http://www.oekomarkt-chamissoplatz.de"
-            }
-        },
-        {
-            "type": "Feature",
-            "geometry": {
-                "type": "Point",
-                "coordinates": [
-                    13.41693,
-                    52.53632
-                ]
-            },
-            "properties": {
-                "title": "Ökomarkt am Kollwitzplatz der GRÜNEN LIGA Berlin e. V.",
-                "location": "Kollwitzplatz, 10435",
-                "opening_hours": "Th 12:00-19:00",
-                "opening_hours_unclassified": null,
-                "details_url": "http://www.grueneliga-berlin.de"
+                "details_url": "http://www.marktzeit.berlin"
             }
         },
         {
@@ -2413,23 +794,936 @@
             "geometry": {
                 "type": "Point",
                 "coordinates": [
-                    13.34425,
-                    52.51775
+                    13.43798,
+                    52.46599
                 ]
             },
             "properties": {
-                "title": "Ökomarkt im Hansaviertel",
-                "location": "Altonaer Straße, 10557",
-                "opening_hours": "Fr 12:00-18:30",
+                "title": "Die Dicke Linda",
+                "location": "Kranoldplatz, 12051",
+                "opening_hours": "Sa 10:00-16:00",
                 "opening_hours_unclassified": null,
-                "details_url": "http://www.marktzeit.berlin"
+                "details_url": "http://www.dicke-linda-markt.de"
+            }
+        },
+        {
+            "type": "Feature",
+            "geometry": {
+                "type": "Point",
+                "coordinates": [
+                    13.44206,
+                    52.4737
+                ]
+            },
+            "properties": {
+                "title": "Neuköllner Wochenmärkte Rixdorf \"Gesunder Genuss auf dem Rixdorfer Markt\"",
+                "location": "Karl-Marx-Platz, 12043",
+                "opening_hours": "We 11:00-18:00;Sa 08:00-15:00",
+                "opening_hours_unclassified": null,
+                "details_url": "http://www.diemarktplaner.de"
+            }
+        },
+        {
+            "type": "Feature",
+            "geometry": {
+                "type": "Point",
+                "coordinates": [
+                    13.49286,
+                    52.42252
+                ]
+            },
+            "properties": {
+                "title": "Neuköllner Wochenmärkte Rudow \"Regionale Qualität in Rudow\"",
+                "location": "Prierosser Straße, 12355",
+                "opening_hours": "We,Sa 08:00-13:00",
+                "opening_hours_unclassified": null,
+                "details_url": "http://www.diemarktplaner.de"
+            }
+        },
+        {
+            "type": "Feature",
+            "geometry": {
+                "type": "Point",
+                "coordinates": [
+                    13.44918,
+                    52.43757
+                ]
+            },
+            "properties": {
+                "title": "Neuköllner Wochenmärkte Britz-Süd \"Frisches vom Markt\"",
+                "location": "Gutschmidtstraße, 12359",
+                "opening_hours": null,
+                "opening_hours_unclassified": "Mo, Do Sa 08:00 - 13:00 08:00 - 14:00",
+                "details_url": "http://www.diemarktplaner.de"
+            }
+        },
+        {
+            "type": "Feature",
+            "geometry": {
+                "type": "Point",
+                "coordinates": [
+                    13.42438,
+                    52.48727
+                ]
+            },
+            "properties": {
+                "title": "Neuköllner Wochenmärkte Hermannplatz \"Marktfood - vor Ort und für Zuhause\"",
+                "location": "Hermannplatz, 10967",
+                "opening_hours": "Mo-Fr 10:00-18:00",
+                "opening_hours_unclassified": null,
+                "details_url": "http://www.diemarktplaner.de"
+            }
+        },
+        {
+            "type": "Feature",
+            "geometry": {
+                "type": "Point",
+                "coordinates": [
+                    13.42666,
+                    52.49234
+                ]
+            },
+            "properties": {
+                "title": "Neuköllner Wochenmärkte Maybachufer",
+                "location": "Maybachufer 1 - 13, 12047",
+                "opening_hours": "Tu,Fr 11:00-18:30",
+                "opening_hours_unclassified": null,
+                "details_url": "http://www.diemarktplaner.de"
+            }
+        },
+        {
+            "type": "Feature",
+            "geometry": {
+                "type": "Point",
+                "coordinates": [
+                    13.4502,
+                    52.44593
+                ]
+            },
+            "properties": {
+                "title": "Neuköllner Wochenmärkte Parchimer Allee \"Freitagsmarkt bis abends!\"",
+                "location": "Fritz-Reuter-Allee 73, 12359",
+                "opening_hours": "Fr 10:00-18:00",
+                "opening_hours_unclassified": null,
+                "details_url": "http://www.diemarktplaner.de"
+            }
+        },
+        {
+            "type": "Feature",
+            "geometry": {
+                "type": "Point",
+                "coordinates": [
+                    13.47533,
+                    52.42332
+                ]
+            },
+            "properties": {
+                "title": "Neuköllner Wochenmärkte Wutzkyallee",
+                "location": "Rotraut-Richter-Platz, 12353",
+                "opening_hours": "We 08:00-14:00;Sa 08:00-13:00",
+                "opening_hours_unclassified": null,
+                "details_url": "http://www.diemarktplaner.de"
+            }
+        },
+        {
+            "type": "Feature",
+            "geometry": {
+                "type": "Point",
+                "coordinates": [
+                    13.42302,
+                    52.47697
+                ]
+            },
+            "properties": {
+                "title": "Wochenmarkt Schillermarkt am Herrfurthplatz",
+                "location": "Herrfurthplatz, 12049",
+                "opening_hours": "Sa 10:00-16:00",
+                "opening_hours_unclassified": null,
+                "details_url": "http://www.mv-perske.de"
+            }
+        },
+        {
+            "type": "Feature",
+            "geometry": {
+                "type": "Point",
+                "coordinates": [
+                    13.43125,
+                    52.49248
+                ]
+            },
+            "properties": {
+                "title": "Neuköllner Stoff am Maybachufer",
+                "location": "Maybachufer 31, 12047",
+                "opening_hours": "Sa 11:00-17:00",
+                "opening_hours_unclassified": null,
+                "details_url": "http://www.mv-perske.de"
+            }
+        },
+        {
+            "type": "Feature",
+            "geometry": {
+                "type": "Point",
+                "coordinates": [
+                    13.44073,
+                    52.54321
+                ]
+            },
+            "properties": {
+                "title": "Wochenmarkt Greifswalder Straße / Thomas-Mann-Straße",
+                "location": "Greifswalder Straße 157, 10409",
+                "opening_hours": null,
+                "opening_hours_unclassified": "Di, Do Sa 08:00 - 18:00 08:00 - 14:00"
+            }
+        },
+        {
+            "type": "Feature",
+            "geometry": {
+                "type": "Point",
+                "coordinates": [
+                    13.41693,
+                    52.53632
+                ]
+            },
+            "properties": {
+                "title": "Ökomarkt am Kollwitzplatz der GRÜNEN LIGA Berlin e. V.",
+                "location": "Kollwitzplatz, 10435",
+                "opening_hours": "Th 12:00-19:00",
+                "opening_hours_unclassified": null,
+                "details_url": "http://www.grueneliga-berlin.de"
+            }
+        },
+        {
+            "type": "Feature",
+            "geometry": {
+                "type": "Point",
+                "coordinates": [
+                    13.41693,
+                    52.53632
+                ]
+            },
+            "properties": {
+                "title": "Wochenmarkt Neuer Markt am Kollwitzplatz",
+                "location": "Kollwitzplatz, 10435",
+                "opening_hours": "Sa 10:30-16:30",
+                "opening_hours_unclassified": null
+            }
+        },
+        {
+            "type": "Feature",
+            "geometry": {
+                "type": "Point",
+                "coordinates": [
+                    13.40528,
+                    52.57019
+                ]
+            },
+            "properties": {
+                "title": "Wochenmarkt Breite Straße",
+                "location": "Breite Str. 17, 13187",
+                "opening_hours": "Tu 08:00-14:00;We 09:00-17:00;Fr 08:00-16:00;Sa 08:00-15:00",
+                "opening_hours_unclassified": null
+            }
+        },
+        {
+            "type": "Feature",
+            "geometry": {
+                "type": "Point",
+                "coordinates": [
+                    13.42012,
+                    52.60731
+                ]
+            },
+            "properties": {
+                "title": "Wochenmarkt Markt am Hugenottenplatz",
+                "location": "Hugenottenplatz, 13127",
+                "opening_hours": "Sa 09:00-13:00",
+                "opening_hours_unclassified": null
+            }
+        },
+        {
+            "type": "Feature",
+            "geometry": {
+                "type": "Point",
+                "coordinates": [
+                    13.36725,
+                    52.58554
+                ]
+            },
+            "properties": {
+                "title": "Wochenmarkt Hauptstraße / Goethestraße Wilhelmsruh",
+                "location": "Hauptstraße, 13158",
+                "opening_hours": "We,Fr 08:00-14:00",
+                "opening_hours_unclassified": null
+            }
+        },
+        {
+            "type": "Feature",
+            "geometry": {
+                "type": "Point",
+                "coordinates": [
+                    13.41084,
+                    52.55215
+                ]
+            },
+            "properties": {
+                "title": "Wochenmarkt Seelower Straße",
+                "location": "Seelower Straße, 10439",
+                "opening_hours": "Sa 09:00-16:00",
+                "opening_hours_unclassified": null,
+                "details_url": "http://www.bbm-maerkte.de"
+            }
+        },
+        {
+            "type": "Feature",
+            "geometry": {
+                "type": "Point",
+                "coordinates": [
+                    13.43583,
+                    52.5323
+                ]
+            },
+            "properties": {
+                "title": "Wochenmarkt Markt am Stierbrunnen",
+                "location": "Pasteurstraße 32, 10407",
+                "opening_hours": "Sa 09:00-15:00",
+                "opening_hours_unclassified": null
+            }
+        },
+        {
+            "type": "Feature",
+            "geometry": {
+                "type": "Point",
+                "coordinates": [
+                    13.41961,
+                    52.54314
+                ]
+            },
+            "properties": {
+                "title": "Wochenmarkt Markt am Helmholtzplatz",
+                "location": "Helmholtzplatz, 10437",
+                "opening_hours": "Sa 09:00-16:00",
+                "opening_hours_unclassified": null
+            }
+        },
+        {
+            "type": "Feature",
+            "geometry": {
+                "type": "Point",
+                "coordinates": [
+                    13.48712,
+                    52.61745
+                ]
+            },
+            "properties": {
+                "title": "Wochenmarkt Bucher Chaussee / Achillesstraße",
+                "location": "Bucher Chaussee, 13125",
+                "opening_hours": "Th 08:00-16:30;Sa 08:00-14:30",
+                "opening_hours_unclassified": null
+            }
+        },
+        {
+            "type": "Feature",
+            "geometry": {
+                "type": "Point",
+                "coordinates": [
+                    13.45159,
+                    52.54848
+                ]
+            },
+            "properties": {
+                "title": "Wochenmarkt Antonplatz",
+                "location": "Antonplatz, 13086",
+                "opening_hours": "Mo-Fr 09:00-18:00",
+                "opening_hours_unclassified": null,
+                "details_url": "http://www.mv-perske.de"
+            }
+        },
+        {
+            "type": "Feature",
+            "geometry": {
+                "type": "Point",
+                "coordinates": [
+                    13.4305,
+                    52.55254
+                ]
+            },
+            "properties": {
+                "title": "Wochenmarkt Caligariplatz",
+                "location": "Caligariplatz, 10119",
+                "opening_hours": "We,Fr 08:00-18:00",
+                "opening_hours_unclassified": null
+            }
+        },
+        {
+            "type": "Feature",
+            "geometry": {
+                "type": "Point",
+                "coordinates": [
+                    13.29297,
+                    52.63126
+                ]
+            },
+            "properties": {
+                "title": "Wochenmarkt Burgfrauenstraße",
+                "location": "Burgfrauenstraße, 13465",
+                "opening_hours": "Th-Sa 08:00-13:00",
+                "opening_hours_unclassified": null
+            }
+        },
+        {
+            "type": "Feature",
+            "geometry": {
+                "type": "Point",
+                "coordinates": [
+                    13.35501,
+                    52.59736
+                ]
+            },
+            "properties": {
+                "title": "Wochenmarkt Wilhelmsruher Damm / Senftenberger Ring",
+                "location": "Senftenberger Ring 5A, 13439",
+                "opening_hours": "Th,Sa 08:00-14:00",
+                "opening_hours_unclassified": null
+            }
+        },
+        {
+            "type": "Feature",
+            "geometry": {
+                "type": "Point",
+                "coordinates": [
+                    13.20435,
+                    52.53702
+                ]
+            },
+            "properties": {
+                "title": "Wochenmarkt Rathausvorplatz",
+                "location": "Markt 3, 13597",
+                "opening_hours": "We 08:00-18:00;Sa 08:00-16:00",
+                "opening_hours_unclassified": null
+            }
+        },
+        {
+            "type": "Feature",
+            "geometry": {
+                "type": "Point",
+                "coordinates": [
+                    13.20435,
+                    52.53702
+                ]
+            },
+            "properties": {
+                "title": "Wochenmarkt Altstadt Spandau - Markt Havelländischer Land- und Bauernmarkt",
+                "location": "Markt 3, 13597",
+                "opening_hours": "Mo,Tu,Th,Fr 09:00+",
+                "opening_hours_unclassified": null,
+                "details_url": "http://www.wirtschaftshof-spandau.de"
+            }
+        },
+        {
+            "type": "Feature",
+            "geometry": {
+                "type": "Point",
+                "coordinates": [
+                    13.2061,
+                    52.55916
+                ]
+            },
+            "properties": {
+                "title": "Wochenmarkt Hakenfelde",
+                "location": "Michelstadter Weg, 13587",
+                "opening_hours": "Th 08:00-13:00",
+                "opening_hours_unclassified": null
+            }
+        },
+        {
+            "type": "Feature",
+            "geometry": {
+                "type": "Point",
+                "coordinates": [
+                    13.15637,
+                    52.53258
+                ]
+            },
+            "properties": {
+                "title": "Wochenmarkt Brunsbütteler Damm 265",
+                "location": "Brunsbütteler Damm 265, 13591",
+                "opening_hours": "Fr 08:00-15:00",
+                "opening_hours_unclassified": null,
+                "details_url": "http://www.brandenburger-wochenmaerkte.de"
+            }
+        },
+        {
+            "type": "Feature",
+            "geometry": {
+                "type": "Point",
+                "coordinates": [
+                    13.16508,
+                    52.52162
+                ]
+            },
+            "properties": {
+                "title": "Wochenmarkt Einkaufscenter Staaken",
+                "location": "Obstallee 28, 13593",
+                "opening_hours": "Tu,Fr 09:00-15:00",
+                "opening_hours_unclassified": null
+            }
+        },
+        {
+            "type": "Feature",
+            "geometry": {
+                "type": "Point",
+                "coordinates": [
+                    13.25189,
+                    52.44959
+                ]
+            },
+            "properties": {
+                "title": "Wochenmarkt Onkel-Toms-Hütte",
+                "location": "Onkel-Tom-Str. 99, 14169",
+                "opening_hours": "Th 12:00-18:30",
+                "opening_hours_unclassified": null,
+                "details_url": "http://www.diemarktplaner.de"
+            }
+        },
+        {
+            "type": "Feature",
+            "geometry": {
+                "type": "Point",
+                "coordinates": [
+                    13.25867,
+                    52.4311
+                ]
+            },
+            "properties": {
+                "title": "Zehlendorf Frische Markt zwischen Teltower Damm und Postplatz direkt am S-Bahnhof Zehlendorf",
+                "location": "S-Bahnhof Zehlendorf, 14163",
+                "opening_hours": "Sa 09:00-16:00",
+                "opening_hours_unclassified": null,
+                "details_url": "http://www.zehlendorfer-wochenmarkt.de"
+            }
+        },
+        {
+            "type": "Feature",
+            "geometry": {
+                "type": "Point",
+                "coordinates": [
+                    13.26428,
+                    52.41171
+                ]
+            },
+            "properties": {
+                "title": "Frischemarkt Andréezeile",
+                "location": "Ladiusstraße, 14165",
+                "opening_hours": "Sa 08:00-13:00",
+                "opening_hours_unclassified": null,
+                "details_url": "http://www.diemarktplaner.de"
+            }
+        },
+        {
+            "type": "Feature",
+            "geometry": {
+                "type": "Point",
+                "coordinates": [
+                    13.14119,
+                    52.41207
+                ]
+            },
+            "properties": {
+                "title": "Dorfmarkt Wannsee",
+                "location": "Wilhelmplatz, 14109",
+                "opening_hours": "Fr 14:00-18:00",
+                "opening_hours_unclassified": null,
+                "details_url": "http://www.diemarktplaner.de"
+            }
+        },
+        {
+            "type": "Feature",
+            "geometry": {
+                "type": "Point",
+                "coordinates": [
+                    13.32237,
+                    52.45692
+                ]
+            },
+            "properties": {
+                "title": "Wochenmarkt Hermann-Ehlers-Platz",
+                "location": "Hermann-Ehlers-Platz, 12165",
+                "opening_hours": null,
+                "opening_hours_unclassified": "Di, Sa Do 08:00 - 14:00 08:00 - 18:00"
+            }
+        },
+        {
+            "type": "Feature",
+            "geometry": {
+                "type": "Point",
+                "coordinates": [
+                    13.32701,
+                    52.42806
+                ]
+            },
+            "properties": {
+                "title": "Wochenmarkt Lichterfelde, Kranoldplatz",
+                "location": "Kranoldplatz, 12209",
+                "opening_hours": "We,Sa 08:00-14:00",
+                "opening_hours_unclassified": null
+            }
+        },
+        {
+            "type": "Feature",
+            "geometry": {
+                "type": "Point",
+                "coordinates": [
+                    13.33838,
+                    52.44451
+                ]
+            },
+            "properties": {
+                "title": "Wochenmarkt Rathaus Lankwitz",
+                "location": "Leonorenstraße, 12247",
+                "opening_hours": "Mo,Fr 08:00-13:00",
+                "opening_hours_unclassified": null
+            }
+        },
+        {
+            "type": "Feature",
+            "geometry": {
+                "type": "Point",
+                "coordinates": [
+                    13.31202,
+                    52.44286
+                ]
+            },
+            "properties": {
+                "title": "Wochenmarkt Ludwig-Beck-Platz",
+                "location": "Ludwig-Beck-Platz, 12203",
+                "opening_hours": "Fr,Sa 08:00-13:00",
+                "opening_hours_unclassified": null
+            }
+        },
+        {
+            "type": "Feature",
+            "geometry": {
+                "type": "Point",
+                "coordinates": [
+                    13.21667,
+                    52.43872
+                ]
+            },
+            "properties": {
+                "title": "Markt Schlachtensee (Wochenmarkt)",
+                "location": "Matterhornstr. 52/54, 14129",
+                "opening_hours": "Tu,Fr 08:00-14:00",
+                "opening_hours_unclassified": null
+            }
+        },
+        {
+            "type": "Feature",
+            "geometry": {
+                "type": "Point",
+                "coordinates": [
+                    13.2884,
+                    52.45871
+                ]
+            },
+            "properties": {
+                "title": "Öko-Wochenmarkt Domäne Dahlem",
+                "location": "Königin-Luise-Str. 49, 14195",
+                "opening_hours": "Sa 08:00-13:00",
+                "opening_hours_unclassified": null,
+                "details_url": "http://www.domaene-dahlem.de"
+            }
+        },
+        {
+            "type": "Feature",
+            "geometry": {
+                "type": "Point",
+                "coordinates": [
+                    13.23279,
+                    52.43756
+                ]
+            },
+            "properties": {
+                "title": "Wochenmarkt Mexikoplatz",
+                "location": "Mexikoplatz, 14163",
+                "opening_hours": "Sa 09:00-15:00",
+                "opening_hours_unclassified": null
+            }
+        },
+        {
+            "type": "Feature",
+            "geometry": {
+                "type": "Point",
+                "coordinates": [
+                    13.3537,
+                    52.48908
+                ]
+            },
+            "properties": {
+                "title": "Ökomarkt & mehr an der Akazienstraße",
+                "location": "Akazienstraße 15, 10823",
+                "opening_hours": "Th 12:00-18:00",
+                "opening_hours_unclassified": null,
+                "details_url": "http://www.marktzeit.berlin/"
+            }
+        },
+        {
+            "type": "Feature",
+            "geometry": {
+                "type": "Point",
+                "coordinates": [
+                    13.38109,
+                    52.4436
+                ]
+            },
+            "properties": {
+                "title": "Wochenmarkt Mariendorfer Damm / Prinzenstraße",
+                "location": "Prinzenstraße, 12109",
+                "opening_hours": "We,Sa 08:00-13:00",
+                "opening_hours_unclassified": null,
+                "details_url": "http://www.berlin.de/ba-tempelhof-schoeneberg/politik-und-verwaltung/aemter/ordnungsamt/maerkte"
+            }
+        },
+        {
+            "type": "Feature",
+            "geometry": {
+                "type": "Point",
+                "coordinates": [
+                    13.35113,
+                    52.40863
+                ]
+            },
+            "properties": {
+                "title": "Wochenmarkt Waldsassener Straße",
+                "location": "Waldsassener Straße 47 - 49, 12279",
+                "opening_hours": "Th 12:00-17:00",
+                "opening_hours_unclassified": null,
+                "details_url": "http://www.berlin.de/ba-tempelhof-schoeneberg/politik-und-verwaltung/aemter/ordnungsamt/maerkte"
+            }
+        },
+        {
+            "type": "Feature",
+            "geometry": {
+                "type": "Point",
+                "coordinates": [
+                    13.35982,
+                    52.49638
+                ]
+            },
+            "properties": {
+                "title": "Wochenmarkt Winterfeldtplatz",
+                "location": "Winterfeldtplatz, 10781",
+                "opening_hours": "We 08:00-14:00;Sa 08:00-16:00",
+                "opening_hours_unclassified": null,
+                "details_url": "http://www.berlin.de/ba-tempelhof-schoeneberg/politik-und-verwaltung/aemter/ordnungsamt/maerkte"
+            }
+        },
+        {
+            "type": "Feature",
+            "geometry": {
+                "type": "Point",
+                "coordinates": [
+                    13.34306,
+                    52.48535
+                ]
+            },
+            "properties": {
+                "title": "Wochenmarkt John-F.-Kennedy-Platz",
+                "location": "John-F.-Kennedy-Platz 1, 10825",
+                "opening_hours": "Tu,Fr 08:00-13:00",
+                "opening_hours_unclassified": null,
+                "details_url": "http://www.berlin.de/ba-tempelhof-schoeneberg/politik-und-verwaltung/aemter/ordnungsamt/maerkte"
+            }
+        },
+        {
+            "type": "Feature",
+            "geometry": {
+                "type": "Point",
+                "coordinates": [
+                    13.33554,
+                    52.47207
+                ]
+            },
+            "properties": {
+                "title": "Wochenmarkt Breslauer Platz",
+                "location": "Breslauer Platz, 12159",
+                "opening_hours": "We 08:00-13:00;Th 12:00-18:00;Sa 08:00-14:00",
+                "opening_hours_unclassified": null,
+                "details_url": "http://www.berlin.de/ba-tempelhof-schoeneberg/politik-und-verwaltung/aemter/ordnungsamt/maerkte"
+            }
+        },
+        {
+            "type": "Feature",
+            "geometry": {
+                "type": "Point",
+                "coordinates": [
+                    13.36551,
+                    52.49103
+                ]
+            },
+            "properties": {
+                "title": "Wochenmarkt Crellestraße",
+                "location": "Crellestraße 24, 10827",
+                "opening_hours": "We,Sa 10:00-15:00",
+                "opening_hours_unclassified": null,
+                "details_url": "http://www.berlin.de/ba-tempelhof-schoeneberg/politik-und-verwaltung/aemter/ordnungsamt/maerkte"
+            }
+        },
+        {
+            "type": "Feature",
+            "geometry": {
+                "type": "Point",
+                "coordinates": [
+                    13.34328,
+                    52.50267
+                ]
+            },
+            "properties": {
+                "title": "Wochenmarkt Wittenbergplatz (Nordseite)",
+                "location": "Wittenbergplatz 5, 10789",
+                "opening_hours": "Tu 09:00-15:00;Fr 08:00-15:00",
+                "opening_hours_unclassified": null,
+                "details_url": "http://www.berlin.de/ba-tempelhof-schoeneberg/politik-und-verwaltung/aemter/ordnungsamt/maerkte"
+            }
+        },
+        {
+            "type": "Feature",
+            "geometry": {
+                "type": "Point",
+                "coordinates": [
+                    13.34328,
+                    52.50267
+                ]
+            },
+            "properties": {
+                "title": "Wittenbergplatz (Nordseite) Brandenburger Bauernmarkt",
+                "location": "Wittenbergplatz 5, 10789",
+                "opening_hours": "Th 09:00-17:00",
+                "opening_hours_unclassified": null,
+                "details_url": "http://www.bbm-maerkte.de"
+            }
+        },
+        {
+            "type": "Feature",
+            "geometry": {
+                "type": "Point",
+                "coordinates": [
+                    13.57401,
+                    52.44501
+                ]
+            },
+            "properties": {
+                "title": "Wochenmarkt Schlossplatz Alt-Köpenick",
+                "location": "Grünstraße 1, 12555",
+                "opening_hours": "Tu,Th 08:30-17:00",
+                "opening_hours_unclassified": null
+            }
+        },
+        {
+            "type": "Feature",
+            "geometry": {
+                "type": "Point",
+                "coordinates": [
+                    13.50249,
+                    52.46139
+                ]
+            },
+            "properties": {
+                "title": "Wochenmarkt Schnellerstraße",
+                "location": "Schnellerstraße, 12439",
+                "opening_hours": "Th 08:00-16:00",
+                "opening_hours_unclassified": null,
+                "details_url": "http://www.brandenburger-wochenmaerkte.de"
+            }
+        },
+        {
+            "type": "Feature",
+            "geometry": {
+                "type": "Point",
+                "coordinates": [
+                    13.50249,
+                    52.46139
+                ]
+            },
+            "properties": {
+                "title": "Wochenmarkt Schellerstraße Ecke Spreestraße",
+                "location": "Schnellerstraße, 12439",
+                "opening_hours": "Th 08:00-16:00",
+                "opening_hours_unclassified": null,
+                "details_url": "http://www.gakenholz-gellesch.e"
+            }
+        },
+        {
+            "type": "Feature",
+            "geometry": {
+                "type": "Point",
+                "coordinates": [
+                    13.52667,
+                    52.45864
+                ]
+            },
+            "properties": {
+                "title": "Wochenmarkt Berlin-Oberschöneweide",
+                "location": "Rathenauplatz, 12459",
+                "opening_hours": "We 09:00-16:00",
+                "opening_hours_unclassified": null,
+                "details_url": "http://www.brandenburger-wochenmaerkte.de"
+            }
+        },
+        {
+            "type": "Feature",
+            "geometry": {
+                "type": "Point",
+                "coordinates": [
+                    13.54325,
+                    52.43632
+                ]
+            },
+            "properties": {
+                "title": "Wochenmarkt Adlershof",
+                "location": "Dörpfeldstraße, 12489",
+                "opening_hours": "We,Th 08:00-16:00",
+                "opening_hours_unclassified": null,
+                "details_url": "http://www.gakenholz-gellesch.de"
+            }
+        },
+        {
+            "type": "Feature",
+            "geometry": {
+                "type": "Point",
+                "coordinates": [
+                    13.62481,
+                    52.44831
+                ]
+            },
+            "properties": {
+                "title": "Wochenmarkt Bölschestraße",
+                "location": "Bölschestraße, 12587",
+                "opening_hours": null,
+                "opening_hours_unclassified": "Mo, Mi, Fr Sa 10:00 - 16:00 09:00 - 13:00"
+            }
+        },
+        {
+            "type": "Feature",
+            "geometry": {
+                "type": "Point",
+                "coordinates": [
+                    13.58014,
+                    52.45824
+                ]
+            },
+            "properties": {
+                "title": "Wochenmarkt Am S-Bhf. Köpenick",
+                "location": "Elcknerplatz, 12555",
+                "opening_hours": "Mo-Fr 09:00-18:00;Sa 09:00-16:00",
+                "opening_hours_unclassified": null,
+                "details_url": "http://www.mv-perske.de"
             }
         }
     ],
     "metadata": {
         "data_source": {
-            "title": "Stadt Berlin, CC BY 3.0 DE, aktualisiert am 27.05.2020",
-            "url": "https://daten.berlin.de/datensaetze/wochen-und-tr%C3%B6delm%C3%A4rkte-0"
+            "title": "Stadt Berlin, CC BY 3.0 DE, aktualisiert am 10.03.2021",
+            "url": "https://daten.berlin.de/datensaetze/wochen-und-tr%C3%B6delm%C3%A4rkte"
         }
     }
 }

--- a/preprocessing/berlin/raw/markets-berlin.json
+++ b/preprocessing/berlin/raw/markets-berlin.json
@@ -6,327 +6,17 @@
             "geometry": {
                 "type": "Point",
                 "coordinates": [
-                    13.31054,
-                    52.46746
-                ]
-            },
-            "properties": {
-                "title": " < 164 Markt, Breitenbachplatz",
-                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/426",
-                "description": "14.06., 12.07., &#10;09.08., 13.09., 11.10., 01.11.2020<br />10:00 - 14:00<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/426\">Mehr...</a>",
-                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/426",
-                "data": {
-                    "id": "426",
-                    "bezirk": "Steglitz-Zehlendorf",
-                    "bezeichnung": " < 164 Markt, Breitenbachplatz",
-                    "strasse": "Breitenbachplatz 1",
-                    "plz": "14195",
-                    "tage": "14.06., 12.07., \n09.08., 13.09., 11.10., 01.11.2020",
-                    "zeiten": "10:00 - 14:00",
-                    "betreiber": "Fa. MARKTTAG, Tel.: 29 77 99 44",
-                    "email": "mailto:markttag@web.de",
-                    "www": "http://www.markttag-berlin.de",
-                    "bemerkungen": "Verkauf von Baby- und Kindersachen",
-                    "_wgs84_lat": "52.46746",
-                    "_wgs84_lon": "13.31054"
-                }
-            }
-        },
-        {
-            "type": "Feature",
-            "geometry": {
-                "type": "Point",
-                "coordinates": [
-                    13.31894,
-                    52.52798
-                ]
-            },
-            "properties": {
-                "title": "10. Design.Börse_Berlin im LOEWE-SAAL",
-                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/387",
-                "description": "13. - 15.11.2020<br />Fr 16:30 - 21:00&#10;Sa 12:00 - 20:00&#10;So 11:00-19:00<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/387\">Mehr...</a>",
-                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/387",
-                "data": {
-                    "id": "387",
-                    "bezirk": "Mitte",
-                    "bezeichnung": "10. Design.Börse_Berlin im LOEWE-SAAL",
-                    "strasse": "Wiebestraße 42",
-                    "plz": "10553",
-                    "tage": "13. - 15.11.2020",
-                    "zeiten": "Fr 16:30 - 21:00\nSa 12:00 - 20:00\nSo 11:00-19:00",
-                    "betreiber": "Oldthing Marktveranstaltung, Tel.: 29 00 20 10",
-                    "email": "mailto:info@oldthing.de",
-                    "www": "http://www.oldthing.de",
-                    "bemerkungen": "Vintage-Möbel & Produktdesign, Designklassiker & Stilikonen der letzten 120 Jahre, Eintritt, http://www.design-boerse-berlin.de",
-                    "_wgs84_lat": "52.52798",
-                    "_wgs84_lon": "13.31894"
-                }
-            }
-        },
-        {
-            "type": "Feature",
-            "geometry": {
-                "type": "Point",
-                "coordinates": [
-                    13.29531,
-                    52.51911
-                ]
-            },
-            "properties": {
-                "title": "11. Berliner Kunstallee",
-                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/438",
-                "description": "05.-06.09.2020<br />11:00 - 18:00<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/438\">Mehr...</a>",
-                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/438",
-                "data": {
-                    "id": "438",
-                    "bezirk": "Charlottenburg-Wilmersdorf",
-                    "bezeichnung": "11. Berliner Kunstallee",
-                    "strasse": "Schloßstr. 1",
-                    "plz": "14059",
-                    "tage": "05.-06.09.2020",
-                    "zeiten": "11:00 - 18:00",
-                    "betreiber": "Cornelja Hasler, Kunsthand-Berlin, Tel.: 40 63 70 31",
-                    "email": "info@kunsthand-berlin.de",
-                    "www": "www.kunsthand-berlin.de",
-                    "bemerkungen": "Eintritt frei, Handelsware nicht zugelassen, vis-à-vis Schloss Charlottenburg",
-                    "_wgs84_lat": "52.519109",
-                    "_wgs84_lon": "13.2953145"
-                }
-            }
-        },
-        {
-            "type": "Feature",
-            "geometry": {
-                "type": "Point",
-                "coordinates": [
-                    13.56643,
-                    52.53795
-                ]
-            },
-            "properties": {
-                "title": "15. Kunst- und Keramikmarkt",
-                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/357",
-                "description": "07./08.11.2020<br />10:00 - 18:00<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/357\">Mehr...</a>",
-                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/357",
-                "data": {
-                    "id": "357",
-                    "bezirk": "Marzahn-Hellersdorf",
-                    "bezeichnung": "15. Kunst- und Keramikmarkt",
-                    "strasse": "Alt Marzahn",
-                    "plz": "12685",
-                    "tage": "07./08.11.2020",
-                    "zeiten": "10:00 - 18:00",
-                    "betreiber": "KulturGut Alt-Marzahn, Alt-Marzahn 23, 12685 Berlin, Tel.: 56 29 42 83 oder 86, Fax: 99 28 78 35",
-                    "email": "mailto:petrich@agrar-boerse-ev.de",
-                    "www": "http://www.agrar-boerse-ev.de/kulturgut.html",
-                    "bemerkungen": "http://www.agrar-boerse-ev.de/",
-                    "_wgs84_lat": "52.5379542",
-                    "_wgs84_lon": "13.5664266"
-                }
-            }
-        },
-        {
-            "type": "Feature",
-            "geometry": {
-                "type": "Point",
-                "coordinates": [
-                    13.28996,
-                    52.63267
-                ]
-            },
-            "properties": {
-                "title": "17. Gartenlust & Kunstgenuss Frohnau",
-                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/435",
-                "description": "12.-13.09.2020<br />11:00 - 18:00<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/435\">Mehr...</a>",
-                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/435",
-                "data": {
-                    "id": "435",
-                    "bezirk": "Reinickendorf",
-                    "bezeichnung": "17. Gartenlust & Kunstgenuss Frohnau",
-                    "strasse": "S-Bahnhof Frohnau",
-                    "plz": "13465",
-                    "tage": "12.-13.09.2020",
-                    "zeiten": "11:00 - 18:00",
-                    "betreiber": "Cornelja Hasler, Kunsthand-Berlin, Tel.: 40 63 70 31",
-                    "email": "info@kunsthand-berlin.de",
-                    "www": "www.kunsthand-berlin.de",
-                    "bemerkungen": "Eintritt frei, Handeslware nicht zugelassen, Zentrum der Gartenstadt Frohnau",
-                    "_wgs84_lat": "52.6326725",
-                    "_wgs84_lon": "13.2899634"
-                }
-            }
-        },
-        {
-            "type": "Feature",
-            "geometry": {
-                "type": "Point",
-                "coordinates": [
-                    13.29527,
-                    52.50781
-                ]
-            },
-            "properties": {
-                "title": "19. ANTIKMEILE Suarezstraße",
-                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/51",
-                "description": "05.09.2020<br />12:00 - 20:00<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/51\">Mehr...</a>",
-                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/51",
-                "data": {
-                    "id": "51",
-                    "bezirk": "Charlottenburg-Wilmersdorf",
-                    "bezeichnung": "19. ANTIKMEILE Suarezstraße",
-                    "strasse": "Suarezstraße",
-                    "plz": "14057",
-                    "tage": "05.09.2020",
-                    "zeiten": "12:00 - 20:00",
-                    "betreiber": "Oldthing Marktveranstaltung\nTel.: 29 00 20 10",
-                    "email": "mailto:service@oldthing.de",
-                    "www": "http://www.oldthing.de",
-                    "bemerkungen": "Info & Anmeldung: oldthing.de/suarezstrasse",
-                    "_wgs84_lat": "52.5078147",
-                    "_wgs84_lon": "13.2952716"
-                }
-            }
-        },
-        {
-            "type": "Feature",
-            "geometry": {
-                "type": "Point",
-                "coordinates": [
-                    13.39519,
-                    52.5203
-                ]
-            },
-            "properties": {
-                "title": "Antik- und Buchmarkt am Bode Museum",
-                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/153",
-                "description": "Sa, So, gesetzliche Feiertage<br />11:00 - 17:00<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/153\">Mehr...</a>",
-                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/153",
-                "data": {
-                    "id": "153",
-                    "bezirk": "Mitte",
-                    "bezeichnung": "Antik- und Buchmarkt am Bode Museum",
-                    "strasse": "Am Kupfergraben",
-                    "plz": "10117",
-                    "tage": "Sa, So, gesetzliche Feiertage",
-                    "zeiten": "11:00 - 17:00",
-                    "betreiber": "M.S.P.-Marktservice GmbH, Tel. 0176/66 66 67 15",
-                    "email": "",
-                    "www": "",
-                    "bemerkungen": "Am Kupfergraben/ Museumsinsel, \naußer Karfreitag, Volkstrauertag, Totensonntag, 24. und 31.12.2019",
-                    "_wgs84_lat": "52.5203",
-                    "_wgs84_lon": "13.39519"
-                }
-            }
-        },
-        {
-            "type": "Feature",
-            "geometry": {
-                "type": "Point",
-                "coordinates": [
-                    13.29812,
-                    52.5161
-                ]
-            },
-            "properties": {
-                "title": "Antik- und Kunstmarkt an der Villa Oppenheim",
-                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/54",
-                "description": "19.09.2020&#10;20.09.2020<br />11:00 - 18:00&#10;10:00 - 18:00&#10;11:00 - 18:00&#10;10:00 - 18:00<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/54\">Mehr...</a>",
-                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/54",
-                "data": {
-                    "id": "54",
-                    "bezirk": "Charlottenburg-Wilmersdorf",
-                    "bezeichnung": "Antik- und Kunstmarkt an der Villa Oppenheim",
-                    "strasse": "Schloßstraße 55",
-                    "plz": "14059",
-                    "tage": "19.09.2020\n20.09.2020",
-                    "zeiten": "11:00 - 18:00\n10:00 - 18:00\n11:00 - 18:00\n10:00 - 18:00",
-                    "betreiber": "Herr Hanisch, Tel.: 0177/856 65 98 und 58 91 69 05",
-                    "email": "mailto:info@markt-rix.de",
-                    "www": "http://www.markt-rix.de",
-                    "bemerkungen": "Schloßstr. 55 (Otto-Grüneberg-Weg), 14059 Berlin",
-                    "_wgs84_lat": "52.5161",
-                    "_wgs84_lon": "13.29812"
-                }
-            }
-        },
-        {
-            "type": "Feature",
-            "geometry": {
-                "type": "Point",
-                "coordinates": [
-                    13.43401,
-                    52.51038
-                ]
-            },
-            "properties": {
-                "title": "Antikmarkt Ostbahnhof Pfingst-Spezial",
-                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/345",
-                "description": "31.05./01.06.2020<br />09:00 - 17:00<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/345\">Mehr...</a>",
-                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/345",
-                "data": {
-                    "id": "345",
-                    "bezirk": "Friedrichshain-Kreuzberg",
-                    "bezeichnung": "Antikmarkt Ostbahnhof Pfingst-Spezial",
-                    "strasse": "Koppenstraße 3",
-                    "plz": "10243",
-                    "tage": "31.05./01.06.2020",
-                    "zeiten": "09:00 - 17:00",
-                    "betreiber": "Oldthing Marktveranstaltung\nTel.: 29 00 20 10",
-                    "email": "mailto:info@oldthing.de",
-                    "www": "http://www.oldthing.de",
-                    "bemerkungen": "",
-                    "_wgs84_lat": "52.5103843",
-                    "_wgs84_lon": "13.4340144"
-                }
-            }
-        },
-        {
-            "type": "Feature",
-            "geometry": {
-                "type": "Point",
-                "coordinates": [
-                    13.43429,
-                    52.5115
-                ]
-            },
-            "properties": {
-                "title": "Antikmarkt am Berliner Ostbahnhof",
-                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/75",
-                "description": "So<br />09:00 - 16:00 (Winter)&#10;09.00 - 17:00 (Sommer)<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/75\">Mehr...</a>",
-                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/75",
-                "data": {
-                    "id": "75",
-                    "bezirk": "Friedrichshain-Kreuzberg",
-                    "bezeichnung": "Antikmarkt am Berliner Ostbahnhof",
-                    "strasse": "Erich-Steinfurth-Straße",
-                    "plz": "10243",
-                    "tage": "So",
-                    "zeiten": "09:00 - 16:00 (Winter)\n09.00 - 17:00 (Sommer)",
-                    "betreiber": "Oldthing Marktveranstaltung\nTel.: 29 00 20 10",
-                    "email": "mailto:info@oldthing.de",
-                    "www": "http://www.oldthing.de",
-                    "bemerkungen": "außer Volkstrauertag und Totensonntag; im Sommer bis 17:00 geöffnet",
-                    "_wgs84_lat": "52.5115019",
-                    "_wgs84_lon": "13.434294"
-                }
-            }
-        },
-        {
-            "type": "Feature",
-            "geometry": {
-                "type": "Point",
-                "coordinates": [
                     13.35989,
                     52.54752
                 ]
             },
             "properties": {
                 "title": "Bauernmarkt Leopoldplatz",
-                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/366",
-                "description": "Di, Fr<br />10:00 - 17:00<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/366\">Mehr...</a>",
-                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/366",
+                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/280",
+                "description": "Di, Fr<br />10:00 - 17:00<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/280\">Mehr...</a>",
+                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/280",
                 "data": {
-                    "id": "366",
+                    "id": "280",
                     "bezirk": "Mitte",
                     "bezeichnung": "Bauernmarkt Leopoldplatz",
                     "strasse": "Leopoldplatz",
@@ -347,17 +37,17 @@
             "geometry": {
                 "type": "Point",
                 "coordinates": [
-                    13.40799,
+                    13.40798,
                     52.51674
                 ]
             },
             "properties": {
                 "title": "Berlin-Brandenburger-Bauernmarkt - \nSaisonmarkt auf dem Nikolaikirchplatz",
-                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/351",
-                "description": "März - Oktober<br />10:00 - 17:00<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/351\">Mehr...</a>",
-                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/351",
+                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/271",
+                "description": "März - Oktober<br />10:00 - 17:00<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/271\">Mehr...</a>",
+                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/271",
                 "data": {
-                    "id": "351",
+                    "id": "271",
                     "bezirk": "Mitte",
                     "bezeichnung": "Berlin-Brandenburger-Bauernmarkt - \nSaisonmarkt auf dem Nikolaikirchplatz",
                     "strasse": "Nikolaikirchplatz",
@@ -368,8 +58,8 @@
                     "email": "mailto:info@bbm-maerkte.de",
                     "www": "http://www.bbm-maerkte.de",
                     "bemerkungen": "",
-                    "_wgs84_lat": "52.5167377",
-                    "_wgs84_lon": "13.4079858"
+                    "_wgs84_lat": "52.5167368",
+                    "_wgs84_lon": "13.4079838"
                 }
             }
         },
@@ -378,215 +68,29 @@
             "geometry": {
                 "type": "Point",
                 "coordinates": [
-                    13.09485,
-                    52.39426
+                    13.43798,
+                    52.46599
                 ]
             },
             "properties": {
-                "title": "Floh- und Bauernmarkt in Potsdam",
-                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/342",
-                "description": "Sa<br />07:00 - 13:00<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/342\">Mehr...</a>",
-                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/342",
+                "title": "Die Dicke Linda",
+                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/268",
+                "description": "Sa <br />10:00 - 16:00<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/268\">Mehr...</a>",
+                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/268",
                 "data": {
-                    "id": "342",
-                    "bezirk": "Brandenburg",
-                    "bezeichnung": "Floh- und Bauernmarkt in Potsdam",
-                    "strasse": "Weberplatz",
-                    "plz": "14482",
-                    "tage": "Sa",
-                    "zeiten": "07:00 - 13:00",
-                    "betreiber": "Fa. Koscholke, \nTel.: 03322/23 32 88 und 0177/233 28 80",
-                    "email": "mailto:koscholke@arcor.de",
-                    "www": "http://www.koscholke.de",
-                    "bemerkungen": "außer an gesetzlichen Feiertagen",
-                    "_wgs84_lat": "52.39426",
-                    "_wgs84_lon": "13.09485"
-                }
-            }
-        },
-        {
-            "type": "Feature",
-            "geometry": {
-                "type": "Point",
-                "coordinates": [
-                    13.17722,
-                    52.54832
-                ]
-            },
-            "properties": {
-                "title": "Flohmarkt Falkenseer Chaussee, Siegener Straße",
-                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/423",
-                "description": "So<br />08:00 - 16:00<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/423\">Mehr...</a>",
-                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/423",
-                "data": {
-                    "id": "423",
-                    "bezirk": "Spandau",
-                    "bezeichnung": "Flohmarkt Falkenseer Chaussee, Siegener Straße",
-                    "strasse": " Falkenseer Chaussee 239",
-                    "plz": "13583",
-                    "tage": "So",
-                    "zeiten": "08:00 - 16:00",
-                    "betreiber": "Betreiber: Herr Yesildag, Tel.: 38 30 70 44 und 0179/483 05 42, Fax: 38 30 85 75",
-                    "email": "",
-                    "www": "http://www.troedelmarkt.berlin",
-                    "bemerkungen": "Edeka-Parkplatz, außer Volkstrauertag und Totensonntag, an verkaufsoffenen Sonntagen 08:00 - 13:00",
-                    "_wgs84_lat": "52.54832",
-                    "_wgs84_lon": "13.17722"
-                }
-            }
-        },
-        {
-            "type": "Feature",
-            "geometry": {
-                "type": "Point",
-                "coordinates": [
-                    13.37904,
-                    52.43085
-                ]
-            },
-            "properties": {
-                "title": "Flohmarkt Marienfelde, Hornbach-Parkplatz",
-                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/315",
-                "description": "So<br />09:00 - 15:00<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/315\">Mehr...</a>",
-                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/315",
-                "data": {
-                    "id": "315",
-                    "bezirk": "Tempelhof-Schöneberg",
-                    "bezeichnung": "Flohmarkt Marienfelde, Hornbach-Parkplatz",
-                    "strasse": "Großbeerenstr. 133",
-                    "plz": "12107",
-                    "tage": "So",
-                    "zeiten": "09:00 - 15:00",
-                    "betreiber": "Marktleitung: Ayvaz Flohmärkte GmbH, Tel.: 50 34 99 62 und 0177/611 11 10",
-                    "email": "mailto:info@ayvaz.de",
-                    "www": "http://www.ayvaz.de",
-                    "bemerkungen": "http://www.flohmarkt-marienfelde.de; außer Volkstrauertag und Totensonntag",
-                    "_wgs84_lat": "52.4308527",
-                    "_wgs84_lon": "13.3790421"
-                }
-            }
-        },
-        {
-            "type": "Feature",
-            "geometry": {
-                "type": "Point",
-                "coordinates": [
-                    13.54541,
-                    52.39736
-                ]
-            },
-            "properties": {
-                "title": "Flohmarkt Schönefeld",
-                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/333",
-                "description": "So<br />09:00 - 15:00<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/333\">Mehr...</a>",
-                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/333",
-                "data": {
-                    "id": "333",
-                    "bezirk": "Treptow-Köpenick",
-                    "bezeichnung": "Flohmarkt Schönefeld",
-                    "strasse": "Grünbergallee 279",
-                    "plz": "12526",
-                    "tage": "So",
-                    "zeiten": "09:00 - 15:00",
-                    "betreiber": "Marktleitung: Ayvaz Flohmärkte GmbH, Tel.: 50 34 99 62 und 0163/611 11 10",
-                    "email": "mailto:info@ayvaz.de",
-                    "www": "http://www.ayvaz.de",
-                    "bemerkungen": "Hornbach-Parkplatz\nhttp://www.flohmarkt-schoenefeld.de; außer Volkstrauertag und Totensonntag",
-                    "_wgs84_lat": "52.3973643",
-                    "_wgs84_lon": "13.5454146"
-                }
-            }
-        },
-        {
-            "type": "Feature",
-            "geometry": {
-                "type": "Point",
-                "coordinates": [
-                    13.6266,
-                    52.45784
-                ]
-            },
-            "properties": {
-                "title": "Flohmarkt am S-Bhf. Friedrichshagen",
-                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/330",
-                "description": "So<br />08:00 - 16:00<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/330\">Mehr...</a>",
-                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/330",
-                "data": {
-                    "id": "330",
-                    "bezirk": "Treptow-Köpenick",
-                    "bezeichnung": "Flohmarkt am S-Bhf. Friedrichshagen",
-                    "strasse": "Schöneicher Str. 1",
-                    "plz": "12587",
-                    "tage": "So",
-                    "zeiten": "08:00 - 16:00",
-                    "betreiber": "Oldthing Marktveranstaltung\nTel.: 29 00 20 10",
-                    "email": "mailto:info@oldthing.de",
-                    "www": "http://www.oldthing.de",
-                    "bemerkungen": "außer Volkstrauertag und Totensonntag",
-                    "_wgs84_lat": "52.45784",
-                    "_wgs84_lon": "13.6266"
-                }
-            }
-        },
-        {
-            "type": "Feature",
-            "geometry": {
-                "type": "Point",
-                "coordinates": [
-                    13.4019,
-                    52.54192
-                ]
-            },
-            "properties": {
-                "title": "Flohmarkt im Mauerpark",
-                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/159",
-                "description": "So<br />10:00 - 18:00<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/159\">Mehr...</a>",
-                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/159",
-                "data": {
-                    "id": "159",
-                    "bezirk": "Mitte",
-                    "bezeichnung": "Flohmarkt im Mauerpark",
-                    "strasse": "Bernauer Straße 63-64",
-                    "plz": "13355",
-                    "tage": "So",
-                    "zeiten": "10:00 - 18:00",
-                    "betreiber": "Marktverwaltung Rainer Perske\nTel.: 29 77 24 86, Fax: 29 77 25 91",
-                    "email": "mailto:info@mv-perske.de",
-                    "www": "http://www.flohmarktimmauerpark.de",
-                    "bemerkungen": "",
-                    "_wgs84_lat": "52.5419243",
-                    "_wgs84_lon": "13.4018956"
-                }
-            }
-        },
-        {
-            "type": "Feature",
-            "geometry": {
-                "type": "Point",
-                "coordinates": [
-                    12.86189,
-                    52.29768
-                ]
-            },
-            "properties": {
-                "title": "Großer Familien-Flohmarkt in Klaistow",
-                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/360",
-                "description": "23.08., 08.11.<br />10:00 - 16:00<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/360\">Mehr...</a>",
-                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/360",
-                "data": {
-                    "id": "360",
-                    "bezirk": "Brandenburg",
-                    "bezeichnung": "Großer Familien-Flohmarkt in Klaistow",
-                    "strasse": "Glindower Str. 28",
-                    "plz": "14547",
-                    "tage": "23.08., 08.11.",
+                    "id": "268",
+                    "bezirk": "Neukölln",
+                    "bezeichnung": "Die Dicke Linda",
+                    "strasse": "Kranoldplatz",
+                    "plz": "12051",
+                    "tage": "Sa ",
                     "zeiten": "10:00 - 16:00",
-                    "betreiber": "Buschmann & Winkelmann Spargel- und Erlebnishof Klaistow, Glindower Str. 28, 14547 Klaistow, Tel.: 033206/610 70",
-                    "email": "mailto:info@buschmann-winkelmann.de",
-                    "www": "http://www.spargelhof-klaistow.de",
-                    "bemerkungen": "Die verbindliche Stand-Anmeldung ist ab dem 01.02.2020 im Ticketshop auf der Internetseite http://www.spargelhof-klaistow.de möglich.",
-                    "_wgs84_lat": "52.297684",
-                    "_wgs84_lon": "12.8618903"
+                    "betreiber": "diemarktplaner, Dipl.-Ing. Nikolaus Fink, Sanderstr. 4, 12047 Berlin, Tel.: 29 30 96 01, Fax: 29 00 96 23",
+                    "email": "mailto:info@diemarktplaner.de",
+                    "www": "http://www.dicke-linda-markt.de",
+                    "bemerkungen": "",
+                    "_wgs84_lat": "52.46599",
+                    "_wgs84_lon": "13.43798"
                 }
             }
         },
@@ -595,29 +99,60 @@
             "geometry": {
                 "type": "Point",
                 "coordinates": [
-                    13.40073,
-                    52.53735
+                    13.14119,
+                    52.41207
                 ]
             },
             "properties": {
-                "title": "Großer Trödelmarkt am Arkonaplatz",
-                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/150",
-                "description": "So<br />10:00 - 16:00 (Winter)&#10;10:00 - 17:00 (Sommer)<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/150\">Mehr...</a>",
-                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/150",
+                "title": "Dorfmarkt Wannsee",
+                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/310",
+                "description": "Fr<br />14:00 - 18:00<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/310\">Mehr...</a>",
+                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/310",
                 "data": {
-                    "id": "150",
-                    "bezirk": "Mitte",
-                    "bezeichnung": "Großer Trödelmarkt am Arkonaplatz",
-                    "strasse": "Arkonaplatz",
-                    "plz": "10435",
-                    "tage": "So",
-                    "zeiten": "10:00 - 16:00 (Winter)\n10:00 - 17:00 (Sommer)",
-                    "betreiber": "Marktleitung: Hans-Jürgen Müller & Alfred van Loh",
-                    "email": "",
-                    "www": "http://www.troedelmarkt-arkonaplatz.de",
-                    "bemerkungen": "außer Volkstrauertag, Totensonntag, 24. und 31.12.2019",
-                    "_wgs84_lat": "52.53735",
-                    "_wgs84_lon": "13.40073"
+                    "id": "310",
+                    "bezirk": "Steglitz-Zehlendorf",
+                    "bezeichnung": "Dorfmarkt Wannsee",
+                    "strasse": "Wilhelmplatz",
+                    "plz": "14109",
+                    "tage": "Fr",
+                    "zeiten": "14:00 - 18:00",
+                    "betreiber": "diemarktplaner, Dipl.-Ing. Nikolaus Fink, Sanderstr. 4, 12047 Berlin, Tel.: 29 30 96 01, Fax: 29 00 96 23",
+                    "email": "mailto:info@diemarktplaner.de",
+                    "www": "http://www.diemarktplaner.de",
+                    "bemerkungen": "",
+                    "_wgs84_lat": "52.4120708",
+                    "_wgs84_lon": "13.1411862"
+                }
+            }
+        },
+        {
+            "type": "Feature",
+            "geometry": {
+                "type": "Point",
+                "coordinates": [
+                    13.26428,
+                    52.41171
+                ]
+            },
+            "properties": {
+                "title": "Frischemarkt Andréezeile",
+                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/307",
+                "description": "Sa<br />08:00 - 13:00<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/307\">Mehr...</a>",
+                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/307",
+                "data": {
+                    "id": "307",
+                    "bezirk": "Steglitz-Zehlendorf",
+                    "bezeichnung": "Frischemarkt Andréezeile",
+                    "strasse": "Ladiusstraße",
+                    "plz": "14165",
+                    "tage": "Sa",
+                    "zeiten": "08:00 - 13:00",
+                    "betreiber": "diemarktplaner, Dipl.-Ing. Nikolaus Fink, Sanderstr. 4, 12047 Berlin, Tel.: 29 30 96 01, Fax: 29 00 96 23",
+                    "email": "mailto:info@diemarktplaner.de",
+                    "www": "http://www.diemarktplaner.de",
+                    "bemerkungen": "Ecke Andréezeile",
+                    "_wgs84_lat": "52.41171",
+                    "_wgs84_lon": "13.26428"
                 }
             }
         },
@@ -631,14 +166,14 @@
                 ]
             },
             "properties": {
-                "title": "KMA93?Karl-Marx-Allee vor Nr. 93",
-                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/57",
-                "description": "Di, Do<br />10:00 - 16:00<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/57\">Mehr...</a>",
-                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/57",
+                "title": "KMA93 Karl-Marx-Allee vor Nr. 93",
+                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/37",
+                "description": "Di, Do<br />10:00 - 16:00<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/37\">Mehr...</a>",
+                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/37",
                 "data": {
-                    "id": "57",
+                    "id": "37",
                     "bezirk": "Friedrichshain-Kreuzberg",
-                    "bezeichnung": "KMA93?Karl-Marx-Allee vor Nr. 93",
+                    "bezeichnung": "KMA93 Karl-Marx-Allee vor Nr. 93",
                     "strasse": "Karl-Marx-Allee 93",
                     "plz": "10243",
                     "tage": "Di, Do",
@@ -657,203 +192,17 @@
             "geometry": {
                 "type": "Point",
                 "coordinates": [
-                    13.23279,
-                    52.43756
-                ]
-            },
-            "properties": {
-                "title": "KUNST trifft HANDWERK",
-                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/432",
-                "description": "20.09.2020<br />11:00 - 18:00<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/432\">Mehr...</a>",
-                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/432",
-                "data": {
-                    "id": "432",
-                    "bezirk": "Steglitz-Zehlendorf",
-                    "bezeichnung": "KUNST trifft HANDWERK",
-                    "strasse": "Mexikoplatz",
-                    "plz": "14163",
-                    "tage": "20.09.2020",
-                    "zeiten": "11:00 - 18:00",
-                    "betreiber": "Cornelja Hasler, Kunsthand-Berlin, Tel.: 40 63 70 31",
-                    "email": "info@kunsthand-berlin.de",
-                    "www": "www.kunsthand-berlin.de",
-                    "bemerkungen": "Eintritt frei, Handelsware nicht zugelassen, Vorplatz S-Bahnhof Mexikoplatz",
-                    "_wgs84_lat": "52.437559",
-                    "_wgs84_lon": "13.2327904"
-                }
-            }
-        },
-        {
-            "type": "Feature",
-            "geometry": {
-                "type": "Point",
-                "coordinates": [
-                    13.36855,
-                    52.51564
-                ]
-            },
-            "properties": {
-                "title": "Kunst- und Trödelmarkt \nStraße des 17. Juni",
-                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/42",
-                "description": "Sa, So<br />10:00 - 17:00<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/42\">Mehr...</a>",
-                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/42",
-                "data": {
-                    "id": "42",
-                    "bezirk": "Charlottenburg-Wilmersdorf",
-                    "bezeichnung": "Kunst- und Trödelmarkt \nStraße des 17. Juni",
-                    "strasse": "Straße des 17. Juni",
-                    "plz": "10785",
-                    "tage": "Sa, So",
-                    "zeiten": "10:00 - 17:00",
-                    "betreiber": "Wewerka Märkte GmbH, \nTel.: 26 55 00 96",
-                    "email": "mailto:info@berliner-troedelmarkt.de",
-                    "www": "http://www.berliner-troedelmarkt.de",
-                    "bemerkungen": "außer Volkstrauertag, Totensonntag, zusätzliche Termine: 13.04., 01.06.2020. ab ca. 22.03. bis 08.11.2020 So 10:00-17:00 Kunstmarkt",
-                    "_wgs84_lat": "52.5156437",
-                    "_wgs84_lon": "13.3685484"
-                }
-            }
-        },
-        {
-            "type": "Feature",
-            "geometry": {
-                "type": "Point",
-                "coordinates": [
-                    13.31343,
-                    52.49083
-                ]
-            },
-            "properties": {
-                "title": "Kunst- und Trödelmarkt Fehrbelliner Platz",
-                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/45",
-                "description": "Sa, So<br />10:00 - 16:00<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/45\">Mehr...</a>",
-                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/45",
-                "data": {
-                    "id": "45",
-                    "bezirk": "Charlottenburg-Wilmersdorf",
-                    "bezeichnung": "Kunst- und Trödelmarkt Fehrbelliner Platz",
-                    "strasse": "Fehrbelliner Platz",
-                    "plz": "10707",
-                    "tage": "Sa, So",
-                    "zeiten": "10:00 - 16:00",
-                    "betreiber": "Betreiber: André Burdack, Burdack Märkte e.K., Tel.: 24 35 85 10 (Mi-Fr 14:00-18:00), Fax: 24 35 85 11",
-                    "email": "mailto:info@burdack-maerkte.de",
-                    "www": "http://www.burdack-maerkte.de",
-                    "bemerkungen": "außer Volkstrauertag und Totensonntag, U-Bahnhof, zusätzliche Termine: 01.05., 01.06., 03.10. und 26.12.2020",
-                    "_wgs84_lat": "52.4908309",
-                    "_wgs84_lon": "13.3134333"
-                }
-            }
-        },
-        {
-            "type": "Feature",
-            "geometry": {
-                "type": "Point",
-                "coordinates": [
-                    13.35138,
-                    52.49091
-                ]
-            },
-            "properties": {
-                "title": "Kunst-Kreativ-Markt Kiezoase Schöneberg",
-                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/411",
-                "description": "06.06.2020<br />14:00 - 18:00<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/411\">Mehr...</a>",
-                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/411",
-                "data": {
-                    "id": "411",
-                    "bezirk": "Tempelhof-Schöneberg",
-                    "bezeichnung": "Kunst-Kreativ-Markt Kiezoase Schöneberg",
-                    "strasse": "Karl-Schrader-Straße 7-8",
-                    "plz": "10781",
-                    "tage": "06.06.2020",
-                    "zeiten": "14:00 - 18:00",
-                    "betreiber": "Café Kiezoase Schöneberg, Barbarossastr. 65",
-                    "email": "mailto:kiezoase@pfh-berlin.de",
-                    "www": "http://www.kiezoase.de",
-                    "bemerkungen": "für Anbieter ab 13:00",
-                    "_wgs84_lat": "52.4909081",
-                    "_wgs84_lon": "13.3513793"
-                }
-            }
-        },
-        {
-            "type": "Feature",
-            "geometry": {
-                "type": "Point",
-                "coordinates": [
-                    13.39703,
-                    52.51772
-                ]
-            },
-            "properties": {
-                "title": "Kunstmarkt am Zeughaus",
-                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/162",
-                "description": "Sa, So, gesetzliche Feiertage<br />11:00 - 17:00<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/162\">Mehr...</a>",
-                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/162",
-                "data": {
-                    "id": "162",
-                    "bezirk": "Mitte",
-                    "bezeichnung": "Kunstmarkt am Zeughaus",
-                    "strasse": "Unter den Linden 2",
-                    "plz": "10117",
-                    "tage": "Sa, So, gesetzliche Feiertage",
-                    "zeiten": "11:00 - 17:00",
-                    "betreiber": "Herr Schöll, Tel.: 0172/301 88 73",
-                    "email": "",
-                    "www": "",
-                    "bemerkungen": "außer Karfreitag, Volkstrauertag, Totensonntag, 24.12. und 31.12.",
-                    "_wgs84_lat": "52.51772",
-                    "_wgs84_lon": "13.39703"
-                }
-            }
-        },
-        {
-            "type": "Feature",
-            "geometry": {
-                "type": "Point",
-                "coordinates": [
-                    13.32701,
-                    52.42806
-                ]
-            },
-            "properties": {
-                "title": "Landmarkt DIE DICKE LINDA",
-                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/348",
-                "description": "Sa <br />10:00 - 16:00<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/348\">Mehr...</a>",
-                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/348",
-                "data": {
-                    "id": "348",
-                    "bezirk": "Neukölln",
-                    "bezeichnung": "Landmarkt DIE DICKE LINDA",
-                    "strasse": "Kranoldplatz",
-                    "plz": "12209",
-                    "tage": "Sa ",
-                    "zeiten": "10:00 - 16:00",
-                    "betreiber": "diemarktplaner, Dipl.-Ing. Nikolaus Fink, Sanderstr. 4, 12047 Berlin, Tel.: 29 30 96 01, Fax: 29 00 96 23",
-                    "email": "mailto:info@diemarktplaner.de",
-                    "www": "http://www.dicke-linda-markt.de",
-                    "bemerkungen": "An jedem 2. Samstag im Monat mit Live-Musik",
-                    "_wgs84_lat": "52.428055",
-                    "_wgs84_lon": "13.3270148"
-                }
-            }
-        },
-        {
-            "type": "Feature",
-            "geometry": {
-                "type": "Point",
-                "coordinates": [
                     13.21667,
                     52.43872
                 ]
             },
             "properties": {
                 "title": "Markt Schlachtensee (Wochenmarkt)",
-                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/273",
-                "description": "Di, Fr<br />08:00 - 14:00<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/273\">Mehr...</a>",
-                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/273",
+                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/217",
+                "description": "Di, Fr<br />08:00 - 14:00<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/217\">Mehr...</a>",
+                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/217",
                 "data": {
-                    "id": "273",
+                    "id": "217",
                     "bezirk": "Steglitz-Zehlendorf",
                     "bezeichnung": "Markt Schlachtensee (Wochenmarkt)",
                     "strasse": "Matterhornstr. 52/54",
@@ -874,17 +223,17 @@
             "geometry": {
                 "type": "Point",
                 "coordinates": [
-                    13.43172,
-                    52.50198
+                    13.43202,
+                    52.50199
                 ]
             },
             "properties": {
                 "title": "Markthalle Neun",
-                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/69",
-                "description": "Fr&#10;Sa<br />12:00 - 18:00&#10;10:00 - 18:00<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/69\">Mehr...</a>",
-                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/69",
+                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/49",
+                "description": "Fr&#10;Sa<br />12:00 - 18:00&#10;10:00 - 18:00<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/49\">Mehr...</a>",
+                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/49",
                 "data": {
-                    "id": "69",
+                    "id": "49",
                     "bezirk": "Friedrichshain-Kreuzberg",
                     "bezeichnung": "Markthalle Neun",
                     "strasse": "Eisenbahnstraße 42/43",
@@ -895,8 +244,8 @@
                     "email": "mailto:info@markthalleneun.de",
                     "www": "http://www.markthalleneun.de",
                     "bemerkungen": "Street Food Thursday: Do 17:00 - 22:00, Basisangebot Lebensmittel: Di, - Do 12:00 - 18:00, Themenmärkte (Cheese Berlin, Naschmarkt, Berlin Coffee Festival, Brotzeit, Raw Wine, Merry Markthalle, Prosit - der Weinmarkt)",
-                    "_wgs84_lat": "52.5019768",
-                    "_wgs84_lon": "13.4317228"
+                    "_wgs84_lat": "52.5019874",
+                    "_wgs84_lon": "13.432024"
                 }
             }
         },
@@ -911,11 +260,11 @@
             },
             "properties": {
                 "title": "Neuer Markt am Südstern",
-                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/72",
-                "description": "Sa<br />10:00 - 16:00<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/72\">Mehr...</a>",
-                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/72",
+                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/52",
+                "description": "Sa<br />10:00 - 16:00<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/52\">Mehr...</a>",
+                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/52",
                 "data": {
-                    "id": "72",
+                    "id": "52",
                     "bezirk": "Friedrichshain-Kreuzberg",
                     "bezeichnung": "Neuer Markt am Südstern",
                     "strasse": "Südstern",
@@ -925,7 +274,7 @@
                     "betreiber": "diemarktplaner, Dipl.-Ing. Nikolaus Fink, Sanderstr. 4, 12047 Berlin, Tel.: 29 30 96 01, Fax: 29 00 96 23",
                     "email": "mailto:info@diemarktplaner.de",
                     "www": "http://www.diemarktplaner.de",
-                    "bemerkungen": "",
+                    "bemerkungen": "U-Südstern",
                     "_wgs84_lat": "52.4894657",
                     "_wgs84_lon": "13.4066445"
                 }
@@ -942,11 +291,11 @@
             },
             "properties": {
                 "title": "Neuköllner Stoff am Maybachufer",
-                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/189",
-                "description": "Sa<br />11:00 - 17:00<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/189\">Mehr...</a>",
-                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/189",
+                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/148",
+                "description": "Sa<br />11:00 - 17:00<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/148\">Mehr...</a>",
+                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/148",
                 "data": {
-                    "id": "189",
+                    "id": "148",
                     "bezirk": "Neukölln",
                     "bezeichnung": "Neuköllner Stoff am Maybachufer",
                     "strasse": "Maybachufer 31",
@@ -972,14 +321,14 @@
                 ]
             },
             "properties": {
-                "title": "Neuköllner Wochenmärkte Britz-Süd",
-                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/171",
-                "description": "Mo, Do&#10;Sa<br />08:00 - 13:00&#10;08:00 - 14:00<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/171\">Mehr...</a>",
-                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/171",
+                "title": "Neuköllner Wochenmärkte Britz-Süd \"Frisches vom Markt\"",
+                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/130",
+                "description": "Mo, Do&#10;Sa<br />08:00 - 13:00&#10;08:00 - 14:00<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/130\">Mehr...</a>",
+                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/130",
                 "data": {
-                    "id": "171",
+                    "id": "130",
                     "bezirk": "Neukölln",
-                    "bezeichnung": "Neuköllner Wochenmärkte Britz-Süd",
+                    "bezeichnung": "Neuköllner Wochenmärkte Britz-Süd \"Frisches vom Markt\"",
                     "strasse": "Gutschmidtstraße",
                     "plz": "12359",
                     "tage": "Mo, Do\nSa",
@@ -987,7 +336,7 @@
                     "betreiber": "diemarktplaner, Dipl.-Ing. Nikolaus Fink, Sanderstr. 4, 12047 Berlin, Tel.: 29 30 96 01, Fax: 29 00 96 23",
                     "email": "mailto:info@diemarktplaner.de",
                     "www": "http://www.diemarktplaner.de",
-                    "bemerkungen": "Ecke Fritz-Reuter-Allee\nApril bis Dezember mit Flohmarkt. Von April bis September an jedem 1. Samstag mit Marktbühne von 11:00-14:00 Uhr",
+                    "bemerkungen": "Ecke Fritz-Reuter-Allee, Sa ab 03.04.2021 mit Flohmarkt 08:00 - 14:00\n",
                     "_wgs84_lat": "52.43757",
                     "_wgs84_lon": "13.4491801"
                 }
@@ -1003,14 +352,14 @@
                 ]
             },
             "properties": {
-                "title": "Neuköllner Wochenmärkte Hermannplatz",
-                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/174",
-                "description": "Mo - Fr<br />10:00 - 18:00<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/174\">Mehr...</a>",
-                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/174",
+                "title": "Neuköllner Wochenmärkte Hermannplatz \"Marktfood - vor Ort und für Zuhause\"",
+                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/133",
+                "description": "Mo - Fr<br />10:00 - 18:00<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/133\">Mehr...</a>",
+                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/133",
                 "data": {
-                    "id": "174",
+                    "id": "133",
                     "bezirk": "Neukölln",
-                    "bezeichnung": "Neuköllner Wochenmärkte Hermannplatz",
+                    "bezeichnung": "Neuköllner Wochenmärkte Hermannplatz \"Marktfood - vor Ort und für Zuhause\"",
                     "strasse": "Hermannplatz",
                     "plz": "10967",
                     "tage": "Mo - Fr",
@@ -1018,7 +367,7 @@
                     "betreiber": "diemarktplaner, Dipl.-Ing. Nikolaus Fink, Sanderstr. 4, 12047 Berlin, Tel.: 29 30 96 01, Fax: 29 00 96 23",
                     "email": "mailto:info@diemarktplaner.de",
                     "www": "http://www.diemarktplaner.de",
-                    "bemerkungen": "Von April bis Oktober jeden 1. Donnerstag im Monat Marktbühne von 13:00 - 17:00 Uhr",
+                    "bemerkungen": "Mittelinsel",
                     "_wgs84_lat": "52.48727",
                     "_wgs84_lon": "13.42438"
                 }
@@ -1029,20 +378,20 @@
             "geometry": {
                 "type": "Point",
                 "coordinates": [
-                    13.43125,
-                    52.49248
+                    13.42666,
+                    52.49234
                 ]
             },
             "properties": {
                 "title": "Neuköllner Wochenmärkte Maybachufer",
-                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/177",
-                "description": "Di, Fr<br />11:00 - 18:30<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/177\">Mehr...</a>",
-                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/177",
+                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/136",
+                "description": "Di, Fr<br />11:00 - 18:30<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/136\">Mehr...</a>",
+                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/136",
                 "data": {
-                    "id": "177",
+                    "id": "136",
                     "bezirk": "Neukölln",
                     "bezeichnung": "Neuköllner Wochenmärkte Maybachufer",
-                    "strasse": "Maybachufer 31",
+                    "strasse": "Maybachufer 1 - 13",
                     "plz": "12047",
                     "tage": "Di, Fr",
                     "zeiten": "11:00 - 18:30",
@@ -1050,8 +399,8 @@
                     "email": "mailto:info@diemarktplaner.de",
                     "www": "http://www.diemarktplaner.de",
                     "bemerkungen": "",
-                    "_wgs84_lat": "52.4924786",
-                    "_wgs84_lon": "13.4312533"
+                    "_wgs84_lat": "52.4923377",
+                    "_wgs84_lon": "13.426662"
                 }
             }
         },
@@ -1065,14 +414,14 @@
                 ]
             },
             "properties": {
-                "title": "Neuköllner Wochenmärkte Parchimer Allee",
-                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/180",
-                "description": "Fr<br />10:00 - 18:00<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/180\">Mehr...</a>",
-                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/180",
+                "title": "Neuköllner Wochenmärkte Parchimer Allee \"Freitagsmarkt bis abends!\"",
+                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/139",
+                "description": "Fr<br />10:00 - 18:00<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/139\">Mehr...</a>",
+                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/139",
                 "data": {
-                    "id": "180",
+                    "id": "139",
                     "bezirk": "Neukölln",
-                    "bezeichnung": "Neuköllner Wochenmärkte Parchimer Allee",
+                    "bezeichnung": "Neuköllner Wochenmärkte Parchimer Allee \"Freitagsmarkt bis abends!\"",
                     "strasse": "Fritz-Reuter-Allee 73",
                     "plz": "12359",
                     "tage": "Fr",
@@ -1096,14 +445,14 @@
                 ]
             },
             "properties": {
-                "title": "Neuköllner Wochenmärkte Rixdorf",
-                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/165",
-                "description": "Mi&#10;Sa<br />11:00 - 18:00&#10;08:00 - 15:00<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/165\">Mehr...</a>",
-                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/165",
+                "title": "Neuköllner Wochenmärkte Rixdorf \"Gesunder Genuss auf dem Rixdorfer Markt\"",
+                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/124",
+                "description": "Mi&#10;Sa<br />11:00 - 18:00&#10;08:00 - 15:00<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/124\">Mehr...</a>",
+                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/124",
                 "data": {
-                    "id": "165",
+                    "id": "124",
                     "bezirk": "Neukölln",
-                    "bezeichnung": "Neuköllner Wochenmärkte Rixdorf",
+                    "bezeichnung": "Neuköllner Wochenmärkte Rixdorf \"Gesunder Genuss auf dem Rixdorfer Markt\"",
                     "strasse": "Karl-Marx-Platz",
                     "plz": "12043",
                     "tage": "Mi\nSa",
@@ -1122,29 +471,29 @@
             "geometry": {
                 "type": "Point",
                 "coordinates": [
-                    13.4927,
-                    52.42258
+                    13.49286,
+                    52.42252
                 ]
             },
             "properties": {
-                "title": "Neuköllner Wochenmärkte Rudow",
-                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/168",
-                "description": "Mi, Sa<br />08:00 - 13:00<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/168\">Mehr...</a>",
-                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/168",
+                "title": "Neuköllner Wochenmärkte Rudow \"Regionale Qualität in Rudow\"",
+                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/127",
+                "description": "Mi, Sa<br />08:00 - 13:00<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/127\">Mehr...</a>",
+                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/127",
                 "data": {
-                    "id": "168",
+                    "id": "127",
                     "bezirk": "Neukölln",
-                    "bezeichnung": "Neuköllner Wochenmärkte Rudow",
+                    "bezeichnung": "Neuköllner Wochenmärkte Rudow \"Regionale Qualität in Rudow\"",
                     "strasse": "Prierosser Straße",
-                    "plz": "12357",
+                    "plz": "12355",
                     "tage": "Mi, Sa",
                     "zeiten": "08:00 - 13:00",
                     "betreiber": "diemarktplaner, Dipl.-Ing. Nikolaus Fink, Sanderstr. 4, 12047 Berlin, Tel.: 29 30 96 01, Fax: 29 00 96 23",
                     "email": "mailto:info@diemarktplaner.de",
                     "www": "http://www.diemarktplaner.de",
-                    "bemerkungen": "Juni - September jeden 1. Sa im Monat 10:00-13:00 Marktbühne mit Musik und Artistik",
-                    "_wgs84_lat": "52.4225823",
-                    "_wgs84_lon": "13.4927036"
+                    "bemerkungen": "",
+                    "_wgs84_lat": "52.4225223",
+                    "_wgs84_lon": "13.4928551"
                 }
             }
         },
@@ -1153,17 +502,17 @@
             "geometry": {
                 "type": "Point",
                 "coordinates": [
-                    13.47461,
-                    52.4233
+                    13.47533,
+                    52.42332
                 ]
             },
             "properties": {
                 "title": "Neuköllner Wochenmärkte Wutzkyallee",
-                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/183",
-                "description": "Mi&#10;Sa<br />08:00 - 14:00&#10;08:00 - 13:00<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/183\">Mehr...</a>",
-                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/183",
+                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/142",
+                "description": "Mi&#10;Sa<br />08:00 - 14:00&#10;08:00 - 13:00<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/142\">Mehr...</a>",
+                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/142",
                 "data": {
-                    "id": "183",
+                    "id": "142",
                     "bezirk": "Neukölln",
                     "bezeichnung": "Neuköllner Wochenmärkte Wutzkyallee",
                     "strasse": "Rotraut-Richter-Platz",
@@ -1173,536 +522,9 @@
                     "betreiber": "diemarktplaner, Dipl.-Ing. Nikolaus Fink, Sanderstr. 4, 12047 Berlin, Tel.: 29 30 96 01, Fax: 29 00 96 23",
                     "email": "mailto:info@diemarktplaner.de",
                     "www": "http://www.diemarktplaner.de",
-                    "bemerkungen": "An jedem letzten Samstag im Monat von April bis September mit Marktbühne von 10:00 - 13:00 Uhr",
-                    "_wgs84_lat": "52.4233011",
-                    "_wgs84_lon": "13.4746142"
-                }
-            }
-        },
-        {
-            "type": "Feature",
-            "geometry": {
-                "type": "Point",
-                "coordinates": [
-                    13.43125,
-                    52.49248
-                ]
-            },
-            "properties": {
-                "title": "Nowkoelln Flowmarkt",
-                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/405",
-                "description": "24.05., 07.06., 21.06., 05.07., &#10;19.07., 02.08., 16.08., 30.08., 13.09., &#10;27.09., 11.10., 25.10., 08.11., 29.11.2020<br />10:00 - 17:00<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/405\">Mehr...</a>",
-                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/405",
-                "data": {
-                    "id": "405",
-                    "bezirk": "Neukölln",
-                    "bezeichnung": "Nowkoelln Flowmarkt",
-                    "strasse": "Maybachufer 31",
-                    "plz": "12047",
-                    "tage": "24.05., 07.06., 21.06., 05.07., \n19.07., 02.08., 16.08., 30.08., 13.09., \n27.09., 11.10., 25.10., 08.11., 29.11.2020",
-                    "zeiten": "10:00 - 17:00",
-                    "betreiber": "Michael Groß",
-                    "email": "mailto:info@nowkoelln.de",
-                    "www": "http://www.flowmarkt.de/nowkoelln.de",
-                    "bemerkungen": "Ecke Liberdastraße",
-                    "_wgs84_lat": "52.4924786",
-                    "_wgs84_lon": "13.4312533"
-                }
-            }
-        },
-        {
-            "type": "Feature",
-            "geometry": {
-                "type": "Point",
-                "coordinates": [
-                    13.52483,
-                    52.47843
-                ]
-            },
-            "properties": {
-                "title": "Riesenflohmarkt Trabrennbahn Karlshorst",
-                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/381",
-                "description": "03. - 04.10.2020<br />09:00 - 17:00<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/381\">Mehr...</a>",
-                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/381",
-                "data": {
-                    "id": "381",
-                    "bezirk": "Lichtenberg",
-                    "bezeichnung": "Riesenflohmarkt Trabrennbahn Karlshorst",
-                    "strasse": "Treskowallee 129",
-                    "plz": "10318",
-                    "tage": "03. - 04.10.2020",
-                    "zeiten": "09:00 - 17:00",
-                    "betreiber": "Oldthing Marktveranstaltung, Tel.: 29 00 20 10",
-                    "email": "mailto:info@oldthing.de",
-                    "www": "http://www.oldthing.de",
-                    "bemerkungen": "",
-                    "_wgs84_lat": "52.47843",
-                    "_wgs84_lon": "13.52483"
-                }
-            }
-        },
-        {
-            "type": "Feature",
-            "geometry": {
-                "type": "Point",
-                "coordinates": [
-                    13.52483,
-                    52.47843
-                ]
-            },
-            "properties": {
-                "title": "Sammlerbörse Trabrennbahn Karlshorst, Tribünenhalle",
-                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/384",
-                "description": "03.10.2020<br />09:00 - 17:00<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/384\">Mehr...</a>",
-                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/384",
-                "data": {
-                    "id": "384",
-                    "bezirk": "Lichtenberg",
-                    "bezeichnung": "Sammlerbörse Trabrennbahn Karlshorst, Tribünenhalle",
-                    "strasse": "Treskowallee 129",
-                    "plz": "10318",
-                    "tage": "03.10.2020",
-                    "zeiten": "09:00 - 17:00",
-                    "betreiber": "Oldthing Marktveranstaltung, Tel.: 29 00 20 10",
-                    "email": "mailto:info@oldthing.de",
-                    "www": "http://www.oldthing.de",
-                    "bemerkungen": "",
-                    "_wgs84_lat": "52.47843",
-                    "_wgs84_lon": "13.52483"
-                }
-            }
-        },
-        {
-            "type": "Feature",
-            "geometry": {
-                "type": "Point",
-                "coordinates": [
-                    13.39514,
-                    52.48959
-                ]
-            },
-            "properties": {
-                "title": "Trödelmarkt Bergmannstraße",
-                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/78",
-                "description": "Sa&#10;So<br />10:00 - 16:00&#10;11:00 - 17:00<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/78\">Mehr...</a>",
-                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/78",
-                "data": {
-                    "id": "78",
-                    "bezirk": "Friedrichshain-Kreuzberg",
-                    "bezeichnung": "Trödelmarkt Bergmannstraße",
-                    "strasse": "Marheinekeplatz",
-                    "plz": "10961",
-                    "tage": "Sa\nSo",
-                    "zeiten": "10:00 - 16:00\n11:00 - 17:00",
-                    "betreiber": "Marktleitung: \nMario Krüger, Tel.: 0172/958 91 57",
-                    "email": "",
-                    "www": "",
-                    "bemerkungen": "im Winter So bis 16:00\naußer Volkstrauertag, Totensonntag",
-                    "_wgs84_lat": "52.48959",
-                    "_wgs84_lon": "13.39514"
-                }
-            }
-        },
-        {
-            "type": "Feature",
-            "geometry": {
-                "type": "Point",
-                "coordinates": [
-                    13.45999,
-                    52.51172
-                ]
-            },
-            "properties": {
-                "title": "Trödelmarkt Boxhagener Platz",
-                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/390",
-                "description": "So<br />10:00 - 18:00<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/390\">Mehr...</a>",
-                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/390",
-                "data": {
-                    "id": "390",
-                    "bezirk": "Friedrichshain-Kreuzberg",
-                    "bezeichnung": "Trödelmarkt Boxhagener Platz",
-                    "strasse": "Grünberger Straße 75",
-                    "plz": "10245",
-                    "tage": "So",
-                    "zeiten": "10:00 - 18:00",
-                    "betreiber": "Marktleitung: Herr Walk, Tel.: 0162/292 30 66",
-                    "email": "",
-                    "www": "",
-                    "bemerkungen": "außer Volkstrauertag und Totensonntag",
-                    "_wgs84_lat": "52.5117187",
-                    "_wgs84_lon": "13.4599934"
-                }
-            }
-        },
-        {
-            "type": "Feature",
-            "geometry": {
-                "type": "Point",
-                "coordinates": [
-                    13.42199,
-                    52.45337
-                ]
-            },
-            "properties": {
-                "title": "Trödelmarkt Hornbach Neukölln",
-                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/414",
-                "description": "So<br />07:00 - 14:00<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/414\">Mehr...</a>",
-                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/414",
-                "data": {
-                    "id": "414",
-                    "bezirk": "Neukölln",
-                    "bezeichnung": "Trödelmarkt Hornbach Neukölln",
-                    "strasse": "Gradestraße 100",
-                    "plz": "12347",
-                    "tage": "So",
-                    "zeiten": "07:00 - 14:00",
-                    "betreiber": "Höfges Veranstaltungspool GmbH, Krefeld\nTel.: 02151/659 17 17, Fax 02151/659 17 18",
-                    "email": "",
-                    "www": "http://www.hoefges.de",
-                    "bemerkungen": "außer\nVolkstrauertag, Totensonntag und evtl. verkaufsoffenen Sonntagen",
-                    "_wgs84_lat": "52.4533739",
-                    "_wgs84_lon": "13.4219909"
-                }
-            }
-        },
-        {
-            "type": "Feature",
-            "geometry": {
-                "type": "Point",
-                "coordinates": [
-                    13.51498,
-                    52.53494
-                ]
-            },
-            "properties": {
-                "title": "Trödelmarkt Landsberger Allee auf dem IKEA Parkplatz",
-                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/408",
-                "description": "So<br />09:00 - 15:00<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/408\">Mehr...</a>",
-                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/408",
-                "data": {
-                    "id": "408",
-                    "bezirk": "Lichtenberg",
-                    "bezeichnung": "Trödelmarkt Landsberger Allee auf dem IKEA Parkplatz",
-                    "strasse": "Landsberger Allee 364",
-                    "plz": "10365",
-                    "tage": "So",
-                    "zeiten": "09:00 - 15:00",
-                    "betreiber": "Marktleitung: B-B-M Berlin-Brandenburger Markt Veranstaltungs- und Service GmbH, \nFrau Hintsche, Tel.: 23 63 63 60 (Di-Fr 10:00-16:00, Mo, So Ruhetag) und 0172/188 31 57 (Di-Sa 06:00-18:00, Mo, So Ruhetag), Fax: 23 63 63 61 (24h täglich)",
-                    "email": "mailto:info@bbm-maerkte.de",
-                    "www": "http://www.bbm-maerkte.de",
-                    "bemerkungen": "Reservierungen über WhatsApp oder SMS unter 0172/188 31 57. Außer an verkaufsoffenen Sonntagen und Feiertagen",
-                    "_wgs84_lat": "52.53494",
-                    "_wgs84_lon": "13.51498"
-                }
-            }
-        },
-        {
-            "type": "Feature",
-            "geometry": {
-                "type": "Point",
-                "coordinates": [
-                    13.39007,
-                    52.41248
-                ]
-            },
-            "properties": {
-                "title": "Trödelmarkt METRO Marienfelde",
-                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/312",
-                "description": "So<br />07:00 - 14:00<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/312\">Mehr...</a>",
-                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/312",
-                "data": {
-                    "id": "312",
-                    "bezirk": "Tempelhof-Schöneberg",
-                    "bezeichnung": "Trödelmarkt METRO Marienfelde",
-                    "strasse": "Buckower Chaussee 25-35",
-                    "plz": "12277",
-                    "tage": "So",
-                    "zeiten": "07:00 - 14:00",
-                    "betreiber": "Höfges Veranstaltungspool GmbH, Krefeld\nTel.: 02151/659 17 17, Fax: 02151/659 17 18",
-                    "email": "",
-                    "www": "http://www.hoefges.de",
-                    "bemerkungen": "Metroparkplatz\naußer\nVolkstrauertag, Totensonntag und evtl. verkaufsoffenen Sonntagen",
-                    "_wgs84_lat": "52.41248",
-                    "_wgs84_lon": "13.39007"
-                }
-            }
-        },
-        {
-            "type": "Feature",
-            "geometry": {
-                "type": "Point",
-                "coordinates": [
-                    13.2453,
-                    52.53982
-                ]
-            },
-            "properties": {
-                "title": "Trödelmarkt METRO Spandau",
-                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/249",
-                "description": "So<br />07:00 - 14:00<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/249\">Mehr...</a>",
-                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/249",
-                "data": {
-                    "id": "249",
-                    "bezirk": "Spandau",
-                    "bezeichnung": "Trödelmarkt METRO Spandau",
-                    "strasse": "Nonnendammallee 135",
-                    "plz": "13599",
-                    "tage": "So",
-                    "zeiten": "07:00 - 14:00",
-                    "betreiber": "Höfges Veranstaltungspool GmbH, Krefeld\nTel.: 02151/659 17 17, Fax 02151/659 17 18",
-                    "email": "",
-                    "www": "http://www.hoefges.de",
-                    "bemerkungen": "Metroparkplatz; außer Volkstrauertag, Totensonntag und evtl. verkaufsoffenen Sonntagen",
-                    "_wgs84_lat": "52.53982",
-                    "_wgs84_lon": "13.2453"
-                }
-            }
-        },
-        {
-            "type": "Feature",
-            "geometry": {
-                "type": "Point",
-                "coordinates": [
-                    13.36583,
-                    52.56079
-                ]
-            },
-            "properties": {
-                "title": "Trödelmarkt Markstraße",
-                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/417",
-                "description": "So<br />07:00 - 15:30<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/417\">Mehr...</a>",
-                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/417",
-                "data": {
-                    "id": "417",
-                    "bezirk": "Reinickendorf",
-                    "bezeichnung": "Trödelmarkt Markstraße",
-                    "strasse": "Markstraße 32-34",
-                    "plz": "13409",
-                    "tage": "So",
-                    "zeiten": "07:00 - 15:30",
-                    "betreiber": "Betreiber: Herr Yesildag, Tel.: 38 30 70 44 und 0179/483 05 42, Fax: 38 30 85 75",
-                    "email": "",
-                    "www": "http://www.troedelmarkt.berlin",
-                    "bemerkungen": "Edeka-Parkplatz, außer Volkstrauertag und Totensonntag",
-                    "_wgs84_lat": "52.560786",
-                    "_wgs84_lon": "13.3658304"
-                }
-            }
-        },
-        {
-            "type": "Feature",
-            "geometry": {
-                "type": "Point",
-                "coordinates": [
-                    13.32806,
-                    52.57014
-                ]
-            },
-            "properties": {
-                "title": "Trödelmarkt Ollenhauerstraße",
-                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/420",
-                "description": "So<br />08:00 - 16:00<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/420\">Mehr...</a>",
-                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/420",
-                "data": {
-                    "id": "420",
-                    "bezirk": "Reinickendorf",
-                    "bezeichnung": "Trödelmarkt Ollenhauerstraße",
-                    "strasse": "Ollenhauerstraße 107",
-                    "plz": "13403",
-                    "tage": "So",
-                    "zeiten": "08:00 - 16:00",
-                    "betreiber": "Betreiber: Herr Yesildag, Tel.: 38 30 70 44 und 0179/483 05 42, Fax: 38 30 85 75",
-                    "email": "",
-                    "www": "http://www.troedelmarkt.berlin",
-                    "bemerkungen": "Edeka-Parkplatz, außer Volkstrauertag und Totensonntag, an verkaufsoffenen Sonntagen 08:00 - 13:00",
-                    "_wgs84_lat": "52.5701376",
-                    "_wgs84_lon": "13.328056"
-                }
-            }
-        },
-        {
-            "type": "Feature",
-            "geometry": {
-                "type": "Point",
-                "coordinates": [
-                    13.36355,
-                    52.56023
-                ]
-            },
-            "properties": {
-                "title": "Trödelmarkt Schuhcenter Siemes Wedding, Parkplatz",
-                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/231",
-                "description": "So<br />07:00 - 14:00<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/231\">Mehr...</a>",
-                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/231",
-                "data": {
-                    "id": "231",
-                    "bezirk": "Mitte",
-                    "bezeichnung": "Trödelmarkt Schuhcenter Siemes Wedding, Parkplatz",
-                    "strasse": "Markstr. 17 - 18",
-                    "plz": "13409",
-                    "tage": "So",
-                    "zeiten": "07:00 - 14:00",
-                    "betreiber": "Höfges Veranstaltungspool GmbH, Krefeld\nTel.: 02151/659 17 17, Fax 02151/659 17 18",
-                    "email": "",
-                    "www": "http://www.hoefges.de",
-                    "bemerkungen": "außer Volkstrauertag, Totensonntag und evtl. verkaufsoffenen Sonntagen",
-                    "_wgs84_lat": "52.5602336",
-                    "_wgs84_lon": "13.363551"
-                }
-            }
-        },
-        {
-            "type": "Feature",
-            "geometry": {
-                "type": "Point",
-                "coordinates": [
-                    13.31586,
-                    52.48215
-                ]
-            },
-            "properties": {
-                "title": "Trödelmarkt an der Mecklenburgischen Straße",
-                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/48",
-                "description": "So<br />08:00 - 16:00<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/48\">Mehr...</a>",
-                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/48",
-                "data": {
-                    "id": "48",
-                    "bezirk": "Charlottenburg-Wilmersdorf",
-                    "bezeichnung": "Trödelmarkt an der Mecklenburgischen Straße",
-                    "strasse": "Mecklenburgische Straße",
-                    "plz": "14197",
-                    "tage": "So",
-                    "zeiten": "08:00 - 16:00",
-                    "betreiber": "Betreiber: Jörg Rau, Tel.: 01573/797 39 26",
-                    "email": "",
-                    "www": "http://www.der-mecklenburger-troedelmarkt.de",
-                    "bemerkungen": "Parkplatz Edeka, Wiesbadener Str. 53 Ecke Mecklenburgische Straße\naußer Volkstrauertag, Totensonntag sowie an verkaufsoffenen Sonntagen",
-                    "_wgs84_lat": "52.4821477",
-                    "_wgs84_lon": "13.3158565"
-                }
-            }
-        },
-        {
-            "type": "Feature",
-            "geometry": {
-                "type": "Point",
-                "coordinates": [
-                    13.32166,
-                    52.45685
-                ]
-            },
-            "properties": {
-                "title": "Trödelmarkt auf dem Hermann-Ehlers-Platz",
-                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/282",
-                "description": "So<br />07:00 - 16:00<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/282\">Mehr...</a>",
-                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/282",
-                "data": {
-                    "id": "282",
-                    "bezirk": "Steglitz-Zehlendorf",
-                    "bezeichnung": "Trödelmarkt auf dem Hermann-Ehlers-Platz",
-                    "strasse": "Hermann-Ehlers-Platz",
-                    "plz": "12165",
-                    "tage": "So",
-                    "zeiten": "07:00 - 16:00",
-                    "betreiber": "Juliane Glowka-Lessow, Tel.: 796 14 00",
-                    "email": "",
-                    "www": "",
-                    "bemerkungen": "außer Volkstrauertag und Totensonntag",
-                    "_wgs84_lat": "52.4568489",
-                    "_wgs84_lon": "13.3216632"
-                }
-            }
-        },
-        {
-            "type": "Feature",
-            "geometry": {
-                "type": "Point",
-                "coordinates": [
-                    13.34306,
-                    52.48535
-                ]
-            },
-            "properties": {
-                "title": "Trödelmarkt auf dem John-F.-Kennedy-Platz",
-                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/309",
-                "description": "Sa, So<br />08:00 - 16:00<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/309\">Mehr...</a>",
-                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/309",
-                "data": {
-                    "id": "309",
-                    "bezirk": "Tempelhof-Schöneberg",
-                    "bezeichnung": "Trödelmarkt auf dem John-F.-Kennedy-Platz",
-                    "strasse": "John-F.-Kennedy-Platz 1",
-                    "plz": "10825",
-                    "tage": "Sa, So",
-                    "zeiten": "08:00 - 16:00",
-                    "betreiber": "Jörg Thurmann, \nTel.: 03322/21 08 68 (Mo-Fr 09:00-17:00), Fax: 03322/24 67 24",
-                    "email": "mailto:j.thurmann@tts-wc.de",
-                    "www": "http://www.berlin-flohmaerkte.de",
-                    "bemerkungen": "außer Wochenende 28./29.09.2019, Volkstrauertag und Totensonntag, info@berlin-flohmaerkte.de",
-                    "_wgs84_lat": "52.4853514",
-                    "_wgs84_lon": "13.3430559"
-                }
-            }
-        },
-        {
-            "type": "Feature",
-            "geometry": {
-                "type": "Point",
-                "coordinates": [
-                    13.35989,
-                    52.54752
-                ]
-            },
-            "properties": {
-                "title": "Trödelmarkt auf dem Leopoldplatz",
-                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/156",
-                "description": "Sa<br />10:00 - 16:00 (Sommer)&#10;10:00 - 15:00 (Winter)<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/156\">Mehr...</a>",
-                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/156",
-                "data": {
-                    "id": "156",
-                    "bezirk": "Mitte",
-                    "bezeichnung": "Trödelmarkt auf dem Leopoldplatz",
-                    "strasse": "Leopoldplatz",
-                    "plz": "13353",
-                    "tage": "Sa",
-                    "zeiten": "10:00 - 16:00 (Sommer)\n10:00 - 15:00 (Winter)",
-                    "betreiber": "Marktleitung: B-B-M Berlin-Brandenburger Markt Veranstaltungs- und Service GmbH, \nFrau Hintsche, Tel.: 23 63 63 60 (Di-Fr 10:00-16:00, Mo, So Ruhetag) und 0172/188 31 57 (Di-Sa 06:00-18:00, Mo, So Ruhetag), Fax: 23 63 63 61 (24h täglich)",
-                    "email": "mailto:info@bbm-maerkte.de",
-                    "www": "http://www.bbm-maerkte.de",
-                    "bemerkungen": "",
-                    "_wgs84_lat": "52.5475193",
-                    "_wgs84_lon": "13.3598859"
-                }
-            }
-        },
-        {
-            "type": "Feature",
-            "geometry": {
-                "type": "Point",
-                "coordinates": [
-                    13.20388,
-                    52.53726
-                ]
-            },
-            "properties": {
-                "title": "WeinSommer in Verbindung mit dem Spandauer Altstadtfest",
-                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/252",
-                "description": "27.08.2020&#10;28.08.2020&#10;29.08.2020&#10;30.09.2020<br />&#10;&#10;&#10;&#10;&#10;&#10;&#10;&#10;&#10;&#10;&#10;&#10;&#10;&#10;15:00-23:00&#10;11:00-24:00&#10;11:00-24:00&#10;11:00-20:00<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/252\">Mehr...</a>",
-                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/252",
-                "data": {
-                    "id": "252",
-                    "bezirk": "Spandau",
-                    "bezeichnung": "WeinSommer in Verbindung mit dem Spandauer Altstadtfest",
-                    "strasse": "Markt 1",
-                    "plz": "13597",
-                    "tage": "27.08.2020\n28.08.2020\n29.08.2020\n30.09.2020",
-                    "zeiten": "\n\n\n\n\n\n\n\n\n\n\n\n\n\n15:00-23:00\n11:00-24:00\n11:00-24:00\n11:00-20:00",
-                    "betreiber": "Partner für Spandau Gesellschaft für Bezirks-Marketing mbH, Geschäftsführung/Händlerinformation: Sven-Uwe Dettmann, Tel.: 36 75 72 61, Fax: 35 30 23 32",
-                    "email": "mailto:info@partner-fuer-spandau.de",
-                    "www": "http://www.partner-fuer-spandau.de",
-                    "bemerkungen": "Marktplatz und Fußgängerzone Altstadt Spandau\nEintritt frei, mehr als ein Dutzend rheinland-pfälzische Weingüter präsentieren ihre edlen Rebensäfte. Zahlreiche Spezialitätenstände entlang der Carl-Schurz-Straße laden zusätzlich zum Verweilen ein.",
-                    "_wgs84_lat": "52.53726",
-                    "_wgs84_lon": "13.20388"
+                    "bemerkungen": "Gropiusstadt",
+                    "_wgs84_lat": "52.423324",
+                    "_wgs84_lon": "13.4753291"
                 }
             }
         },
@@ -1717,11 +539,11 @@
             },
             "properties": {
                 "title": "Wittenbergplatz (Nordseite)\nBrandenburger Bauernmarkt",
-                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/306",
-                "description": "Do<br />09:00 - 17:00<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/306\">Mehr...</a>",
-                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/306",
+                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/247",
+                "description": "Do<br />09:00 - 17:00<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/247\">Mehr...</a>",
+                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/247",
                 "data": {
-                    "id": "306",
+                    "id": "247",
                     "bezirk": "Tempelhof-Schöneberg",
                     "bezeichnung": "Wittenbergplatz (Nordseite)\nBrandenburger Bauernmarkt",
                     "strasse": "Wittenbergplatz 5",
@@ -1748,11 +570,11 @@
             },
             "properties": {
                 "title": "Wochenmarkt Adlershof",
-                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/393",
-                "description": "Mi, Do<br />08:00 - 16:00<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/393\">Mehr...</a>",
-                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/393",
+                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/295",
+                "description": "Mi, Do<br />08:00 - 16:00<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/295\">Mehr...</a>",
+                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/295",
                 "data": {
-                    "id": "393",
+                    "id": "295",
                     "bezirk": "Treptow-Köpenick",
                     "bezeichnung": "Wochenmarkt Adlershof",
                     "strasse": "Dörpfeldstraße",
@@ -1779,11 +601,11 @@
             },
             "properties": {
                 "title": "Wochenmarkt Altstadt Spandau - Markt\nHavelländischer Land- und Bauernmarkt",
-                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/240",
-                "description": "Mo, Di, Do, Fr<br />ab 09:00<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/240\">Mehr...</a>",
-                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/240",
+                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/196",
+                "description": "Mo, Di, Do, Fr<br />ab 09:00<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/196\">Mehr...</a>",
+                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/196",
                 "data": {
-                    "id": "240",
+                    "id": "196",
                     "bezirk": "Spandau",
                     "bezeichnung": "Wochenmarkt Altstadt Spandau - Markt\nHavelländischer Land- und Bauernmarkt",
                     "strasse": "Markt 3",
@@ -1810,11 +632,11 @@
             },
             "properties": {
                 "title": "Wochenmarkt Am Kaufhof Ostbahnhof\n(Erich-Steinfurth-Straße)",
-                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/63",
-                "description": "Mo - Sa&#10;(Sommer)<br />09:00 - 18:00<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/63\">Mehr...</a>",
-                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/63",
+                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/43",
+                "description": "Mo - Sa&#10;(Sommer)<br />09:00 - 18:00<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/43\">Mehr...</a>",
+                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/43",
                 "data": {
-                    "id": "63",
+                    "id": "43",
                     "bezirk": "Friedrichshain-Kreuzberg",
                     "bezeichnung": "Wochenmarkt Am Kaufhof Ostbahnhof\n(Erich-Steinfurth-Straße)",
                     "strasse": "Ostbahnhof",
@@ -1841,11 +663,11 @@
             },
             "properties": {
                 "title": "Wochenmarkt Am Nauener Tor\n14467 Potsdam",
-                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/336",
-                "description": "Mi, Sa<br />09:00 - 16:00<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/336\">Mehr...</a>",
-                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/336",
+                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/262",
+                "description": "Mi, Sa<br />09:00 - 16:00<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/262\">Mehr...</a>",
+                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/262",
                 "data": {
-                    "id": "336",
+                    "id": "262",
                     "bezirk": "Brandenburg",
                     "bezeichnung": "Wochenmarkt Am Nauener Tor\n14467 Potsdam",
                     "strasse": "Hegelallee 55",
@@ -1866,17 +688,17 @@
             "geometry": {
                 "type": "Point",
                 "coordinates": [
-                    13.5801,
+                    13.58014,
                     52.45824
                 ]
             },
             "properties": {
                 "title": "Wochenmarkt Am S-Bhf. Köpenick",
-                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/321",
-                "description": "Mo - Fr&#10;Sa<br />09:00 - 18:00&#10;09:00 - 16:00<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/321\">Mehr...</a>",
-                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/321",
+                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/253",
+                "description": "Mo - Fr&#10;Sa<br />09:00 - 18:00&#10;09:00 - 16:00<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/253\">Mehr...</a>",
+                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/253",
                 "data": {
-                    "id": "321",
+                    "id": "253",
                     "bezirk": "Treptow-Köpenick",
                     "bezeichnung": "Wochenmarkt Am S-Bhf. Köpenick",
                     "strasse": "Elcknerplatz",
@@ -1887,39 +709,8 @@
                     "email": "mailto:info@mv-perske.de",
                     "www": "http://www.mv-perske.de",
                     "bemerkungen": "",
-                    "_wgs84_lat": "52.4582441",
-                    "_wgs84_lon": "13.5801"
-                }
-            }
-        },
-        {
-            "type": "Feature",
-            "geometry": {
-                "type": "Point",
-                "coordinates": [
-                    13.26197,
-                    52.41225
-                ]
-            },
-            "properties": {
-                "title": "Wochenmarkt Andrézeile (Ladiusmarkt)",
-                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/267",
-                "description": "Sa<br />08:00 - 13:00<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/267\">Mehr...</a>",
-                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/267",
-                "data": {
-                    "id": "267",
-                    "bezirk": "Steglitz-Zehlendorf",
-                    "bezeichnung": "Wochenmarkt Andrézeile (Ladiusmarkt)",
-                    "strasse": "Andrézeile",
-                    "plz": "14165",
-                    "tage": "Sa",
-                    "zeiten": "08:00 - 13:00",
-                    "betreiber": "Marktleitung: Metin Sunday\nTel.: 03329/69 72 15, 0172/390 20 05",
-                    "email": "",
-                    "www": "",
-                    "bemerkungen": "",
-                    "_wgs84_lat": "52.4122548",
-                    "_wgs84_lon": "13.261967"
+                    "_wgs84_lat": "52.4582432",
+                    "_wgs84_lon": "13.5801407"
                 }
             }
         },
@@ -1934,11 +725,11 @@
             },
             "properties": {
                 "title": "Wochenmarkt Anton-Saefkow-Platz",
-                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/81",
-                "description": "Di, Do<br />09:00 - 18:00<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/81\">Mehr...</a>",
-                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/81",
+                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/55",
+                "description": "Di, Do<br />09:00 - 18:00<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/55\">Mehr...</a>",
+                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/55",
                 "data": {
-                    "id": "81",
+                    "id": "55",
                     "bezirk": "Lichtenberg",
                     "bezeichnung": "Wochenmarkt Anton-Saefkow-Platz",
                     "strasse": "Anton-Saefkow-Platz",
@@ -1965,17 +756,17 @@
             },
             "properties": {
                 "title": "Wochenmarkt Antonplatz",
-                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/216",
-                "description": "Di, Fr&#10;Do*<br />09:00 - 18:00&#10;11:00 - 16:00<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/216\">Mehr...</a>",
-                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/216",
+                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/175",
+                "description": "Mo - Fr<br />09:00 - 18:00<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/175\">Mehr...</a>",
+                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/175",
                 "data": {
-                    "id": "216",
+                    "id": "175",
                     "bezirk": "Pankow",
                     "bezeichnung": "Wochenmarkt Antonplatz",
                     "strasse": "Antonplatz",
                     "plz": "13086",
-                    "tage": "Di, Fr\nDo*",
-                    "zeiten": "09:00 - 18:00\n11:00 - 16:00",
+                    "tage": "Mo - Fr",
+                    "zeiten": "09:00 - 18:00",
                     "betreiber": "Marktleitung: Marktverwaltung Rainer Perske\nTel.: 29 77 24 86, Fax: 29 77 25 91",
                     "email": "mailto:info@mv-perske.de",
                     "www": "http://www.mv-perske.de",
@@ -1990,17 +781,17 @@
             "geometry": {
                 "type": "Point",
                 "coordinates": [
-                    13.52801,
-                    52.46095
+                    13.52667,
+                    52.45864
                 ]
             },
             "properties": {
                 "title": "Wochenmarkt Berlin-Oberschöneweide",
-                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/369",
-                "description": "Mi<br />09:00 - 16:00<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/369\">Mehr...</a>",
-                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/369",
+                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/283",
+                "description": "Mi<br />09:00 - 16:00<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/283\">Mehr...</a>",
+                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/283",
                 "data": {
-                    "id": "369",
+                    "id": "283",
                     "bezirk": "Treptow-Köpenick",
                     "bezeichnung": "Wochenmarkt Berlin-Oberschöneweide",
                     "strasse": "Rathenauplatz",
@@ -2011,8 +802,8 @@
                     "email": "mailto:berndgellesch@t-online.de",
                     "www": "http://www.brandenburger-wochenmaerkte.de",
                     "bemerkungen": "",
-                    "_wgs84_lat": "52.4609452",
-                    "_wgs84_lon": "13.528007"
+                    "_wgs84_lat": "52.4586392",
+                    "_wgs84_lon": "13.5266724"
                 }
             }
         },
@@ -2027,11 +818,11 @@
             },
             "properties": {
                 "title": "Wochenmarkt Boxhagener Platz",
-                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/60",
-                "description": "Sa<br />09:00 - 15:30<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/60\">Mehr...</a>",
-                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/60",
+                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/40",
+                "description": "Sa<br />09:00 - 15:30<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/40\">Mehr...</a>",
+                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/40",
                 "data": {
-                    "id": "60",
+                    "id": "40",
                     "bezirk": "Friedrichshain-Kreuzberg",
                     "bezeichnung": "Wochenmarkt Boxhagener Platz",
                     "strasse": "Boxhagener Platz",
@@ -2042,8 +833,8 @@
                     "email": "",
                     "www": "",
                     "bemerkungen": "",
-                    "_wgs84_lat": "52.5111911",
-                    "_wgs84_lon": "13.4587126"
+                    "_wgs84_lat": "52.5111906",
+                    "_wgs84_lon": "13.4587124"
                 }
             }
         },
@@ -2058,11 +849,11 @@
             },
             "properties": {
                 "title": "Wochenmarkt Breite Straße",
-                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/195",
-                "description": "Di&#10;Mi&#10;Fr&#10;Sa<br />08:00 - 14:00&#10;09:00 - 17:00&#10;08:00 - 16:00&#10;08:00 - 15:00<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/195\">Mehr...</a>",
-                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/195",
+                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/154",
+                "description": "Di&#10;Mi&#10;Fr&#10;Sa<br />08:00 - 14:00&#10;09:00 - 17:00&#10;08:00 - 16:00&#10;08:00 - 15:00<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/154\">Mehr...</a>",
+                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/154",
                 "data": {
-                    "id": "195",
+                    "id": "154",
                     "bezirk": "Pankow",
                     "bezeichnung": "Wochenmarkt Breite Straße",
                     "strasse": "Breite Str. 17",
@@ -2083,17 +874,17 @@
             "geometry": {
                 "type": "Point",
                 "coordinates": [
-                    13.33542,
-                    52.47185
+                    13.33554,
+                    52.47207
                 ]
             },
             "properties": {
                 "title": "Wochenmarkt Breslauer Platz",
-                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/297",
-                "description": "Mi&#10;Do&#10;Sa<br />08:00 - 13:00&#10;12:00 - 18:00&#10;08:00 - 14:00<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/297\">Mehr...</a>",
-                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/297",
+                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/238",
+                "description": "Mi&#10;Do&#10;Sa<br />08:00 - 13:00&#10;12:00 - 18:00&#10;08:00 - 14:00<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/238\">Mehr...</a>",
+                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/238",
                 "data": {
-                    "id": "297",
+                    "id": "238",
                     "bezirk": "Tempelhof-Schöneberg",
                     "bezeichnung": "Wochenmarkt Breslauer Platz",
                     "strasse": "Breslauer Platz",
@@ -2104,8 +895,8 @@
                     "email": "mailto:marktverwaltung@ba-ts.berlin.de",
                     "www": "http://www.berlin.de/ba-tempelhof-schoeneberg/politik-und-verwaltung/aemter/ordnungsamt/maerkte",
                     "bemerkungen": "Es werden für den Markt Breslauer Platz noch freie Plätze angeboten",
-                    "_wgs84_lat": "52.4718516",
-                    "_wgs84_lon": "13.3354188"
+                    "_wgs84_lat": "52.472066",
+                    "_wgs84_lon": "13.3355369"
                 }
             }
         },
@@ -2120,11 +911,11 @@
             },
             "properties": {
                 "title": "Wochenmarkt Brunsbütteler Damm 265",
-                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/243",
-                "description": "Fr<br />08:00 - 15:00<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/243\">Mehr...</a>",
-                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/243",
+                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/199",
+                "description": "Fr<br />08:00 - 15:00<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/199\">Mehr...</a>",
+                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/199",
                 "data": {
-                    "id": "243",
+                    "id": "199",
                     "bezirk": "Spandau",
                     "bezeichnung": "Wochenmarkt Brunsbütteler Damm 265",
                     "strasse": "Brunsbütteler Damm 265",
@@ -2145,17 +936,17 @@
             "geometry": {
                 "type": "Point",
                 "coordinates": [
-                    13.48707,
-                    52.61747
+                    13.48712,
+                    52.61745
                 ]
             },
             "properties": {
                 "title": "Wochenmarkt Bucher Chaussee / Achillesstraße",
-                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/213",
-                "description": "Do&#10;Sa<br />08:00 - 16:30&#10;08:00 - 14:30<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/213\">Mehr...</a>",
-                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/213",
+                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/172",
+                "description": "Do&#10;Sa<br />08:00 - 16:30&#10;08:00 - 14:30<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/172\">Mehr...</a>",
+                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/172",
                 "data": {
-                    "id": "213",
+                    "id": "172",
                     "bezirk": "Pankow",
                     "bezeichnung": "Wochenmarkt Bucher Chaussee / Achillesstraße",
                     "strasse": "Bucher Chaussee",
@@ -2166,8 +957,8 @@
                     "email": "",
                     "www": "",
                     "bemerkungen": "Winter: Do 09:00 - 16:30, Sa 08:00 - 13:30, Mai - September: Jeden 1. Samstag im Monat mit Trödelecke",
-                    "_wgs84_lat": "52.6174655",
-                    "_wgs84_lon": "13.4870729"
+                    "_wgs84_lat": "52.6174531",
+                    "_wgs84_lon": "13.4871163"
                 }
             }
         },
@@ -2182,11 +973,11 @@
             },
             "properties": {
                 "title": "Wochenmarkt Bundesplatz",
-                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/33",
-                "description": "Mo, Do<br />08:00 - 13:00<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/33\">Mehr...</a>",
-                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/33",
+                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/28",
+                "description": "Mo, Do<br />08:00 - 13:00<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/28\">Mehr...</a>",
+                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/28",
                 "data": {
-                    "id": "33",
+                    "id": "28",
                     "bezirk": "Charlottenburg-Wilmersdorf",
                     "bezeichnung": "Wochenmarkt Bundesplatz",
                     "strasse": "Bundesplatz",
@@ -2207,17 +998,17 @@
             "geometry": {
                 "type": "Point",
                 "coordinates": [
-                    13.29291,
-                    52.63119
+                    13.29297,
+                    52.63126
                 ]
             },
             "properties": {
                 "title": "Wochenmarkt Burgfrauenstraße",
-                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/225",
-                "description": "Do - Sa<br />08:00 - 13:00<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/225\">Mehr...</a>",
-                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/225",
+                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/184",
+                "description": "Do - Sa<br />08:00 - 13:00<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/184\">Mehr...</a>",
+                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/184",
                 "data": {
-                    "id": "225",
+                    "id": "184",
                     "bezirk": "Reinickendorf",
                     "bezeichnung": "Wochenmarkt Burgfrauenstraße",
                     "strasse": "Burgfrauenstraße",
@@ -2228,8 +1019,8 @@
                     "email": "",
                     "www": "",
                     "bemerkungen": "",
-                    "_wgs84_lat": "52.6311885",
-                    "_wgs84_lon": "13.2929099"
+                    "_wgs84_lat": "52.6312618",
+                    "_wgs84_lon": "13.2929675"
                 }
             }
         },
@@ -2238,17 +1029,17 @@
             "geometry": {
                 "type": "Point",
                 "coordinates": [
-                    13.51854,
-                    52.508
+                    13.526,
+                    52.49554
                 ]
             },
             "properties": {
                 "title": "Wochenmarkt Bärenschaufenster\n(öffentl. Straßenland)",
-                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/84",
-                "description": "Mo, &#10;Do, &#10;Fr<br />08:00 - 18:00<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/84\">Mehr...</a>",
-                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/84",
+                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/58",
+                "description": "Mo, &#10;Do, &#10;Fr<br />08:00 - 18:00<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/58\">Mehr...</a>",
+                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/58",
                 "data": {
-                    "id": "84",
+                    "id": "58",
                     "bezirk": "Lichtenberg",
                     "bezeichnung": "Wochenmarkt Bärenschaufenster\n(öffentl. Straßenland)",
                     "strasse": "Am Tierpark",
@@ -2259,8 +1050,8 @@
                     "email": "mailto:berndgellesch@t-online.de",
                     "www": "http://www.brandenburger-wochenmaerkte.de",
                     "bemerkungen": "",
-                    "_wgs84_lat": "52.508",
-                    "_wgs84_lon": "13.51854"
+                    "_wgs84_lat": "52.49554",
+                    "_wgs84_lon": "13.526"
                 }
             }
         },
@@ -2269,17 +1060,17 @@
             "geometry": {
                 "type": "Point",
                 "coordinates": [
-                    13.62469,
-                    52.44836
+                    13.62481,
+                    52.44831
                 ]
             },
             "properties": {
                 "title": "Wochenmarkt Bölschestraße",
-                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/318",
-                "description": "Mo, Mi, Fr&#10;Sa<br />10:00 - 16:00&#10;09:00 - 13:00<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/318\">Mehr...</a>",
-                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/318",
+                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/250",
+                "description": "Mo, Mi, Fr&#10;Sa<br />10:00 - 16:00&#10;09:00 - 13:00<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/250\">Mehr...</a>",
+                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/250",
                 "data": {
-                    "id": "318",
+                    "id": "250",
                     "bezirk": "Treptow-Köpenick",
                     "bezeichnung": "Wochenmarkt Bölschestraße",
                     "strasse": "Bölschestraße",
@@ -2290,8 +1081,8 @@
                     "email": "mailto:markt-hirche@web.de",
                     "www": "",
                     "bemerkungen": "",
-                    "_wgs84_lat": "52.448359",
-                    "_wgs84_lon": "13.6246912"
+                    "_wgs84_lat": "52.4483142",
+                    "_wgs84_lon": "13.6248101"
                 }
             }
         },
@@ -2306,11 +1097,11 @@
             },
             "properties": {
                 "title": "Wochenmarkt Caligariplatz",
-                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/219",
-                "description": "Mi, Fr<br />08:00 - 18:00<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/219\">Mehr...</a>",
-                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/219",
+                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/178",
+                "description": "Mi, Fr<br />08:00 - 18:00<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/178\">Mehr...</a>",
+                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/178",
                 "data": {
-                    "id": "219",
+                    "id": "178",
                     "bezirk": "Pankow",
                     "bezeichnung": "Wochenmarkt Caligariplatz",
                     "strasse": "Caligariplatz",
@@ -2331,17 +1122,17 @@
             "geometry": {
                 "type": "Point",
                 "coordinates": [
-                    13.58978,
+                    13.58979,
                     52.51901
                 ]
             },
             "properties": {
                 "title": "Wochenmarkt Cecilienplatz",
-                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/117",
-                "description": "Mo, Mi, Fr<br />09:00 - 18:00<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/117\">Mehr...</a>",
-                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/117",
+                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/91",
+                "description": "Mo, Mi, Fr<br />09:00 - 18:00<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/91\">Mehr...</a>",
+                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/91",
                 "data": {
-                    "id": "117",
+                    "id": "91",
                     "bezirk": "Marzahn-Hellersdorf",
                     "bezeichnung": "Wochenmarkt Cecilienplatz",
                     "strasse": "Ernst-Bloch-Straße",
@@ -2352,8 +1143,8 @@
                     "email": "mailto:rose.erika@freenet.de",
                     "www": "",
                     "bemerkungen": "",
-                    "_wgs84_lat": "52.5190123",
-                    "_wgs84_lon": "13.5897835"
+                    "_wgs84_lat": "52.5190111",
+                    "_wgs84_lon": "13.5897928"
                 }
             }
         },
@@ -2362,17 +1153,17 @@
             "geometry": {
                 "type": "Point",
                 "coordinates": [
-                    13.29292,
-                    52.48874
+                    13.2938,
+                    52.48862
                 ]
             },
             "properties": {
                 "title": "Wochenmarkt Charlottenbrunner Straße",
-                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/21",
-                "description": "Mo, Do<br />09:00 - 14:00<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/21\">Mehr...</a>",
-                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/21",
+                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/16",
+                "description": "Mo, Do<br />09:00 - 14:00<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/16\">Mehr...</a>",
+                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/16",
                 "data": {
-                    "id": "21",
+                    "id": "16",
                     "bezirk": "Charlottenburg-Wilmersdorf",
                     "bezeichnung": "Wochenmarkt Charlottenbrunner Straße",
                     "strasse": "Charlottenbrunner Straße",
@@ -2383,8 +1174,8 @@
                     "email": "",
                     "www": "",
                     "bemerkungen": "",
-                    "_wgs84_lat": "52.4887369",
-                    "_wgs84_lon": "13.2929173"
+                    "_wgs84_lat": "52.4886247",
+                    "_wgs84_lon": "13.2937998"
                 }
             }
         },
@@ -2393,17 +1184,17 @@
             "geometry": {
                 "type": "Point",
                 "coordinates": [
-                    13.36544,
-                    52.49104
+                    13.36551,
+                    52.49103
                 ]
             },
             "properties": {
                 "title": "Wochenmarkt Crellestraße",
-                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/300",
-                "description": "Mi, Sa<br />10:00 - 15:00<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/300\">Mehr...</a>",
-                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/300",
+                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/241",
+                "description": "Mi, Sa<br />10:00 - 15:00<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/241\">Mehr...</a>",
+                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/241",
                 "data": {
-                    "id": "300",
+                    "id": "241",
                     "bezirk": "Tempelhof-Schöneberg",
                     "bezeichnung": "Wochenmarkt Crellestraße",
                     "strasse": "Crellestraße 24",
@@ -2414,8 +1205,8 @@
                     "email": "mailto:marktverwaltung@ba-ts.berlin.de",
                     "www": "http://www.berlin.de/ba-tempelhof-schoeneberg/politik-und-verwaltung/aemter/ordnungsamt/maerkte",
                     "bemerkungen": "",
-                    "_wgs84_lat": "52.4910379",
-                    "_wgs84_lon": "13.3654444"
+                    "_wgs84_lat": "52.4910251",
+                    "_wgs84_lon": "13.3655057"
                 }
             }
         },
@@ -2430,11 +1221,11 @@
             },
             "properties": {
                 "title": "Wochenmarkt Dorfaue Schöneiche",
-                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/402",
-                "description": "Do<br />09:00 - 14:00<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/402\">Mehr...</a>",
-                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/402",
+                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/304",
+                "description": "Do<br />09:00 - 14:00<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/304\">Mehr...</a>",
+                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/304",
                 "data": {
-                    "id": "402",
+                    "id": "304",
                     "bezirk": "Brandenburg",
                     "bezeichnung": "Wochenmarkt Dorfaue Schöneiche",
                     "strasse": "Dorfaue",
@@ -2461,11 +1252,11 @@
             },
             "properties": {
                 "title": "Wochenmarkt Eberbacher Straße",
-                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/24",
-                "description": "Di, Fr<br />08:00 - 13:00<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/24\">Mehr...</a>",
-                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/24",
+                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/19",
+                "description": "Di, Fr<br />08:00 - 13:00<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/19\">Mehr...</a>",
+                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/19",
                 "data": {
-                    "id": "24",
+                    "id": "19",
                     "bezirk": "Charlottenburg-Wilmersdorf",
                     "bezeichnung": "Wochenmarkt Eberbacher Straße",
                     "strasse": "Eberbacher Straße",
@@ -2492,11 +1283,11 @@
             },
             "properties": {
                 "title": "Wochenmarkt Einkaufscenter Staaken",
-                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/246",
-                "description": "Di, Fr<br />09:00 - 15:00<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/246\">Mehr...</a>",
-                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/246",
+                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/202",
+                "description": "Di, Fr<br />09:00 - 15:00<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/202\">Mehr...</a>",
+                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/202",
                 "data": {
-                    "id": "246",
+                    "id": "202",
                     "bezirk": "Spandau",
                     "bezeichnung": "Wochenmarkt Einkaufscenter Staaken",
                     "strasse": "Obstallee 28",
@@ -2523,16 +1314,16 @@
             },
             "properties": {
                 "title": "Wochenmarkt Fehrbelliner Platz",
-                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/36",
-                "description": "Di, Do<br />11:00 - 16:00<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/36\">Mehr...</a>",
-                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/36",
+                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/31",
+                "description": "Mo, Di, Do<br />11:00 - 16:00<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/31\">Mehr...</a>",
+                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/31",
                 "data": {
-                    "id": "36",
+                    "id": "31",
                     "bezirk": "Charlottenburg-Wilmersdorf",
                     "bezeichnung": "Wochenmarkt Fehrbelliner Platz",
                     "strasse": "Fehrbelliner Platz",
                     "plz": "10707",
-                    "tage": "Di, Do",
+                    "tage": "Mo, Di, Do",
                     "zeiten": "11:00 - 16:00",
                     "betreiber": "Bezirksamt Charlottenburg-Wilmersdorf, Marktverwaltung, Hohenzollerndamm 174-177, 10713 Berlin\nTel.: 9029 - 290 72/3",
                     "email": "",
@@ -2554,11 +1345,11 @@
             },
             "properties": {
                 "title": "Wochenmarkt Frankfurter Allee 172",
-                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/90",
-                "description": "Mi<br />09:00 - 16:00<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/90\">Mehr...</a>",
-                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/90",
+                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/64",
+                "description": "Mi<br />09:00 - 16:00<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/64\">Mehr...</a>",
+                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/64",
                 "data": {
-                    "id": "90",
+                    "id": "64",
                     "bezirk": "Lichtenberg",
                     "bezeichnung": "Wochenmarkt Frankfurter Allee 172",
                     "strasse": "Frankfurter Allee 172",
@@ -2585,11 +1376,11 @@
             },
             "properties": {
                 "title": "Wochenmarkt Friedrichsfelde Ost",
-                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/96",
-                "description": "Mo - Fr<br />08:00 - 18:00<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/96\">Mehr...</a>",
-                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/96",
+                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/70",
+                "description": "Mo - Fr<br />08:00 - 18:00<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/70\">Mehr...</a>",
+                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/70",
                 "data": {
-                    "id": "96",
+                    "id": "70",
                     "bezirk": "Lichtenberg",
                     "bezeichnung": "Wochenmarkt Friedrichsfelde Ost",
                     "strasse": "Seddiner Straße",
@@ -2616,11 +1407,11 @@
             },
             "properties": {
                 "title": "Wochenmarkt Friedrichstraße Erkner",
-                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/399",
-                "description": "Do<br />09:00 - 14:00<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/399\">Mehr...</a>",
-                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/399",
+                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/301",
+                "description": "Do<br />09:00 - 14:00<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/301\">Mehr...</a>",
+                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/301",
                 "data": {
-                    "id": "399",
+                    "id": "301",
                     "bezirk": "Brandenburg",
                     "bezeichnung": "Wochenmarkt Friedrichstraße Erkner",
                     "strasse": "Friedrichstraße",
@@ -2647,11 +1438,11 @@
             },
             "properties": {
                 "title": "Wochenmarkt Greifswalder Straße / Thomas-Mann-Straße",
-                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/375",
-                "description": "Di, Do&#10;Sa<br />08:00 - 18:00&#10;08:00 - 14:00<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/375\">Mehr...</a>",
-                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/375",
+                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/289",
+                "description": "Di, Do&#10;Sa<br />08:00 - 18:00&#10;08:00 - 14:00<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/289\">Mehr...</a>",
+                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/289",
                 "data": {
-                    "id": "375",
+                    "id": "289",
                     "bezirk": "Pankow",
                     "bezeichnung": "Wochenmarkt Greifswalder Straße / Thomas-Mann-Straße",
                     "strasse": "Greifswalder Straße 157",
@@ -2678,11 +1469,11 @@
             },
             "properties": {
                 "title": "Wochenmarkt Hakenfelde",
-                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/237",
-                "description": "Do<br />08:00 - 13:00<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/237\">Mehr...</a>",
-                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/237",
+                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/193",
+                "description": "Do<br />08:00 - 13:00<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/193\">Mehr...</a>",
+                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/193",
                 "data": {
-                    "id": "237",
+                    "id": "193",
                     "bezirk": "Spandau",
                     "bezeichnung": "Wochenmarkt Hakenfelde",
                     "strasse": "Michelstadter Weg",
@@ -2709,11 +1500,11 @@
             },
             "properties": {
                 "title": "Wochenmarkt Hauptstraße / Goethestraße\nWilhelmsruh",
-                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/201",
-                "description": "Mi, Fr<br />08:00 - 14:00<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/201\">Mehr...</a>",
-                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/201",
+                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/160",
+                "description": "Mi, Fr<br />08:00 - 14:00<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/160\">Mehr...</a>",
+                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/160",
                 "data": {
-                    "id": "201",
+                    "id": "160",
                     "bezirk": "Pankow",
                     "bezeichnung": "Wochenmarkt Hauptstraße / Goethestraße\nWilhelmsruh",
                     "strasse": "Hauptstraße",
@@ -2740,11 +1531,11 @@
             },
             "properties": {
                 "title": "Wochenmarkt Helene-Weigel-Platz",
-                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/111",
-                "description": "Mo - Sa<br />09:00 - 17:00<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/111\">Mehr...</a>",
-                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/111",
+                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/85",
+                "description": "Mo - Sa<br />09:00 - 17:00<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/85\">Mehr...</a>",
+                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/85",
                 "data": {
-                    "id": "111",
+                    "id": "85",
                     "bezirk": "Marzahn-Hellersdorf",
                     "bezeichnung": "Wochenmarkt Helene-Weigel-Platz",
                     "strasse": "Helene-Weigel-Platz",
@@ -2771,11 +1562,11 @@
             },
             "properties": {
                 "title": "Wochenmarkt Helle Mitte",
-                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/105",
-                "description": "Mi, Fr<br />08:00 - 17:00<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/105\">Mehr...</a>",
-                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/105",
+                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/79",
+                "description": "Mi, Fr<br />08:00 - 17:00<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/79\">Mehr...</a>",
+                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/79",
                 "data": {
-                    "id": "105",
+                    "id": "79",
                     "bezirk": "Marzahn-Hellersdorf",
                     "bezeichnung": "Wochenmarkt Helle Mitte",
                     "strasse": "Peter-Weiss-Gasse",
@@ -2796,17 +1587,17 @@
             "geometry": {
                 "type": "Point",
                 "coordinates": [
-                    13.32166,
-                    52.45685
+                    13.32237,
+                    52.45692
                 ]
             },
             "properties": {
                 "title": "Wochenmarkt Hermann-Ehlers-Platz",
-                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/255",
-                "description": "Di, Sa&#10;Do<br />08:00 - 14:00&#10;08:00 - 18:00<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/255\">Mehr...</a>",
-                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/255",
+                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/205",
+                "description": "Di, Sa&#10;Do<br />08:00 - 14:00&#10;08:00 - 18:00<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/205\">Mehr...</a>",
+                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/205",
                 "data": {
-                    "id": "255",
+                    "id": "205",
                     "bezirk": "Steglitz-Zehlendorf",
                     "bezeichnung": "Wochenmarkt Hermann-Ehlers-Platz",
                     "strasse": "Hermann-Ehlers-Platz",
@@ -2817,8 +1608,8 @@
                     "email": "",
                     "www": "",
                     "bemerkungen": "am Rathaus Steglitz",
-                    "_wgs84_lat": "52.4568489",
-                    "_wgs84_lon": "13.3216632"
+                    "_wgs84_lat": "52.4569244",
+                    "_wgs84_lon": "13.3223656"
                 }
             }
         },
@@ -2828,16 +1619,16 @@
                 "type": "Point",
                 "coordinates": [
                     13.48408,
-                    52.52635
+                    52.52633
                 ]
             },
             "properties": {
                 "title": "Wochenmarkt Herzbergstraße / Weißenseer Weg\n(Roedernplatz)",
-                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/87",
-                "description": "Di, &#10;Fr<br />08:00 - 17:00<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/87\">Mehr...</a>",
-                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/87",
+                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/61",
+                "description": "Di, &#10;Fr<br />08:00 - 17:00<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/61\">Mehr...</a>",
+                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/61",
                 "data": {
-                    "id": "87",
+                    "id": "61",
                     "bezirk": "Lichtenberg",
                     "bezeichnung": "Wochenmarkt Herzbergstraße / Weißenseer Weg\n(Roedernplatz)",
                     "strasse": "Herzbergstraße",
@@ -2848,8 +1639,8 @@
                     "email": "mailto:berndgellesch@t-online.de",
                     "www": "",
                     "bemerkungen": "",
-                    "_wgs84_lat": "52.5263471",
-                    "_wgs84_lon": "13.484081"
+                    "_wgs84_lat": "52.5263329",
+                    "_wgs84_lon": "13.4840802"
                 }
             }
         },
@@ -2864,11 +1655,11 @@
             },
             "properties": {
                 "title": "Wochenmarkt Hohenzollernplatz",
-                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/30",
-                "description": "Mi, Sa<br />08:00 - 13:00<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/30\">Mehr...</a>",
-                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/30",
+                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/25",
+                "description": "Mi, Sa<br />08:00 - 13:00<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/25\">Mehr...</a>",
+                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/25",
                 "data": {
-                    "id": "30",
+                    "id": "25",
                     "bezirk": "Charlottenburg-Wilmersdorf",
                     "bezeichnung": "Wochenmarkt Hohenzollernplatz",
                     "strasse": "Hohenzollernplatz",
@@ -2895,11 +1686,11 @@
             },
             "properties": {
                 "title": "Wochenmarkt Jagowstraße",
-                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/135",
-                "description": "Mi, Sa<br />08:00 - 13:00<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/135\">Mehr...</a>",
-                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/135",
+                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/109",
+                "description": "Mi, Sa<br />08:00 - 13:00<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/109\">Mehr...</a>",
+                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/109",
                 "data": {
-                    "id": "135",
+                    "id": "109",
                     "bezirk": "Mitte",
                     "bezeichnung": "Wochenmarkt Jagowstraße",
                     "strasse": "Jagowstraße",
@@ -2926,11 +1717,11 @@
             },
             "properties": {
                 "title": "Wochenmarkt John-F.-Kennedy-Platz",
-                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/294",
-                "description": "Di, Fr<br />08:00 - 13:00<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/294\">Mehr...</a>",
-                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/294",
+                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/235",
+                "description": "Di, Fr<br />08:00 - 13:00<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/235\">Mehr...</a>",
+                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/235",
                 "data": {
-                    "id": "294",
+                    "id": "235",
                     "bezirk": "Tempelhof-Schöneberg",
                     "bezeichnung": "Wochenmarkt John-F.-Kennedy-Platz",
                     "strasse": "John-F.-Kennedy-Platz 1",
@@ -2957,11 +1748,11 @@
             },
             "properties": {
                 "title": "Wochenmarkt Karl-August-Platz",
-                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/12",
-                "description": "Mi&#10;Sa<br />08:00 - 13:00&#10;08:00 - 14:00<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/12\">Mehr...</a>",
-                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/12",
+                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/10",
+                "description": "Mi&#10;Sa<br />08:00 - 13:00&#10;08:00 - 14:00<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/10\">Mehr...</a>",
+                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/10",
                 "data": {
-                    "id": "12",
+                    "id": "10",
                     "bezirk": "Charlottenburg-Wilmersdorf",
                     "bezeichnung": "Wochenmarkt Karl-August-Platz",
                     "strasse": "Karl-August-Platz",
@@ -2988,11 +1779,11 @@
             },
             "properties": {
                 "title": "Wochenmarkt Karlshorst",
-                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/93",
-                "description": "Di, &#10;Fr<br />09:00 - 17:00<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/93\">Mehr...</a>",
-                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/93",
+                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/67",
+                "description": "Di, &#10;Fr<br />09:00 - 17:00<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/67\">Mehr...</a>",
+                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/67",
                 "data": {
-                    "id": "93",
+                    "id": "67",
                     "bezirk": "Lichtenberg",
                     "bezeichnung": "Wochenmarkt Karlshorst",
                     "strasse": "Ehrenfelsstraße",
@@ -3003,8 +1794,8 @@
                     "email": "mailto:berndgellesch@t-online.de",
                     "www": "http://www.gakenholz-gellesch.de",
                     "bemerkungen": "",
-                    "_wgs84_lat": "52.48119",
-                    "_wgs84_lon": "13.5286599"
+                    "_wgs84_lat": "52.4811891",
+                    "_wgs84_lon": "13.528659"
                 }
             }
         },
@@ -3019,11 +1810,11 @@
             },
             "properties": {
                 "title": "Wochenmarkt Klausenerplatz",
-                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/6",
-                "description": "Di, Fr<br />08:00 - 13:00<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/6\">Mehr...</a>",
-                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/6",
+                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/4",
+                "description": "Di, Fr<br />08:00 - 13:00<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/4\">Mehr...</a>",
+                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/4",
                 "data": {
-                    "id": "6",
+                    "id": "4",
                     "bezirk": "Charlottenburg-Wilmersdorf",
                     "bezeichnung": "Wochenmarkt Klausenerplatz",
                     "strasse": "Klausenerplatz",
@@ -3044,17 +1835,17 @@
             "geometry": {
                 "type": "Point",
                 "coordinates": [
-                    13.29058,
-                    52.47681
+                    13.29048,
+                    52.47695
                 ]
             },
             "properties": {
                 "title": "Wochenmarkt Kolberger Platz",
-                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/39",
-                "description": "Mi, Sa<br />06:00 - 15:00<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/39\">Mehr...</a>",
-                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/39",
+                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/34",
+                "description": "Mi, Sa<br />06:00 - 15:00<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/34\">Mehr...</a>",
+                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/34",
                 "data": {
-                    "id": "39",
+                    "id": "34",
                     "bezirk": "Charlottenburg-Wilmersdorf",
                     "bezeichnung": "Wochenmarkt Kolberger Platz",
                     "strasse": "Kolberger Platz",
@@ -3065,8 +1856,8 @@
                     "email": "",
                     "www": "",
                     "bemerkungen": "",
-                    "_wgs84_lat": "52.4768081",
-                    "_wgs84_lon": "13.2905838"
+                    "_wgs84_lat": "52.4769532",
+                    "_wgs84_lon": "13.2904827"
                 }
             }
         },
@@ -3081,11 +1872,11 @@
             },
             "properties": {
                 "title": "Wochenmarkt Leopoldplatz",
-                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/132",
-                "description": "Do<br />11:00 - 17:00<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/132\">Mehr...</a>",
-                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/132",
+                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/106",
+                "description": "Do<br />11:00 - 17:00<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/106\">Mehr...</a>",
+                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/106",
                 "data": {
-                    "id": "132",
+                    "id": "106",
                     "bezirk": "Mitte",
                     "bezeichnung": "Wochenmarkt Leopoldplatz",
                     "strasse": "Leopoldplatz",
@@ -3112,11 +1903,11 @@
             },
             "properties": {
                 "title": "Wochenmarkt Lichterfelde, Kranoldplatz",
-                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/258",
-                "description": "Mi, Sa<br />08:00 - 14:00<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/258\">Mehr...</a>",
-                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/258",
+                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/208",
+                "description": "Mi, Sa<br />08:00 - 14:00<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/208\">Mehr...</a>",
+                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/208",
                 "data": {
-                    "id": "258",
+                    "id": "208",
                     "bezirk": "Steglitz-Zehlendorf",
                     "bezeichnung": "Wochenmarkt Lichterfelde, Kranoldplatz",
                     "strasse": "Kranoldplatz",
@@ -3143,11 +1934,11 @@
             },
             "properties": {
                 "title": "Wochenmarkt Ludwig-Beck-Platz",
-                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/264",
-                "description": "Fr, Sa<br />08:00 - 13:00<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/264\">Mehr...</a>",
-                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/264",
+                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/214",
+                "description": "Fr, Sa<br />08:00 - 13:00<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/214\">Mehr...</a>",
+                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/214",
                 "data": {
-                    "id": "264",
+                    "id": "214",
                     "bezirk": "Steglitz-Zehlendorf",
                     "bezeichnung": "Wochenmarkt Ludwig-Beck-Platz",
                     "strasse": "Ludwig-Beck-Platz",
@@ -3168,17 +1959,17 @@
             "geometry": {
                 "type": "Point",
                 "coordinates": [
-                    13.59146,
-                    52.48463
+                    13.59143,
+                    52.48475
                 ]
             },
             "properties": {
                 "title": "Wochenmarkt Mahlsdorf\nRoedernstraße / Hultschiner Damm",
-                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/108",
-                "description": "Do<br />07:00 - 15:00<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/108\">Mehr...</a>",
-                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/108",
+                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/82",
+                "description": "Do<br />07:00 - 15:00<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/82\">Mehr...</a>",
+                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/82",
                 "data": {
-                    "id": "108",
+                    "id": "82",
                     "bezirk": "Marzahn-Hellersdorf",
                     "bezeichnung": "Wochenmarkt Mahlsdorf\nRoedernstraße / Hultschiner Damm",
                     "strasse": "Roedernstraße",
@@ -3189,8 +1980,8 @@
                     "email": "mailto:lme_berlin@gmx.de",
                     "www": "",
                     "bemerkungen": "",
-                    "_wgs84_lat": "52.48463",
-                    "_wgs84_lon": "13.59146"
+                    "_wgs84_lat": "52.484753",
+                    "_wgs84_lon": "13.591428"
                 }
             }
         },
@@ -3205,11 +1996,11 @@
             },
             "properties": {
                 "title": "Wochenmarkt Mariendorfer Damm / Prinzenstraße",
-                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/285",
-                "description": "Mi, Sa<br />08:00 - 13:00<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/285\">Mehr...</a>",
-                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/285",
+                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/226",
+                "description": "Mi, Sa<br />08:00 - 13:00<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/226\">Mehr...</a>",
+                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/226",
                 "data": {
-                    "id": "285",
+                    "id": "226",
                     "bezirk": "Tempelhof-Schöneberg",
                     "bezeichnung": "Wochenmarkt Mariendorfer Damm / Prinzenstraße",
                     "strasse": "Prinzenstraße",
@@ -3230,17 +2021,17 @@
             "geometry": {
                 "type": "Point",
                 "coordinates": [
-                    13.41965,
-                    52.54313
+                    13.41961,
+                    52.54314
                 ]
             },
             "properties": {
                 "title": "Wochenmarkt Markt am Helmholtzplatz",
-                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/210",
-                "description": "Sa<br />09:00 - 16:00<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/210\">Mehr...</a>",
-                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/210",
+                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/169",
+                "description": "Sa<br />09:00 - 16:00<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/169\">Mehr...</a>",
+                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/169",
                 "data": {
-                    "id": "210",
+                    "id": "169",
                     "bezirk": "Pankow",
                     "bezeichnung": "Wochenmarkt Markt am Helmholtzplatz",
                     "strasse": "Helmholtzplatz",
@@ -3251,8 +2042,8 @@
                     "email": "",
                     "www": "",
                     "bemerkungen": "",
-                    "_wgs84_lat": "52.5431295",
-                    "_wgs84_lon": "13.4196464"
+                    "_wgs84_lat": "52.543144",
+                    "_wgs84_lon": "13.419613"
                 }
             }
         },
@@ -3262,16 +2053,16 @@
                 "type": "Point",
                 "coordinates": [
                     13.42012,
-                    52.60728
+                    52.60731
                 ]
             },
             "properties": {
                 "title": "Wochenmarkt Markt am Hugenottenplatz",
-                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/198",
-                "description": "Sa<br />09:00 - 13:00<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/198\">Mehr...</a>",
-                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/198",
+                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/157",
+                "description": "Sa<br />09:00 - 13:00<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/157\">Mehr...</a>",
+                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/157",
                 "data": {
-                    "id": "198",
+                    "id": "157",
                     "bezirk": "Pankow",
                     "bezeichnung": "Wochenmarkt Markt am Hugenottenplatz",
                     "strasse": "Hugenottenplatz",
@@ -3282,8 +2073,8 @@
                     "email": "",
                     "www": "",
                     "bemerkungen": "Buchholz",
-                    "_wgs84_lat": "52.6072825",
-                    "_wgs84_lon": "13.4201154"
+                    "_wgs84_lat": "52.6073116",
+                    "_wgs84_lon": "13.4201239"
                 }
             }
         },
@@ -3298,11 +2089,11 @@
             },
             "properties": {
                 "title": "Wochenmarkt Markt am Spittelmarkt",
-                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/126",
-                "description": "Mi, Fr<br />10:00 - 15:00<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/126\">Mehr...</a>",
-                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/126",
+                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/100",
+                "description": "Mi, Fr<br />10:00 - 15:00<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/100\">Mehr...</a>",
+                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/100",
                 "data": {
-                    "id": "126",
+                    "id": "100",
                     "bezirk": "Mitte",
                     "bezeichnung": "Wochenmarkt Markt am Spittelmarkt",
                     "strasse": "Spittelmarkt",
@@ -3329,11 +2120,11 @@
             },
             "properties": {
                 "title": "Wochenmarkt Markt am Stierbrunnen",
-                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/207",
-                "description": "Sa<br />09:00 - 15:00<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/207\">Mehr...</a>",
-                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/207",
+                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/166",
+                "description": "Sa<br />09:00 - 15:00<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/166\">Mehr...</a>",
+                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/166",
                 "data": {
-                    "id": "207",
+                    "id": "166",
                     "bezirk": "Pankow",
                     "bezeichnung": "Wochenmarkt Markt am Stierbrunnen",
                     "strasse": " Pasteurstraße 32",
@@ -3360,11 +2151,11 @@
             },
             "properties": {
                 "title": "Wochenmarkt Marzahner Promenade",
-                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/114",
-                "description": "Mo, Mi, Fr<br />08:30 - 17:00<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/114\">Mehr...</a>",
-                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/114",
+                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/88",
+                "description": "Mo, Mi, Fr<br />08:30 - 17:00<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/88\">Mehr...</a>",
+                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/88",
                 "data": {
-                    "id": "114",
+                    "id": "88",
                     "bezirk": "Marzahn-Hellersdorf",
                     "bezeichnung": "Wochenmarkt Marzahner Promenade",
                     "strasse": "Marzahner Promenade 30-33",
@@ -3391,11 +2182,11 @@
             },
             "properties": {
                 "title": "Wochenmarkt Mexikoplatz",
-                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/279",
-                "description": "Sa<br />09:00 - 15:00<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/279\">Mehr...</a>",
-                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/279",
+                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/223",
+                "description": "Sa<br />09:00 - 15:00<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/223\">Mehr...</a>",
+                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/223",
                 "data": {
-                    "id": "279",
+                    "id": "223",
                     "bezirk": "Steglitz-Zehlendorf",
                     "bezeichnung": "Wochenmarkt Mexikoplatz",
                     "strasse": "Mexikoplatz",
@@ -3422,11 +2213,11 @@
             },
             "properties": {
                 "title": "Wochenmarkt Mierendorffplatz",
-                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/15",
-                "description": "Mi, Sa<br />08:00 - 13:00<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/15\">Mehr...</a>",
-                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/15",
+                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/13",
+                "description": "Mi, Sa<br />08:00 - 13:00<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/13\">Mehr...</a>",
+                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/13",
                 "data": {
-                    "id": "15",
+                    "id": "13",
                     "bezirk": "Charlottenburg-Wilmersdorf",
                     "bezeichnung": "Wochenmarkt Mierendorffplatz",
                     "strasse": "Mierendorffplatz",
@@ -3453,11 +2244,11 @@
             },
             "properties": {
                 "title": "Wochenmarkt Nestorstraße",
-                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/27",
-                "description": "Di, Fr<br />08:00 - 13:00<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/27\">Mehr...</a>",
-                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/27",
+                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/22",
+                "description": "Di, Fr<br />08:00 - 13:00<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/22\">Mehr...</a>",
+                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/22",
                 "data": {
-                    "id": "27",
+                    "id": "22",
                     "bezirk": "Charlottenburg-Wilmersdorf",
                     "bezeichnung": "Wochenmarkt Nestorstraße",
                     "strasse": "Nestorstraße",
@@ -3484,11 +2275,11 @@
             },
             "properties": {
                 "title": "Wochenmarkt Neuer Markt am Kollwitzplatz",
-                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/222",
-                "description": "Sa<br />10:30 - 16:30<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/222\">Mehr...</a>",
-                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/222",
+                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/181",
+                "description": "Sa<br />10:30 - 16:30<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/181\">Mehr...</a>",
+                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/181",
                 "data": {
-                    "id": "222",
+                    "id": "181",
                     "bezirk": "Pankow",
                     "bezeichnung": "Wochenmarkt Neuer Markt am Kollwitzplatz",
                     "strasse": "Kollwitzplatz",
@@ -3515,11 +2306,11 @@
             },
             "properties": {
                 "title": "Wochenmarkt Onkel-Toms-Hütte",
-                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/354",
-                "description": "Do<br />12:00 - 18:30<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/354\">Mehr...</a>",
-                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/354",
+                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/274",
+                "description": "Do<br />12:00 - 18:30<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/274\">Mehr...</a>",
+                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/274",
                 "data": {
-                    "id": "354",
+                    "id": "274",
                     "bezirk": "Steglitz-Zehlendorf",
                     "bezeichnung": "Wochenmarkt Onkel-Toms-Hütte",
                     "strasse": "Onkel-Tom-Str. 99",
@@ -3529,7 +2320,7 @@
                     "betreiber": "DIEMARKTPLANER (Märkte & Marktstandverleih), Dipl.-Ing. Nikolaus Fink, Sanderstr. 4, 12047 Berlin, Tel.: 29 30 96 01, Fax: 29 00 96 23",
                     "email": "mailto:info@diemarktplaner.de",
                     "www": "http://www.diemarktplaner.de",
-                    "bemerkungen": "",
+                    "bemerkungen": "U-Onkel-Toms-Hütte",
                     "_wgs84_lat": "52.44959",
                     "_wgs84_lon": "13.25189"
                 }
@@ -3546,11 +2337,11 @@
             },
             "properties": {
                 "title": "Wochenmarkt Potsdam Bassinplatz",
-                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/339",
-                "description": "Mo - Fr&#10;Sa<br />07:00 - 16:00&#10;07:00 - 13:00<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/339\">Mehr...</a>",
-                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/339",
+                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/265",
+                "description": "Mo - Fr&#10;Sa<br />07:00 - 16:00&#10;07:00 - 13:00<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/265\">Mehr...</a>",
+                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/265",
                 "data": {
-                    "id": "339",
+                    "id": "265",
                     "bezirk": "Brandenburg",
                     "bezeichnung": "Wochenmarkt Potsdam Bassinplatz",
                     "strasse": "Am Bassin 6",
@@ -3577,11 +2368,11 @@
             },
             "properties": {
                 "title": "Wochenmarkt Prerower Platz",
-                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/102",
-                "description": "Mi<br />09:00 - 17:00<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/102\">Mehr...</a>",
-                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/102",
+                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/76",
+                "description": "Mi<br />09:00 - 17:00<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/76\">Mehr...</a>",
+                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/76",
                 "data": {
-                    "id": "102",
+                    "id": "76",
                     "bezirk": "Lichtenberg",
                     "bezeichnung": "Wochenmarkt Prerower Platz",
                     "strasse": "Prerower Platz",
@@ -3608,11 +2399,11 @@
             },
             "properties": {
                 "title": "Wochenmarkt Preußenallee",
-                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/9",
-                "description": "Di, Fr<br />08:00 - 13:00<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/9\">Mehr...</a>",
-                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/9",
+                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/7",
+                "description": "Di, Fr<br />08:00 - 13:00<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/7\">Mehr...</a>",
+                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/7",
                 "data": {
-                    "id": "9",
+                    "id": "7",
                     "bezirk": "Charlottenburg-Wilmersdorf",
                     "bezeichnung": "Wochenmarkt Preußenallee",
                     "strasse": "Preußenallee",
@@ -3639,11 +2430,11 @@
             },
             "properties": {
                 "title": "Wochenmarkt Rathaus Lankwitz",
-                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/261",
-                "description": "Mo, Fr<br />08:00 - 13:00<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/261\">Mehr...</a>",
-                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/261",
+                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/211",
+                "description": "Mo, Fr<br />08:00 - 13:00<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/211\">Mehr...</a>",
+                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/211",
                 "data": {
-                    "id": "261",
+                    "id": "211",
                     "bezirk": "Steglitz-Zehlendorf",
                     "bezeichnung": "Wochenmarkt Rathaus Lankwitz",
                     "strasse": "Leonorenstraße",
@@ -3670,11 +2461,11 @@
             },
             "properties": {
                 "title": "Wochenmarkt Rathausvorplatz",
-                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/234",
-                "description": "Mi&#10;Sa<br />08:00 - 18:00&#10;08:00 - 16:00<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/234\">Mehr...</a>",
-                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/234",
+                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/190",
+                "description": "Mi&#10;Sa<br />08:00 - 18:00&#10;08:00 - 16:00<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/190\">Mehr...</a>",
+                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/190",
                 "data": {
-                    "id": "234",
+                    "id": "190",
                     "bezirk": "Spandau",
                     "bezeichnung": "Wochenmarkt Rathausvorplatz",
                     "strasse": "Markt 3",
@@ -3701,11 +2492,11 @@
             },
             "properties": {
                 "title": "Wochenmarkt Richard-Wagner-Platz",
-                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/3",
-                "description": "Mo, Do<br />08:00 - 13:00<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/3\">Mehr...</a>",
-                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/3",
+                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/1",
+                "description": "Mo, Do<br />08:00 - 13:00<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/1\">Mehr...</a>",
+                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/1",
                 "data": {
-                    "id": "3",
+                    "id": "1",
                     "bezirk": "Charlottenburg-Wilmersdorf",
                     "bezeichnung": "Wochenmarkt Richard-Wagner-Platz",
                     "strasse": "Richard-Wagner-Platz",
@@ -3717,7 +2508,7 @@
                     "www": "",
                     "bemerkungen": "",
                     "_wgs84_lat": "52.517322",
-                    "_wgs84_lon": "13.3058631"
+                    "_wgs84_lon": "13.3058632"
                 }
             }
         },
@@ -3732,11 +2523,11 @@
             },
             "properties": {
                 "title": "Wochenmarkt Schellerstraße Ecke Spreestraße",
-                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/396",
-                "description": "Do<br />08:00 - 16:00<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/396\">Mehr...</a>",
-                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/396",
+                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/298",
+                "description": "Do<br />08:00 - 16:00<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/298\">Mehr...</a>",
+                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/298",
                 "data": {
-                    "id": "396",
+                    "id": "298",
                     "bezirk": "Treptow-Köpenick",
                     "bezeichnung": "Wochenmarkt Schellerstraße Ecke Spreestraße",
                     "strasse": "Schnellerstraße",
@@ -3763,11 +2554,11 @@
             },
             "properties": {
                 "title": "Wochenmarkt Schillermarkt am Herrfurthplatz",
-                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/186",
-                "description": "Sa<br />10:00 - 16:00<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/186\">Mehr...</a>",
-                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/186",
+                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/145",
+                "description": "Sa<br />10:00 - 16:00<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/145\">Mehr...</a>",
+                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/145",
                 "data": {
-                    "id": "186",
+                    "id": "145",
                     "bezirk": "Neukölln",
                     "bezeichnung": "Wochenmarkt Schillermarkt am Herrfurthplatz",
                     "strasse": "Herrfurthplatz",
@@ -3788,17 +2579,17 @@
             "geometry": {
                 "type": "Point",
                 "coordinates": [
-                    13.57441,
-                    52.44469
+                    13.57401,
+                    52.44501
                 ]
             },
             "properties": {
                 "title": "Wochenmarkt Schlossplatz Alt-Köpenick",
-                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/324",
-                "description": "Di, Do<br />08:30 - 17:00<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/324\">Mehr...</a>",
-                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/324",
+                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/256",
+                "description": "Di, Do<br />08:30 - 17:00<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/256\">Mehr...</a>",
+                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/256",
                 "data": {
-                    "id": "324",
+                    "id": "256",
                     "bezirk": "Treptow-Köpenick",
                     "bezeichnung": "Wochenmarkt Schlossplatz Alt-Köpenick",
                     "strasse": "Grünstraße 1",
@@ -3809,8 +2600,8 @@
                     "email": "mailto:s.stahl@marktgilde.de",
                     "www": "",
                     "bemerkungen": "",
-                    "_wgs84_lat": "52.4446902",
-                    "_wgs84_lon": "13.5744073"
+                    "_wgs84_lat": "52.445005",
+                    "_wgs84_lon": "13.5740096"
                 }
             }
         },
@@ -3825,11 +2616,11 @@
             },
             "properties": {
                 "title": "Wochenmarkt Schnellerstraße",
-                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/327",
-                "description": "Do<br />08:00 - 16:00<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/327\">Mehr...</a>",
-                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/327",
+                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/259",
+                "description": "Do<br />08:00 - 16:00<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/259\">Mehr...</a>",
+                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/259",
                 "data": {
-                    "id": "327",
+                    "id": "259",
                     "bezirk": "Treptow-Köpenick",
                     "bezeichnung": "Wochenmarkt Schnellerstraße",
                     "strasse": "Schnellerstraße",
@@ -3850,17 +2641,17 @@
             "geometry": {
                 "type": "Point",
                 "coordinates": [
-                    13.41078,
-                    52.55216
+                    13.41084,
+                    52.55215
                 ]
             },
             "properties": {
                 "title": "Wochenmarkt Seelower Straße",
-                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/204",
-                "description": "Sa<br />09:00 - 16:00<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/204\">Mehr...</a>",
-                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/204",
+                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/163",
+                "description": "Sa<br />09:00 - 16:00<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/163\">Mehr...</a>",
+                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/163",
                 "data": {
-                    "id": "204",
+                    "id": "163",
                     "bezirk": "Pankow",
                     "bezeichnung": "Wochenmarkt Seelower Straße",
                     "strasse": "Seelower Straße",
@@ -3871,39 +2662,8 @@
                     "email": "mailto:info@bbm-maerkte.de",
                     "www": "http://www.bbm-maerkte.de",
                     "bemerkungen": "",
-                    "_wgs84_lat": "52.5521599",
-                    "_wgs84_lon": "13.4107757"
-                }
-            }
-        },
-        {
-            "type": "Feature",
-            "geometry": {
-                "type": "Point",
-                "coordinates": [
-                    13.29527,
-                    52.50781
-                ]
-            },
-            "properties": {
-                "title": "Wochenmarkt Suarezstraße",
-                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/18",
-                "description": "Do<br />09:00 - 15:00<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/18\">Mehr...</a>",
-                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/18",
-                "data": {
-                    "id": "18",
-                    "bezirk": "Charlottenburg-Wilmersdorf",
-                    "bezeichnung": "Wochenmarkt Suarezstraße",
-                    "strasse": "Suarezstraße",
-                    "plz": "14057",
-                    "tage": "Do",
-                    "zeiten": "09:00 - 15:00",
-                    "betreiber": "Bezirksamt Charlottenburg-Wilmersdorf, Marktverwaltung, Hohenzollerndamm 174-177, 10713 Berlin\nTel.: 9029 - 290 72/3",
-                    "email": "",
-                    "www": "",
-                    "bemerkungen": "(Amtsgericht Charlottenburg)",
-                    "_wgs84_lat": "52.5078147",
-                    "_wgs84_lon": "13.2952716"
+                    "_wgs84_lat": "52.5521545",
+                    "_wgs84_lon": "13.410841"
                 }
             }
         },
@@ -3918,11 +2678,11 @@
             },
             "properties": {
                 "title": "Wochenmarkt Waldsassener Straße",
-                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/288",
-                "description": "Do<br />12:00 - 17:00<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/288\">Mehr...</a>",
-                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/288",
+                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/229",
+                "description": "Do<br />12:00 - 17:00<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/229\">Mehr...</a>",
+                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/229",
                 "data": {
-                    "id": "288",
+                    "id": "229",
                     "bezirk": "Tempelhof-Schöneberg",
                     "bezeichnung": "Wochenmarkt Waldsassener Straße",
                     "strasse": "Waldsassener Straße 47 - 49",
@@ -3943,48 +2703,17 @@
             "geometry": {
                 "type": "Point",
                 "coordinates": [
-                    13.14119,
-                    52.41207
-                ]
-            },
-            "properties": {
-                "title": "Wochenmarkt Wilhelmplatz",
-                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/270",
-                "description": "Fr<br />12:00 - 18:00<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/270\">Mehr...</a>",
-                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/270",
-                "data": {
-                    "id": "270",
-                    "bezirk": "Steglitz-Zehlendorf",
-                    "bezeichnung": "Wochenmarkt Wilhelmplatz",
-                    "strasse": "Wilhelmplatz",
-                    "plz": "14109",
-                    "tage": "Fr",
-                    "zeiten": "12:00 - 18:00",
-                    "betreiber": "Marktleitung: Metin Sunday\nTel.: 03329/69 72 15, 0172/390 20 05",
-                    "email": "",
-                    "www": "",
-                    "bemerkungen": "",
-                    "_wgs84_lat": "52.4120708",
-                    "_wgs84_lon": "13.1411863"
-                }
-            }
-        },
-        {
-            "type": "Feature",
-            "geometry": {
-                "type": "Point",
-                "coordinates": [
-                    13.3556,
-                    52.59896
+                    13.35501,
+                    52.59736
                 ]
             },
             "properties": {
                 "title": "Wochenmarkt Wilhelmsruher Damm / Senftenberger Ring",
-                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/228",
-                "description": "Do, Sa<br />08:00 - 14:00<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/228\">Mehr...</a>",
-                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/228",
+                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/187",
+                "description": "Do, Sa<br />08:00 - 14:00<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/187\">Mehr...</a>",
+                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/187",
                 "data": {
-                    "id": "228",
+                    "id": "187",
                     "bezirk": "Reinickendorf",
                     "bezeichnung": "Wochenmarkt Wilhelmsruher Damm / Senftenberger Ring",
                     "strasse": "Senftenberger Ring 5A",
@@ -3995,8 +2724,8 @@
                     "email": "",
                     "www": "",
                     "bemerkungen": "",
-                    "_wgs84_lat": "52.5989647",
-                    "_wgs84_lon": "13.3556001"
+                    "_wgs84_lat": "52.5973648",
+                    "_wgs84_lon": "13.3550092"
                 }
             }
         },
@@ -4011,11 +2740,11 @@
             },
             "properties": {
                 "title": "Wochenmarkt Winterfeldtplatz",
-                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/291",
-                "description": "Mi&#10;Sa<br />08:00 - 14:00&#10;08:00 - 16:00<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/291\">Mehr...</a>",
-                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/291",
+                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/232",
+                "description": "Mi&#10;Sa<br />08:00 - 14:00&#10;08:00 - 16:00<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/232\">Mehr...</a>",
+                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/232",
                 "data": {
-                    "id": "291",
+                    "id": "232",
                     "bezirk": "Tempelhof-Schöneberg",
                     "bezeichnung": "Wochenmarkt Winterfeldtplatz",
                     "strasse": "Winterfeldtplatz",
@@ -4042,11 +2771,11 @@
             },
             "properties": {
                 "title": "Wochenmarkt Wittenbergplatz (Nordseite)",
-                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/303",
-                "description": "Di&#10;Fr<br />09:00 - 15:00&#10;08:00 - 15:00<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/303\">Mehr...</a>",
-                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/303",
+                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/244",
+                "description": "Di&#10;Fr<br />09:00 - 15:00&#10;08:00 - 15:00<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/244\">Mehr...</a>",
+                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/244",
                 "data": {
-                    "id": "303",
+                    "id": "244",
                     "bezirk": "Tempelhof-Schöneberg",
                     "bezeichnung": "Wochenmarkt Wittenbergplatz (Nordseite)",
                     "strasse": "Wittenbergplatz 5",
@@ -4073,11 +2802,11 @@
             },
             "properties": {
                 "title": "Wochenmarkt Zingster Straße",
-                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/99",
-                "description": "Sa<br />08:00 - 13:00<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/99\">Mehr...</a>",
-                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/99",
+                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/73",
+                "description": "Sa<br />08:00 - 13:00<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/73\">Mehr...</a>",
+                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/73",
                 "data": {
-                    "id": "99",
+                    "id": "73",
                     "bezirk": "Lichtenberg",
                     "bezeichnung": "Wochenmarkt Zingster Straße",
                     "strasse": "Zingster Straße",
@@ -4104,11 +2833,11 @@
             },
             "properties": {
                 "title": "Wochenmarkt am Arkonaplatz",
-                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/123",
-                "description": "Fr<br />12:00 - 19:00<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/123\">Mehr...</a>",
-                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/123",
+                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/97",
+                "description": "Fr<br />12:00 - 19:00<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/97\">Mehr...</a>",
+                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/97",
                 "data": {
-                    "id": "123",
+                    "id": "97",
                     "bezirk": "Mitte",
                     "bezeichnung": "Wochenmarkt am Arkonaplatz",
                     "strasse": "Arkonaplatz",
@@ -4135,11 +2864,11 @@
             },
             "properties": {
                 "title": "Wochenmarkt am Biesdorf-Center",
-                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/120",
-                "description": "Di, Do<br />09:00 - 17:00<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/120\">Mehr...</a>",
-                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/120",
+                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/94",
+                "description": "Di, Do<br />09:00 - 17:00<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/94\">Mehr...</a>",
+                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/94",
                 "data": {
-                    "id": "120",
+                    "id": "94",
                     "bezirk": "Marzahn-Hellersdorf",
                     "bezeichnung": "Wochenmarkt am Biesdorf-Center",
                     "strasse": "Weißenhöher Straße 88-108",
@@ -4166,42 +2895,11 @@
             },
             "properties": {
                 "title": "Wochenmarkt am Hackeschen Markt",
-                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/138",
-                "description": "Do<br />09:00 - 18:00<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/138\">Mehr...</a>",
-                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/138",
+                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/115",
+                "description": "Sa<br />10:00 - 18:00<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/115\">Mehr...</a>",
+                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/115",
                 "data": {
-                    "id": "138",
-                    "bezirk": "Mitte",
-                    "bezeichnung": "Wochenmarkt am Hackeschen Markt",
-                    "strasse": "Hackescher Markt",
-                    "plz": "10178",
-                    "tage": "Do",
-                    "zeiten": "09:00 - 18:00",
-                    "betreiber": "Marktleitung: Fa. Neue Markt GmbH",
-                    "email": "",
-                    "www": "",
-                    "bemerkungen": "",
-                    "_wgs84_lat": "52.5236717",
-                    "_wgs84_lon": "13.4019318"
-                }
-            }
-        },
-        {
-            "type": "Feature",
-            "geometry": {
-                "type": "Point",
-                "coordinates": [
-                    13.40193,
-                    52.52367
-                ]
-            },
-            "properties": {
-                "title": "Wochenmarkt am Hackeschen Markt",
-                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/141",
-                "description": "Sa<br />10:00 - 18:00<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/141\">Mehr...</a>",
-                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/141",
-                "data": {
-                    "id": "141",
+                    "id": "115",
                     "bezirk": "Mitte",
                     "bezeichnung": "Wochenmarkt am Hackeschen Markt",
                     "strasse": "Hackescher Markt",
@@ -4222,17 +2920,48 @@
             "geometry": {
                 "type": "Point",
                 "coordinates": [
+                    13.40193,
+                    52.52367
+                ]
+            },
+            "properties": {
+                "title": "Wochenmarkt am Hackeschen Markt",
+                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/112",
+                "description": "Do<br />09:00 - 18:00<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/112\">Mehr...</a>",
+                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/112",
+                "data": {
+                    "id": "112",
+                    "bezirk": "Mitte",
+                    "bezeichnung": "Wochenmarkt am Hackeschen Markt",
+                    "strasse": "Hackescher Markt",
+                    "plz": "10178",
+                    "tage": "Do",
+                    "zeiten": "09:00 - 18:00",
+                    "betreiber": "Marktleitung: Fa. Neue Markt GmbH",
+                    "email": "",
+                    "www": "",
+                    "bemerkungen": "",
+                    "_wgs84_lat": "52.5236717",
+                    "_wgs84_lon": "13.4019318"
+                }
+            }
+        },
+        {
+            "type": "Feature",
+            "geometry": {
+                "type": "Point",
+                "coordinates": [
                     13.35159,
                     52.54622
                 ]
             },
             "properties": {
                 "title": "Wochenmarkt am Rathaus Wedding",
-                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/129",
-                "description": "Mi, Sa<br />07:00 - 16:00<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/129\">Mehr...</a>",
-                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/129",
+                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/103",
+                "description": "Mi, Sa<br />07:00 - 16:00<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/103\">Mehr...</a>",
+                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/103",
                 "data": {
-                    "id": "129",
+                    "id": "103",
                     "bezirk": "Mitte",
                     "bezeichnung": "Wochenmarkt am Rathaus Wedding",
                     "strasse": "Ostender Straße",
@@ -4259,11 +2988,11 @@
             },
             "properties": {
                 "title": "Zehlendorf Frische Markt zwischen Teltower Damm und Postplatz direkt am S-Bahnhof Zehlendorf",
-                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/363",
-                "description": "Sa<br />09:00 - 16:00<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/363\">Mehr...</a>",
-                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/363",
+                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/277",
+                "description": "Sa<br />09:00 - 16:00<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/277\">Mehr...</a>",
+                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/277",
                 "data": {
-                    "id": "363",
+                    "id": "277",
                     "bezirk": "Steglitz-Zehlendorf",
                     "bezeichnung": "Zehlendorf Frische Markt zwischen Teltower Damm und Postplatz direkt am S-Bahnhof Zehlendorf",
                     "strasse": "S-Bahnhof Zehlendorf",
@@ -4284,48 +3013,17 @@
             "geometry": {
                 "type": "Point",
                 "coordinates": [
-                    13.30911,
-                    52.46705
-                ]
-            },
-            "properties": {
-                "title": "anZiehmarkt, Breitenbachplatz",
-                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/429",
-                "description": "21.06., 19.07., &#10;16.08., 20.09., 18.10., 08.11.2020<br />10:30 - 15:00<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/429\">Mehr...</a>",
-                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/429",
-                "data": {
-                    "id": "429",
-                    "bezirk": "Steglitz-Zehlendorf",
-                    "bezeichnung": "anZiehmarkt, Breitenbachplatz",
-                    "strasse": "Breitenbachplatz 2",
-                    "plz": "14195",
-                    "tage": "21.06., 19.07., \n16.08., 20.09., 18.10., 08.11.2020",
-                    "zeiten": "10:30 - 15:00",
-                    "betreiber": "Fa. MARKTTAG, Tel.: 29 77 99 44",
-                    "email": "mailto:markttag@web.de",
-                    "www": "http://www.markttag-berlin.de",
-                    "bemerkungen": "Verkauf von Bekleidung/Büchern/Bildern und Medien",
-                    "_wgs84_lat": "52.4670451",
-                    "_wgs84_lon": "13.3091087"
-                }
-            }
-        },
-        {
-            "type": "Feature",
-            "geometry": {
-                "type": "Point",
-                "coordinates": [
                     13.2884,
                     52.45871
                 ]
             },
             "properties": {
                 "title": "Öko-Wochenmarkt Domäne Dahlem",
-                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/276",
-                "description": "Sa<br />08:00 - 13:00<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/276\">Mehr...</a>",
-                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/276",
+                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/220",
+                "description": "Sa<br />08:00 - 13:00<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/220\">Mehr...</a>",
+                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/220",
                 "data": {
-                    "id": "276",
+                    "id": "220",
                     "bezirk": "Steglitz-Zehlendorf",
                     "bezeichnung": "Öko-Wochenmarkt Domäne Dahlem",
                     "strasse": "Königin-Luise-Str. 49",
@@ -4352,11 +3050,11 @@
             },
             "properties": {
                 "title": "Ökomarkt & mehr an der Akazienstraße",
-                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/378",
-                "description": "Do<br />12:00 - 18:00<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/378\">Mehr...</a>",
-                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/378",
+                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/292",
+                "description": "Do<br />12:00 - 18:00<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/292\">Mehr...</a>",
+                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/292",
                 "data": {
-                    "id": "378",
+                    "id": "292",
                     "bezirk": "Tempelhof-Schöneberg",
                     "bezeichnung": "Ökomarkt & mehr an der Akazienstraße",
                     "strasse": "Akazienstraße 15",
@@ -4383,11 +3081,11 @@
             },
             "properties": {
                 "title": "Ökomarkt & mehr an der Thusnelda-Allee",
-                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/372",
-                "description": "Mi<br />12:00 - 18:00 (Winter)&#10;12:00 - 19:00 (Sommer)<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/372\">Mehr...</a>",
-                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/372",
+                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/286",
+                "description": "Mi<br />12:00 - 18:00 (Winter)&#10;12:00 - 19:00 (Sommer)<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/286\">Mehr...</a>",
+                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/286",
                 "data": {
-                    "id": "372",
+                    "id": "286",
                     "bezirk": "Mitte",
                     "bezeichnung": "Ökomarkt & mehr an der Thusnelda-Allee",
                     "strasse": "Thusnelda-Allee 1",
@@ -4414,11 +3112,11 @@
             },
             "properties": {
                 "title": "Ökomarkt - Chamissoplatz",
-                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/66",
-                "description": "Sa<br />09:00 - 15:00<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/66\">Mehr...</a>",
-                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/66",
+                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/46",
+                "description": "Sa<br />09:00 - 15:00<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/46\">Mehr...</a>",
+                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/46",
                 "data": {
-                    "id": "66",
+                    "id": "46",
                     "bezirk": "Friedrichshain-Kreuzberg",
                     "bezeichnung": "Ökomarkt - Chamissoplatz",
                     "strasse": "Chamissoplatz",
@@ -4445,11 +3143,11 @@
             },
             "properties": {
                 "title": "Ökomarkt am Kollwitzplatz der GRÜNEN LIGA Berlin e. V.",
-                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/192",
-                "description": "Do<br />12:00 - 19:00<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/192\">Mehr...</a>",
-                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/192",
+                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/151",
+                "description": "Do<br />12:00 - 19:00<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/151\">Mehr...</a>",
+                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/151",
                 "data": {
-                    "id": "192",
+                    "id": "151",
                     "bezirk": "Pankow",
                     "bezeichnung": "Ökomarkt am Kollwitzplatz der GRÜNEN LIGA Berlin e. V.",
                     "strasse": "Kollwitzplatz",
@@ -4476,11 +3174,11 @@
             },
             "properties": {
                 "title": "Ökomarkt am Nordbahnhof",
-                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/147",
-                "description": "Mi<br />11:00 - 18:00 (Sommer)&#10;11:00 - 17:00 (Winter)<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/147\">Mehr...</a>",
-                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/147",
+                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/121",
+                "description": "Mi<br />11:00 - 18:00 (Sommer)&#10;11:00 - 17:00 (Winter)<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/121\">Mehr...</a>",
+                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/121",
                 "data": {
-                    "id": "147",
+                    "id": "121",
                     "bezirk": "Mitte",
                     "bezeichnung": "Ökomarkt am Nordbahnhof",
                     "strasse": "Elisabeth-Schwarzhaupt-Platz",
@@ -4507,11 +3205,11 @@
             },
             "properties": {
                 "title": "Ökomarkt im Hansaviertel",
-                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/144",
-                "description": "Fr<br />12:00 - 18:30<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/144\">Mehr...</a>",
-                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/144",
+                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/118",
+                "description": "Fr<br />12:00 - 18:30<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/118\">Mehr...</a>",
+                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/118",
                 "data": {
-                    "id": "144",
+                    "id": "118",
                     "bezirk": "Mitte",
                     "bezeichnung": "Ökomarkt im Hansaviertel",
                     "strasse": "Altonaer Straße",


### PR DESCRIPTION
+ URL also changed! See https://github.com/wo-ist-markt/wo-ist-markt-berlin-update-reminder/pull/6.