### PR TITLE
Improve preprocessing for Berlin data

### DIFF
--- a/cities/berlin.json
+++ b/cities/berlin.json
@@ -1818,8 +1818,8 @@
             "properties": {
                 "title": "Wochenmarkt Wilhelmsruher Damm",
                 "location": "Wilhelmsruher Damm 159, 13439",
-                "opening_hours": null,
-                "opening_hours_unclassified": "Di Do Sa 09:00 - 17:00 09:00 - 17:00 07:00 - 17:00",
+                "opening_hours": "Tu 09:00-17:00;Th 09:00-17:00;Sa 07:00-17:00",
+                "opening_hours_unclassified": null,
                 "details_url": "http://www.brandenburger-wochenmaerkte.de"
             }
         },

--- a/preprocessing/berlin/compile-berlin-geojson.js
+++ b/preprocessing/berlin/compile-berlin-geojson.js
@@ -42,7 +42,13 @@ function sortInputFileByTitle() {
 		var outputData = featureCollection;
 
 		outputData.features = outputData.features.sort(function(a, b) {
-			return a.properties.title > b.properties.title ? 1 : -1;
+			if (a.properties.title > b.properties.title) {
+				return 1;
+			}
+			if (a.properties.title < b.properties.title) {
+				return -1;
+			}
+			return a.properties.id > b.properties.id ? 1 : -1;
 		});
 
 		var outputDataString = JSON.stringify(outputData, null, 4);

--- a/preprocessing/berlin/compile-berlin-geojson.js
+++ b/preprocessing/berlin/compile-berlin-geojson.js
@@ -100,7 +100,7 @@ function prepareFeatureProperties(feature) {
 	var days_hours = sanitizedDays + " " + sanitizedHours;
 
 	try {
-		getOpeningRanges(days_hours);
+		parseWithOpeningHoursJs(days_hours);
 		var opening_hours = composeOpeningHours(sanitizedDays, sanitizedHours);
 		outputProperties.opening_hours = opening_hours;
 		outputProperties.opening_hours_unclassified = null;
@@ -246,9 +246,10 @@ function getSanitizeHours(hours) {
 }
 
 /*
- * Returns opening ranges compiled via opening_hours.js.
+ * Parses the given string with the opening_hours.js library.
+ * An error is thrown if the parsing fails.
  */
-function getOpeningRanges(opening_hours_strings) {
+function parseWithOpeningHoursJs(opening_hours_strings) {
     var monday = dayjs().startOf("week").add(1, 'day').toDate();
     var sunday = dayjs().endOf("week").add(1, 'day').toDate();
     var options = {
@@ -257,5 +258,5 @@ function getOpeningRanges(opening_hours_strings) {
     	}
     };
     var oh = new opening_hours(opening_hours_strings, options);
-    return oh.getOpenIntervals(monday, sunday);
+    oh.getOpenIntervals(monday, sunday);
 }

--- a/preprocessing/berlin/compile-berlin-geojson.js
+++ b/preprocessing/berlin/compile-berlin-geojson.js
@@ -241,6 +241,7 @@ function getSanitizeHours(hours) {
 	hours = hours.replace(/\n/g, " ");
 	hours = hours.replace(/ /g, ",");
 	hours = hours.replace(/^,/g, "");
+	hours = hours.replace(/,$/g, "");
 	hours = hours.trim();
 	return hours;
 }

--- a/preprocessing/berlin/compile-berlin-geojson.js
+++ b/preprocessing/berlin/compile-berlin-geojson.js
@@ -208,10 +208,27 @@ function getSanitizeString(text) {
 	return text;
 }
 
+const ENGLISH_MONTH_ABBREVATION_BY_GERMAN_MONTHS_NAME = {
+	"Januar": "Jan",
+	"Februar": "Feb",
+	"März": "Mar",
+	"April": "Apr",
+	"Mai": "May",
+	"Juni": "Jun",
+	"Juli": "Jul",
+	"August": "Aug",
+	"September": "Sep",
+	"Oktober": "Oct",
+	"November": "Nov",
+	"Dezember": "Dec"
+};
+
 /*
  * Returns a sanitized days string.
  */
 function getSanitizeDays(days) {
+	Object.entries(ENGLISH_MONTH_ABBREVATION_BY_GERMAN_MONTHS_NAME)
+	      .forEach(([key, value]) => { days = days.replaceAll(key, value); });
 	days = days.replace(/gesetzliche Feiertage/g, "PH");
 	days = days.replace("Di", "Tu");
 	days = days.replace("Mi", "We");

--- a/preprocessing/berlin/raw/markets-berlin.json
+++ b/preprocessing/berlin/raw/markets-berlin.json
@@ -12,11 +12,11 @@
             },
             "properties": {
                 "title": "Antik- und Buchmarkt am Bode Museum",
-                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/322",
-                "description": "Sa, So, gesetzliche Feiertage<br />11:00 - 17:00<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/322\">Mehr...</a>",
-                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/322",
+                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/313",
+                "description": "Sa, So, gesetzliche Feiertage<br />11:00 - 17:00<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/313\">Mehr...</a>",
+                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/313",
                 "data": {
-                    "id": "322",
+                    "id": "313",
                     "bezirk": "Mitte",
                     "bezeichnung": "Antik- und Buchmarkt am Bode Museum",
                     "strasse": "Am Kupfergraben",
@@ -43,11 +43,11 @@
             },
             "properties": {
                 "title": "Antik- und Buchmarkt am Bode Museum",
-                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/313",
-                "description": "Sa, So, gesetzliche Feiertage<br />11:00 - 17:00<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/313\">Mehr...</a>",
-                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/313",
+                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/322",
+                "description": "Sa, So, gesetzliche Feiertage<br />11:00 - 17:00<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/322\">Mehr...</a>",
+                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/322",
                 "data": {
-                    "id": "313",
+                    "id": "322",
                     "bezirk": "Mitte",
                     "bezeichnung": "Antik- und Buchmarkt am Bode Museum",
                     "strasse": "Am Kupfergraben",
@@ -60,37 +60,6 @@
                     "bemerkungen": "Am Kupfergraben/ Museumsinsel, \naußer Karfreitag, Volkstrauertag, Totensonntag, 24. und 31.12.2019",
                     "_wgs84_lat": "52.5203",
                     "_wgs84_lon": "13.39519"
-                }
-            }
-        },
-        {
-            "type": "Feature",
-            "geometry": {
-                "type": "Point",
-                "coordinates": [
-                    13.43439,
-                    52.51157
-                ]
-            },
-            "properties": {
-                "title": "Antikmarkt am Berliner Ostbahnhof",
-                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/361",
-                "description": "So<br />09:00 - 17:00<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/361\">Mehr...</a>",
-                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/361",
-                "data": {
-                    "id": "361",
-                    "bezirk": "Friedrichshain-Kreuzberg",
-                    "bezeichnung": "Antikmarkt am Berliner Ostbahnhof",
-                    "strasse": "Erich-Steinfurth-Straße",
-                    "plz": "10243",
-                    "tage": "So",
-                    "zeiten": "09:00 - 17:00",
-                    "betreiber": "Oldthing Marktveranstaltung, Tel.: 29 00 20 10",
-                    "email": "mailto:info@oldthing.de",
-                    "www": "http://www.oldthing.de",
-                    "bemerkungen": "Ecke Hermann-Stöhr-Park, 05.09. und 03.10. geschlossen, außer Volkstrauertag und Totensonntag",
-                    "_wgs84_lat": "52.5115665",
-                    "_wgs84_lon": "13.4343881"
                 }
             }
         },
@@ -120,6 +89,37 @@
                     "email": "mailto:info@oldthing.de",
                     "www": "http://www.oldthing.de",
                     "bemerkungen": "außer Volkstrauertag und Totensonntag; im Sommer bis 17:00 geöffnet",
+                    "_wgs84_lat": "52.5115665",
+                    "_wgs84_lon": "13.4343881"
+                }
+            }
+        },
+        {
+            "type": "Feature",
+            "geometry": {
+                "type": "Point",
+                "coordinates": [
+                    13.43439,
+                    52.51157
+                ]
+            },
+            "properties": {
+                "title": "Antikmarkt am Berliner Ostbahnhof",
+                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/361",
+                "description": "So<br />09:00 - 17:00<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/361\">Mehr...</a>",
+                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/361",
+                "data": {
+                    "id": "361",
+                    "bezirk": "Friedrichshain-Kreuzberg",
+                    "bezeichnung": "Antikmarkt am Berliner Ostbahnhof",
+                    "strasse": "Erich-Steinfurth-Straße",
+                    "plz": "10243",
+                    "tage": "So",
+                    "zeiten": "09:00 - 17:00",
+                    "betreiber": "Oldthing Marktveranstaltung, Tel.: 29 00 20 10",
+                    "email": "mailto:info@oldthing.de",
+                    "www": "http://www.oldthing.de",
+                    "bemerkungen": "Ecke Hermann-Stöhr-Park, 05.09. und 03.10. geschlossen, außer Volkstrauertag und Totensonntag",
                     "_wgs84_lat": "52.5115665",
                     "_wgs84_lon": "13.4343881"
                 }
@@ -3577,19 +3577,19 @@
             },
             "properties": {
                 "title": "Wochenmarkt am Hackeschen Markt",
-                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/112",
-                "description": "Sa<br />10:00 - 18:00<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/112\">Mehr...</a>",
-                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/112",
+                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/109",
+                "description": "Do<br />09:00 - 18:00<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/109\">Mehr...</a>",
+                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/109",
                 "data": {
-                    "id": "112",
+                    "id": "109",
                     "bezirk": "Mitte",
                     "bezeichnung": "Wochenmarkt am Hackeschen Markt",
                     "strasse": "Hackescher Markt",
                     "plz": "10178",
-                    "tage": "Sa",
-                    "zeiten": "10:00 - 18:00",
-                    "betreiber": "Marktleitung: \nGKS Marktbetriebsgesellschaft mbH & Co. KG, Frau Sarah Kolbe, Tel.: 0163/545 07 03",
-                    "email": "mailto:hackescherwochenmarktsamstag@hotmail.de",
+                    "tage": "Do",
+                    "zeiten": "09:00 - 18:00",
+                    "betreiber": "Marktleitung: Fa. Neue Markt GmbH",
+                    "email": "",
                     "www": "",
                     "bemerkungen": "",
                     "_wgs84_lat": "52.5236701",
@@ -3608,19 +3608,19 @@
             },
             "properties": {
                 "title": "Wochenmarkt am Hackeschen Markt",
-                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/109",
-                "description": "Do<br />09:00 - 18:00<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/109\">Mehr...</a>",
-                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/109",
+                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/112",
+                "description": "Sa<br />10:00 - 18:00<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/112\">Mehr...</a>",
+                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/112",
                 "data": {
-                    "id": "109",
+                    "id": "112",
                     "bezirk": "Mitte",
                     "bezeichnung": "Wochenmarkt am Hackeschen Markt",
                     "strasse": "Hackescher Markt",
                     "plz": "10178",
-                    "tage": "Do",
-                    "zeiten": "09:00 - 18:00",
-                    "betreiber": "Marktleitung: Fa. Neue Markt GmbH",
-                    "email": "",
+                    "tage": "Sa",
+                    "zeiten": "10:00 - 18:00",
+                    "betreiber": "Marktleitung: \nGKS Marktbetriebsgesellschaft mbH & Co. KG, Frau Sarah Kolbe, Tel.: 0163/545 07 03",
+                    "email": "mailto:hackescherwochenmarktsamstag@hotmail.de",
                     "www": "",
                     "bemerkungen": "",
                     "_wgs84_lat": "52.5236701",


### PR DESCRIPTION
# Description
- Stabilize **sorting order** for Berlin markets. 
- Clarify how the _opening_hours.js_ library is used.
- Remove **trailing comma** in hours string.
- Convert month names into **month abbreviations** as expected by _opening_hours.js_.

# Before and after screenshots
Please note that this particular market is meanwhile gone due to rebasing and [new data](https://github.com/wo-ist-markt/wo-ist-markt.github.io/pull/432).
![before](https://user-images.githubusercontent.com/144518/144320462-06bf2db9-54a7-4caa-8584-d40452471ecc.png) ![after](https://user-images.githubusercontent.com/144518/144320454-3a3e105d-6521-4f8a-ac39-5cf2ac715597.png)
