### PR TITLE
Improve validation output for market data source URLs

### DIFF
--- a/cities/bielefeld.json
+++ b/cities/bielefeld.json
@@ -3,7 +3,7 @@
   "metadata": {
     "data_source": {
         "title": "Presseamt Stadt Bielefeld, aktualisiert am 03.06.2020",
-        "url": "https://www.bielefeld.de/de/rv/ds_stadtverwaltung/ordg/womae/"
+        "url": "https://www.bielefeld.de/node/5829"
     }
   },
   "features": [

--- a/cities/bochum.json
+++ b/cities/bochum.json
@@ -191,7 +191,7 @@
   "metadata": {
     "data_source": {
       "title": "Stadt Bochum",
-      "url": "https://www.bochum.de/amt32/wochenmaerkte"
+      "url": "https://www.bochum-tourismus.de/bochum-entdecken/einkaufen/wochenmaerkte-in-bochum.html#c25047"
     }
   }
 }

--- a/cities/braunschweig.json
+++ b/cities/braunschweig.json
@@ -190,7 +190,7 @@
     "metadata": {
         "data_source": {
             "title": "Stadt Braunschweig",
-            "url": "http://www.braunschweig.de/leben/einkaufen_maerkte/wochenmaerkte/index.html"
+            "url": "https://www.braunschweig.de/leben/einkaufen_maerkte/wochenmaerkte/index.php"
         }
     },
     "type": "FeatureCollection"

--- a/cities/bretten.json
+++ b/cities/bretten.json
@@ -25,7 +25,7 @@
     "metadata": {
         "data_source": {
             "title": "Stadt Bretten",
-            "url": "http://www.bretten.de/tourismus-kultur-freizeit/wochenmarkt"
+            "url": "https://www.bretten.de/tourismus-kultur-freizeit/wochenmarkt"
         }
     },
     "type": "FeatureCollection"

--- a/cities/bruchköbel.json
+++ b/cities/bruchköbel.json
@@ -34,7 +34,7 @@
     "metadata": {
         "data_source": {
             "title": "Stadtmarketing Bruchköbel GmbH",
-            "url": "https://www.stadtmarketing-bruchkoebel.de/einkaufen-geniessen/wochenmarkt-bruchkoebel/"
+            "url": "https://www.bruchkoebel.de/kultur-einkaufen-genuss/einkaufen-genuss/wochenmarkt"
         }
     },
     "type": "FeatureCollection"

--- a/cities/düsseldorf.json
+++ b/cities/düsseldorf.json
@@ -454,7 +454,7 @@
 	],
     "metadata": {
         "data_source": {
-            "url": "https://www.duesseldorf.de/verbraucherschutz/marktmanagement/wochenmaerkte/termine.html",
+            "url": "https://www.duesseldorf.de/umweltamt/umwelt-und-verbraucherthemen-von-a-z/marktmanagement/wochenmaerkte/termine.html",
             "title": "Amt für Verbraucherschutz Düsseldorf"
         }
     }

--- a/cities/essen.json
+++ b/cities/essen.json
@@ -401,7 +401,7 @@
   "metadata": {
     "data_source": {
       "title": "EVB",
-      "url": "https://www.essen.de/rathaus/aemter/ordner_32/Wochenmaerkte.de.html"
+      "url": "https://www.wochenmaerkte-essen.de"
     }
   }
 }

--- a/cities/frankfurtmain.json
+++ b/cities/frankfurtmain.json
@@ -356,7 +356,7 @@
     "metadata": {
         "data_source": {
             "title": "Stadt Frankfurt am Main",
-            "url": "https://frankfurt.de/sixcms/detail.php?id=4623&_ffmpar%5B_id_eltern%5D=4622"
+            "url": "https://frankfurt.de/frankfurt-entdecken-und-erleben/einkaufen-in-frankfurt/maerkte-und-flohmaerkte/wochenmaerkte"
         }
     },
     "type": "FeatureCollection"

--- a/cities/friedrichsdorf.json
+++ b/cities/friedrichsdorf.json
@@ -19,7 +19,7 @@
     "metadata": {
         "data_source": {
             "title": "Stadt Friedrichsdorf",
-            "url": "http://www.friedrichsdorf.de/lebeninfriedrichsdorf/einkaufenunddienstleistung/wochenmarkt.php"
+            "url": "https://www.friedrichsdorf.de/lebeninfriedrichsdorf/einkaufenunddienstleistung/wochenmarkt.php"
         }
     },
     "type": "FeatureCollection"

--- a/cities/hamm.json
+++ b/cities/hamm.json
@@ -101,7 +101,7 @@
   "metadata": {
     "data_source": {
       "title": "Stadt Hamm",
-      "url": "https://www.hamm.de/touristik/freizeit/einkaufen/wochenmaerkte.html"
+      "url": "https://www.hamm.de/tourismus/freizeit/einkaufen/wochenmaerkte"
     }
   }
 }

--- a/cities/hanau.json
+++ b/cities/hanau.json
@@ -19,7 +19,7 @@
     "metadata": {
         "data_source": {
             "title": "Stadt Hanau",
-            "url": "https://www.hanau.de/lih/sport/maerkte/woma/010241/"
+            "url": "https://www.hanau.de/freizeit/veranstaltungskalender/veranstaltungen/013906.html"
         }
     },
     "type": "FeatureCollection"

--- a/cities/kaiserslautern.json
+++ b/cities/kaiserslautern.json
@@ -50,7 +50,7 @@
     "metadata": {
         "data_source": {
             "title": "Kaiserslauterer Wochenmarktverein",
-            "url": "https://www.wochenmarkt-kaiserslautern.de/"
+            "url": "https://www.wochenmarkt-kl.de"
         }
     },
     "type": "FeatureCollection"

--- a/cities/kassel.json
+++ b/cities/kassel.json
@@ -55,7 +55,7 @@
     "metadata": {
         "data_source": {
             "title": "Stadt Kassel",
-            "url": "https://www.serviceportal-kassel.de/cms05/dienstleistungen/029907/index.html"
+            "url": "https://www.kassel.de/service/produkte/kassel/ordnungsamt/ordnungs--und-aufsichtsangelegenheiten/wochenmaerkte.php"
         }
     },
     "type": "FeatureCollection"

--- a/cities/konstanz.json
+++ b/cities/konstanz.json
@@ -40,7 +40,7 @@
     "metadata": {
         "data_source": {
             "title": "Stadt Konstanz",
-            "url": "https://www.konstanz-tourismus.de/erleben-entdecken/shopping/maerkte/wochenmaerkte.html"
+            "url": "https://www.konstanz-info.com/erleben-entdecken/shopping/maerkte/wochenmaerkte"
         }
     },
     "type": "FeatureCollection"

--- a/cities/luebeck.json
+++ b/cities/luebeck.json
@@ -155,7 +155,7 @@
     ],
     "metadata" : {
         "data_source" : {
-            "url" : "https://www.luebeck-tourismus.de/einkaufen/shoppingparadies/maerkte-regionale-produkte.html",
+            "url" : "https://www.luebeck.de/de/stadtleben/freizeit/wochenmaerkte/index.html",
             "title" : "Lübeck Tourismus. Last update: 2019-06-27"
         }
     }

--- a/cities/münster.json
+++ b/cities/münster.json
@@ -290,7 +290,7 @@
     "metadata": {
         "data_source": {
             "title": "Stadt Münster",
-            "url": "http://www.muenster.de/stadt/maerkte/markt.html"
+            "url": "https://www.stadt-muenster.de/maerkte/startseite.html"
         }
     }
 }

--- a/cities/oberursel.json
+++ b/cities/oberursel.json
@@ -79,7 +79,7 @@
     "metadata": {
         "data_source": {
             "title": "Stadt Oberursel",
-            "url": "https://www.oberursel.de/de/slider-artikel/wochenmarkt/"
+            "url": "https://www.oberursel.de/de/aktuelle-infos/wochenmarkt/"
         }
     },
     "type": "FeatureCollection"

--- a/cities/schwerin.json
+++ b/cities/schwerin.json
@@ -125,7 +125,7 @@
   "metadata": {
     "data_source": {
       "title": "Stadtmarketing Gesellschaft Schwerin mbH",
-      "url": "http://marketing.schwerin.info/stadtmarketing/aufgaben/Flaeche_Maerkte.html"
+      "url": "https://marketing.schwerin.info/stadtmarketing/aufgaben/Flaeche_Maerkte.html"
     }
   }
 }

--- a/cities/stuttgart.json
+++ b/cities/stuttgart.json
@@ -424,7 +424,7 @@
   "metadata": {
     "data_source": {
       "title": "Stuttgarter Wochenmärkte, Koordinaten teilweise OpenStreetMap-Mitwirkende",
-      "url": "http://www.stuttgarter-wochenmaerkte.de/maerkte-staende/uebersicht/"
+      "url": "https://www.stuttgarter-wochenmaerkte.de/maerkte-staende/uebersicht/"
     }
   },
   "type": "FeatureCollection"

--- a/cities/witten.json
+++ b/cities/witten.json
@@ -71,7 +71,7 @@
   "metadata": {
     "data_source": {
       "title": "Stadtmarketing Witten GmbH",
-      "url": "https://www.stadtmarketing-witten.de/einkaufen/wochenmaerkte.html"
+      "url": "https://www.stadtmarketing-witten.de/einkaufen-geniessen/wochenmaerkte"
     }
   }
 }

--- a/cities/wuppertal.json
+++ b/cities/wuppertal.json
@@ -170,7 +170,7 @@
     "metadata": {
         "data_source": {
             "title": "Stadt Wuppertal",
-            "url": "https://www.wuppertal.de/tourismus-freizeit/einkaufen/102370100000204430.php"
+            "url": "https://www.wuppertal.de/tourismus-freizeit/einkaufen/wochenmarkt.php"
         }
     }
 }

--- a/package.json
+++ b/package.json
@@ -19,5 +19,8 @@
     "jasmine-tests": "jasmine",
     "test": "npm run lint && npm run jasmine-tests && npm run validate",
     "validate": "node validation/markets-validator.js"
+  },
+  "dependencies": {
+    "node": ">=12"
   }
 }

--- a/validation/.jshintrc
+++ b/validation/.jshintrc
@@ -1,0 +1,6 @@
+{
+    "node": true,
+    "globals": {
+    	"URL": true
+    }
+}

--- a/validation/markets-validator.js
+++ b/validation/markets-validator.js
@@ -43,7 +43,7 @@ var MIN_LONGITUDE = -180.0;
  * is impossible for us to resolve the issue.
  * The aim is to keep this count as low as possible.
  */
-var ACCEPTABLE_WARNINGS_COUNT = 4;
+var ACCEPTABLE_WARNINGS_COUNT = 2;
 
 var exitCode = 0;
 
@@ -611,6 +611,10 @@ function MetadataValidator(metadata, cityName) {
         request = request.request(url, {
             method: 'HEAD',
             timeout: 10000, // 10 seconds
+            headers: {
+                'User-Agent': REPO_URL,
+                'Accept': '*/*',
+            },
         }, function(response) {
             if (response.statusCode >= 300 && response.statusCode < 400) {
                 asyncWarnings.push(new HttpRedirectStatusIssue(cityName, response.statusCode, response.headers.location));
@@ -619,10 +623,7 @@ function MetadataValidator(metadata, cityName) {
             }
 
             // Cleaning up http request and response
-            // "However, if you add a 'response' event handler, then you
-            //  must consume the data from the response object" NodeJS docs
-            response.on('data', function() {});
-            response.on('end', function() {});
+            response.destroy();
         });
         request.on('error', function(error) {
             if (error == "Error: certificate has expired") {

--- a/validation/markets-validator.js
+++ b/validation/markets-validator.js
@@ -30,6 +30,14 @@ var MIN_LATITUDE = -90.0;
 var MAX_LONGITUDE = 180.0;
 var MIN_LONGITUDE = -180.0;
 
+/**
+ * In an optimal world there should be zero warnings.
+ * Some websites however simply behave strange and it
+ * is impossible for us to resolve the issue.
+ * The aim is to keep this count as low as possible.
+ */
+var ACCEPTABLE_WARNINGS_COUNT = 4;
+
 var exitCode = 0;
 
 var asyncWarnings = [];
@@ -120,6 +128,12 @@ process.on('beforeExit', function () {
         console.log("Error: ".error + error.toString());
     });
 
+    var warningsCount = asyncWarnings.length;
+    if (warningsCount > ACCEPTABLE_WARNINGS_COUNT) {
+        printSupportRequest(warningsCount);
+        exitCode = 1;
+    }
+
     process.exitCode = exitCode;
 });
 
@@ -153,6 +167,20 @@ function getFormattedText(text) {
         }
     }
     return formattedText;
+}
+
+/**
+ * Outputs a message to the console in order to engage the developer to fix issues.
+ *
+ * - warningsCount Number of warnings detected
+ */
+function printSupportRequest(warningsCount) {
+    console.log("--------------------------------------------------------------------------------------------------");
+    console.log("YOUR HELP IS NEEDED. PLEASE SUPPORT THIS PROJECT.\n".warning);
+    console.log(warningsCount + " warnings have been detected. These exceed the acceptable number of " + ACCEPTABLE_WARNINGS_COUNT + ".");
+    console.log("Please take the time to fix some of the issues even if they are not related to your pull request.");
+    console.log("Please add the fix in a separate commit.");
+    console.log("--------------------------------------------------------------------------------------------------\n");
 }
 
 /**

--- a/validation/markets-validator.js
+++ b/validation/markets-validator.js
@@ -41,7 +41,8 @@ colors.setTheme({
     market: 'brightBlue',
     passed: 'green',
     error: 'red',
-    info: 'grey'
+    info: 'grey',
+    warning: 'yellow'
 });
 
 /**
@@ -106,21 +107,53 @@ fs.readdir(MARKETS_DIR_PATH, function (err, files) {
 process.on('beforeExit', function () {
     console.log("\n");
     asyncWarnings.forEach(function (warning) {
-        console.log('Warning: %s', warning.toString());
+        console.log("Warning: ".warning + getFormattedText(warning.toString()));
     });
 
     console.log("\n");
     asyncExpiredCertificateIssues.forEach(function (issue) {
-        console.log("Info: ".info + issue.toString());
+        console.log("Info: ".info + getFormattedText(issue.toString()));
     });
 
     console.log("\n");
     asyncErrors.forEach(function (error) {
-        console.log('Error: %s', error.toString());
+        console.log("Error: ".error + error.toString());
     });
 
     process.exitCode = exitCode;
 });
+
+/**
+  * Returns the given issue or warning text formatted with colors.
+  * Text parts such as the market name, the status code and the new location URL are emphasized.
+  *
+  * - text Issue or warning text delimited by colons and line breaks.
+  */
+function getFormattedText(text) {
+    var formattedText = "";
+    var parts = text.split(":");
+    if (parts.length < 2) {
+        return text;
+    }
+    formattedText += parts[0].market + ":";
+    formattedText += parts[1];
+    if (parts.length == 3) {
+        formattedText += ":" + parts[2].error;
+    }
+    if (parts.length > 3 && parts[2].includes("\n")) {
+        var linebreakPart = parts[2].split("\n");
+        formattedText += ":" + linebreakPart[0].error + "\n";
+        formattedText += linebreakPart[1];
+        for (var i = 3; i < parts.length; i++) {
+            formattedText += ":" + parts[i].warning;
+        }
+    } else if (parts.length > 3) {
+        for (var j = 3; j < parts.length; j++) {
+            formattedText += ":" + parts[j].warning;
+        }
+    }
+    return formattedText;
+}
 
 /**
  * Validator for a market file.

--- a/validation/markets-validator.js
+++ b/validation/markets-validator.js
@@ -13,14 +13,21 @@
  */
 
 
+var assert = require('assert');
 var fs = require('fs');
 var path = require("path");
 var colors = require('colors');
 var opening_hours = require('opening_hours');
-var urlparse = require('url').parse;
 var http = require('http');
 var https = require('https');
+var pkg = require('../package.json');
 
+/** 
+ * The repository URL is used in the user-agent header in the url
+ * status validation (see: MetadataValidator#validateUrlStatus).
+ */
+var REPO_URL = pkg.repository.url;
+assert.ok(REPO_URL, 'missing/invalid repo URL in package.json');
 
 var MARKETS_DIR_PATH = "cities";
 var MARKETS_INDEX_FILE_PATH = path.join('cities', 'cities.json');
@@ -590,9 +597,7 @@ function MetadataValidator(metadata, cityName) {
     };
 
     this.validateUrlStatus = function(url) {
-        url = urlparse(url);
-        url.method = 'HEAD';
-        url.timeout = 10000; // 10 seconds
+        url = new URL(url);
 
         var request;
         switch(url.protocol) {
@@ -603,7 +608,10 @@ function MetadataValidator(metadata, cityName) {
                 return;
         }
 
-        request = request.request(url, function(response) {
+        request = request.request(url, {
+            method: 'HEAD',
+            timeout: 10000, // 10 seconds
+        }, function(response) {
             if (response.statusCode >= 300 && response.statusCode < 400) {
                 asyncWarnings.push(new HttpRedirectStatusIssue(cityName, response.statusCode, response.headers.location));
             } else if (response.statusCode !== 200) {

--- a/validation/markets-validator.js
+++ b/validation/markets-validator.js
@@ -695,7 +695,7 @@ function HttpRedirectStatusIssue(cityName, statusCode, location) {
     this.location = location;
 
     this.toString = function() {
-        return this.cityName + ": HTTP response status of data source url was: " + this.statusCode + "\n New location: " + this.location;
+        return this.cityName + ": HTTP response status of data source url was: " + this.statusCode + "\n     --> New location: " + this.location;
     };
 }
 

--- a/validation/markets-validator.js
+++ b/validation/markets-validator.js
@@ -38,7 +38,7 @@ var asyncErrors = [];
 
 colors.setTheme({
     section: 'blue',
-    market: 'yellow',
+    market: 'brightBlue',
     passed: 'green',
     error: 'red',
     info: 'grey'
@@ -59,10 +59,10 @@ fs.readFile(MARKETS_INDEX_FILE_PATH, function(err, data){
         var json = JSON.parse(data);
         Object.getOwnPropertyNames(json).forEach(function(key) {
             if (key == json[key].id){
-                console.log("Key of ".passed + key.section + " matches id.".passed);
+                console.log("Key of ".passed + key.market + " matches id.".passed);
             }
             else {
-                console.error("Key of ".error + key.section + " does not match id.".error);
+                console.error("Key of ".error + key.market + " does not match id.".error);
                 errorsCount +=1;
             }
 


### PR DESCRIPTION
This pull request targets the data source URLs of the markets by:
- Updating a couple of outdated URLs.
- Improving the readability of the validation output.
  - Expired certificates are output as `Info` and separated from the remaining issues.
  - Specific text parts such as the market name, HTTP status code and the new URL location are colorized.
- Encouraging pull request authors to fix outdated URLs when - meanwhile - they have changed.
- URL validation improvements by @derhuerst: fix {http,https}.request() call, send User-Agent, destroy() response

# Validation output before (example)
![wim-before](https://user-images.githubusercontent.com/144518/111847640-81c7d480-8909-11eb-92b4-ff72ea6de3b4.png)

# Validation output after (example)
![wim-after](https://user-images.githubusercontent.com/144518/111847637-8096a780-8909-11eb-9529-0844b77601e7.png)
 