### PR TITLE
Update data source URL of Schleswig.

### DIFF
--- a/cities/schleswig.json
+++ b/cities/schleswig.json
@@ -49,7 +49,7 @@
     "metadata": {
         "data_source": {
             "title": "Stadt Schleswig",
-            "url": "https://www.schleswig.de/index.php?object=tx|3075.1.1&ModID=9&FID=3075.47.1"
+            "url": "https://www.schleswig.de/Wirtschaft-Bauen/Wirtschaftsf%C3%B6rderung/Wirtschafts-und-Interessenvereine/Wochenm%C3%A4rkte.php?ModID=9&FID=3075.47.1&object=tx%7C3075.1.1&redir=1"
         }
     },
     "type": "FeatureCollection"


### PR DESCRIPTION
+ The server of Schleswig responded with HTTP 301 permanently moved.
+ This fixes the currently [broken build](https://app.travis-ci.com/github/wo-ist-markt/wo-ist-markt.github.io/builds/243286547) on `master`.
+ Follow-up pull requests like #433 and #431 should be rebased.