### PR TITLE
switch to esm

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "wo-ist-markt",
   "version": "0.0.1",
+  "type": "module",
   "dependencies": {
     "dayjs": "^1.10.7",
     "jquery": "^3.6.0",

--- a/preprocessing/addPositionsToCities.js
+++ b/preprocessing/addPositionsToCities.js
@@ -5,9 +5,10 @@
  * If the city or the coordinates are not found, an error is shown.
  * If that happens please add the coordinates manually to the cities.json file.
  */
-var fs = require('fs');
-var axios = require('axios').default;
-var ora = require('ora');
+
+import fs from 'fs';
+import axios from 'axios';
+import ora from 'ora';
 
 var CITY_FILE = 'cities/cities.json';
 var WIKIPEDIA_API_URL = "https://en.wikipedia.org/w/api.php"; 

--- a/preprocessing/berlin/compile-berlin-geojson.js
+++ b/preprocessing/berlin/compile-berlin-geojson.js
@@ -2,10 +2,9 @@
 "use strict";
 
 
-
-var fs = require('fs');
-var dayjs = require('dayjs');
-var opening_hours = require('opening_hours');
+import fs from 'fs';
+import dayjs from 'dayjs';
+import opening_hours from 'opening_hours';
 
 
 var INPUT_FILE = "./preprocessing/berlin/raw/markets-berlin.json";

--- a/spec/citylist-spec.js
+++ b/spec/citylist-spec.js
@@ -1,6 +1,5 @@
-var fs = require('fs'),
-    path = require('path');
-
+import fs from 'fs';
+import path from 'path';
 
 function normalizeString(string){
     return string.normalize();
@@ -84,7 +83,7 @@ describe('CityList', function() {
                 key;
             for (var i = 0, n = keys.length; i < n; i++) {
                 key = keys[i];
-                city = cities[key];
+                var city = cities[key];
                 expect(key).toBe(city.id, "Key and id do not match");
             }
         });

--- a/spec/support/jasmine.json
+++ b/spec/support/jasmine.json
@@ -7,5 +7,6 @@
     "helpers/**/*.js"
   ],
   "stopSpecOnExpectationFailure": false,
-  "random": false
+  "random": false,
+  "jsLoader": "import"
 }

--- a/validation/.jshintrc
+++ b/validation/.jshintrc
@@ -1,4 +1,5 @@
 {
+    "esversion": 8,
     "node": true,
     "globals": {
     	"URL": true

--- a/validation/markets-validator.js
+++ b/validation/markets-validator.js
@@ -13,14 +13,23 @@
  */
 
 
-var assert = require('assert');
-var fs = require('fs');
-var path = require("path");
-var colors = require('colors');
-var opening_hours = require('opening_hours');
-var http = require('http');
-var https = require('https');
-var pkg = require('../package.json');
+import assert from 'assert';
+import fs from 'fs';
+import path from "path";
+import colors from 'colors';
+import opening_hours from 'opening_hours';
+import http from 'http';
+import https from 'https';
+
+function loadPackageJson() {
+  const rootPath = fs.realpathSync('.');
+  const packageJsonPath = path.join(rootPath, 'package.json');
+  const pkgFile = fs.readFileSync(packageJsonPath, 'utf8');
+  const packageJson = JSON.parse(pkgFile);
+  return packageJson;
+}
+
+const pkg = loadPackageJson();
 
 /** 
  * The repository URL is used in the user-agent header in the url


### PR DESCRIPTION
- Switch from CommonJS (`require(...)`) to ESM (`import ... from ...`) for all node scripts.
- This is needed for #410 because `ora@6` only supports ESM.