### PR TITLE
Remove unneeded i18next-client.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,6 @@
       "dependencies": {
         "dayjs": "^1.10.5",
         "font-awesome": "^4.7.0",
-        "i18next-client": "^1.11.4",
         "jquery": "^3.6.0",
         "leaflet": "^1.7.1",
         "leaflet.awesome-markers": "^2.0.5",
@@ -25,7 +24,6 @@
         "@rollup/plugin-node-resolve": "^11.2.1",
         "colors": "^1.4.0",
         "dayjs": "^1.10.5",
-        "i18next-client": "^1.11.5",
         "jasmine": "^3.7.0",
         "jshint": "^2.12.0",
         "opening_hours": "^3.6.0",
@@ -710,15 +708,6 @@
       "integrity": "sha512-YDzIGHhMRvr7M+c8B3EQUKyiMBhfqox4o1qkFvt4QXuu5V2cxf74+NCr+VEkUuU0y+RwcupA238eeolW1Yn80g==",
       "dependencies": {
         "@babel/runtime": "^7.14.6"
-      }
-    },
-    "node_modules/i18next-client": {
-      "version": "1.11.4",
-      "resolved": "https://registry.npmjs.org/i18next-client/-/i18next-client-1.11.4.tgz",
-      "integrity": "sha1-BILrG2Q+z3qEBPe1kuujKOXwmuc=",
-      "deprecated": "you can use npm install i18next from version 2.0.0",
-      "engines": {
-        "node": ">=0.4.12"
       }
     },
     "node_modules/ignore": {
@@ -2026,11 +2015,6 @@
       "requires": {
         "@babel/runtime": "^7.14.6"
       }
-    },
-    "i18next-client": {
-      "version": "1.11.4",
-      "resolved": "https://registry.npmjs.org/i18next-client/-/i18next-client-1.11.4.tgz",
-      "integrity": "sha1-BILrG2Q+z3qEBPe1kuujKOXwmuc="
     },
     "ignore": {
       "version": "5.1.8",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,6 @@
   "dependencies": {
     "dayjs": "^1.10.5",
     "font-awesome": "^4.7.0",
-    "i18next-client": "^1.11.4",
     "jquery": "^3.6.0",
     "leaflet": "^1.7.1",
     "leaflet.awesome-markers": "^2.0.5",
@@ -20,7 +19,6 @@
     "@rollup/plugin-node-resolve": "^11.2.1",
     "colors": "^1.4.0",
     "dayjs": "^1.10.5",
-    "i18next-client": "^1.11.5",
     "jasmine": "^3.7.0",
     "jshint": "^2.12.0",
     "opening_hours": "^3.6.0",


### PR DESCRIPTION
+ The `i18next-client` package was added in 38f4b376f80afde893bde894af4e0b0f1bb97a4d, see https://github.com/wo-ist-markt/wo-ist-markt.github.io/commit/38f4b376f80afde893bde894af4e0b0f1bb97a4d#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519. It appears to be unneeded.

Closes #372