### PR TITLE
Update outdated data source URL for Osnabrück.

### DIFF
--- a/cities/osnabrück.json
+++ b/cities/osnabrück.json
@@ -94,7 +94,7 @@
     "metadata": {
         "data_source": {
             "title": "Stadt Osnabrück",
-            "url": "https://www.osnabrueck.de/tourismus/aktivitaeten/hoehepunkte/wochenmaerkte.html"
+            "url": "https://www.osnabrueck.de/tourismus/aktivitaeten/hoehepunkte/wochenmaerkte"
         }
     },
     "type": "FeatureCollection"


### PR DESCRIPTION
+ This fixes a validation error caused by the HTTP 404.