### PR TITLE
Validation warnings regarding Gelsenkirchen disappeared.

### DIFF
--- a/validation/markets-validator.js
+++ b/validation/markets-validator.js
@@ -52,7 +52,7 @@ var MIN_LONGITUDE = -180.0;
  * is impossible for us to resolve the issue.
  * The aim is to keep this count as low as possible.
  */
-var ACCEPTABLE_WARNINGS_COUNT = 1;
+var ACCEPTABLE_WARNINGS_COUNT = 0;
 
 var exitCode = 0;
 


### PR DESCRIPTION
+ The city renewed its SSL certificate, now valid till 25.10.2022.

---

Resolves #407