### PR TITLE
Add Salzkotten

### DIFF
--- a/README.md
+++ b/README.md
@@ -316,7 +316,7 @@ state as the new version of the website available under [https://wo-ist-markt.de
 [saarbruecken-wikipedia]: https://de.wikipedia.org/wiki/Saarbr%C3%BCcken
 [saarbruecken-markets]: https://www.saarbruecken.de/leben_in_saarbruecken/einkaufen/maerkte
 [salzkotten-wikipedia]: https://de.wikipedia.org/wiki/Salzkotten
-[salzkotten-markets]: http://vv.salzkotten.de/vv/produkte/174030100000004816.php
+[salzkotten-markets]: https://vv.salzkotten.de/vv/produkte/174030100000004816.php
 [schleswig-wikipedia]: https://en.wikipedia.org/wiki/Schleswig,_Schleswig-Holstein
 [schleswig-markets]: http://schleswig.de/start.php?op=adressen&Abteilung=422
 [schwerin-wikipedia]: https://en.wikipedia.org/wiki/Schwerin

--- a/README.md
+++ b/README.md
@@ -140,6 +140,7 @@ in February 2016.
 |[Potsdam][potsdam-wikipedia]|[City of Potsdam][potsdam-markets]|
 |[Rostock][rostock-wikipedia]|[City of Rostock][rostock-markets]|
 |[Saarbrücken][saarbruecken-wikipedia]|[Landeshauptstadt Saarbrücken][saarbruecken-markets]|
+|[Salzkotten][salzkotten-wikipedia]|[City of Salzkotten][salzkotten-markets]|
 |[Schleswig][schleswig-wikipedia]|[City of Schleswig][schleswig-markets]|
 |[Schwerin][schwerin-wikipedia]|[City of Schwerin][schwerin-markets]|
 |[Siegen][siegen-wikipedia]|[City of Siegen][siegen-markets]|
@@ -314,6 +315,8 @@ state as the new version of the website available under [https://wo-ist-markt.de
 [rostock-markets]: http://www.rostocker-wochenmaerkte.de/standorte-angebote/
 [saarbruecken-wikipedia]: https://de.wikipedia.org/wiki/Saarbr%C3%BCcken
 [saarbruecken-markets]: https://www.saarbruecken.de/leben_in_saarbruecken/einkaufen/maerkte
+[salzkotten-wikipedia]: https://de.wikipedia.org/wiki/Salzkotten
+[salzkotten-markets]: http://vv.salzkotten.de/vv/produkte/174030100000004816.php
 [schleswig-wikipedia]: https://en.wikipedia.org/wiki/Schleswig,_Schleswig-Holstein
 [schleswig-markets]: http://schleswig.de/start.php?op=adressen&Abteilung=422
 [schwerin-wikipedia]: https://en.wikipedia.org/wiki/Schwerin

--- a/cities/cities.json
+++ b/cities/cities.json
@@ -495,6 +495,14 @@
             7
         ]
     },
+    "salzkotten": {
+        "id": "salzkotten",
+        "label": "Salzkotten",
+        "coordinates": [
+            51.67083333,
+            8.60472222
+        ]
+    },
     "schleswig": {
         "id": "schleswig",
         "label": "Schleswig",

--- a/cities/salzkotten.json
+++ b/cities/salzkotten.json
@@ -20,7 +20,7 @@
     "metadata": {
         "data_source": {
             "title": "Stadt Salzkotten",
-            "url": "http://vv.salzkotten.de/vv/produkte/174030100000004816.php"
+            "url": "https://vv.salzkotten.de/vv/produkte/174030100000004816.php"
         }
     }
 }

--- a/cities/salzkotten.json
+++ b/cities/salzkotten.json
@@ -1,0 +1,26 @@
+{
+  "type": "FeatureCollection",
+  "features": [
+    {
+      "type": "Feature",
+      "properties": {
+        "location": "Marktplatz vor dem Rathaus",
+        "title": "Wochenmarkt in Salzkotten",
+        "opening_hours": "Fr 14:00-18:00"
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          8.6046,
+          51.6711
+        ]
+      }
+    }
+  ],
+    "metadata": {
+        "data_source": {
+            "title": "Stadt Salzkotten",
+            "url": "http://vv.salzkotten.de/vv/produkte/174030100000004816.php"
+        }
+    }
+}


### PR DESCRIPTION
Add Salzkotten in the district of Paderborn, NRW, Germany as a stand-alone city (as I don't see an opportunity to add another `data_source` to Paderborn) with it's weekly market.

Ads on the rc3 made me aware of this project.