### PR TITLE
Use update date from original data source.

### DIFF
--- a/cities/berlin.json
+++ b/cities/berlin.json
@@ -2095,7 +2095,7 @@
     ],
     "metadata": {
         "data_source": {
-            "title": "Stadt Berlin, CC BY 3.0 DE, aktualisiert am 29.07.2021",
+            "title": "Stadt Berlin, CC BY 3.0 DE, aktualisiert am 20.07.2021",
             "url": "https://daten.berlin.de/datensaetze/wochen-und-tr%C3%B6delm%C3%A4rkte"
         }
     }


### PR DESCRIPTION
+ This fixes the [update reminder](https://github.com/wo-ist-markt/wo-ist-markt-berlin-update-reminder) which daily compares the date of the original data source and the date on the _Wo ist Markt?_ website.
+ Broken since: ddc5b1625a14e953499dc15c5f739471a0f501bb.