### PR TITLE
Only check dependencies once a week to reduce email noise for maintainers.

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,7 +6,7 @@ updates:
   - package-ecosystem: "npm"
     directory: "/"
     schedule:
-      interval: "daily"
+      interval: "weekly"
     labels:
       - "Project setup"
     reviewers:


### PR DESCRIPTION
@k-nut I hope once a week is good enough.