### PR TITLE
Update Gelsenkirchen.

### DIFF
--- a/cities/gelsenkirchen.json
+++ b/cities/gelsenkirchen.json
@@ -161,7 +161,7 @@
   "metadata": {
     "data_source": {
       "title": "Gelsendienste",
-      "url": "https://www.gelsendienste.de/Wochenmaerkte/Unsere_Leistungen/Wochenmaerkte_im_Stadtgebiet.asp"
+      "url": "http://www.gelsendienste.de/privathaushalte/maerkte/"
     }
   }
 }

--- a/validation/markets-validator.js
+++ b/validation/markets-validator.js
@@ -43,7 +43,7 @@ var MIN_LONGITUDE = -180.0;
  * is impossible for us to resolve the issue.
  * The aim is to keep this count as low as possible.
  */
-var ACCEPTABLE_WARNINGS_COUNT = 1;
+var ACCEPTABLE_WARNINGS_COUNT = 2;
 
 var exitCode = 0;
 


### PR DESCRIPTION
+ https fails with: `SSL certificate problem: unable to get local issuer certificate.`