### PR TITLE
Do not classify HTTP 307 (temporary redirect) responses as warnings/errors.

### DIFF
--- a/cities/basel.json
+++ b/cities/basel.json
@@ -79,7 +79,7 @@
     "metadata": {
         "data_source": {
             "title": "Stadt Basel",
-            "url": "https://www.marketing.bs.ch/messen-maerkte"
+            "url": "https://www.bs.ch/Portrait/Veranstaltungen/basler-maerkte.html"
         }
     },
     "type": "FeatureCollection"

--- a/cities/kleve.json
+++ b/cities/kleve.json
@@ -64,7 +64,7 @@
     "metadata": {
         "data_source": {
             "title": "Stadt Kleve",
-            "url": "https://www.kleve.de/de/inhalt/wochenmaerkte/"
+            "url": "https://www.kleve.de/stadt-kleve/freizeit-und-kultur/veranstaltungen/wochenmaerkte-kleve"
         }
     },
     "type": "FeatureCollection"

--- a/validation/markets-validator.js
+++ b/validation/markets-validator.js
@@ -52,7 +52,7 @@ var MIN_LONGITUDE = -180.0;
  * is impossible for us to resolve the issue.
  * The aim is to keep this count as low as possible.
  */
-var ACCEPTABLE_WARNINGS_COUNT = 0;
+var ACCEPTABLE_WARNINGS_COUNT = 1; // Loxstedt
 
 var exitCode = 0;
 

--- a/validation/markets-validator.js
+++ b/validation/markets-validator.js
@@ -52,7 +52,7 @@ var MIN_LONGITUDE = -180.0;
  * is impossible for us to resolve the issue.
  * The aim is to keep this count as low as possible.
  */
-var ACCEPTABLE_WARNINGS_COUNT = 2; // Cuxhaven, Schleswig
+var ACCEPTABLE_WARNINGS_COUNT = 0;
 
 var exitCode = 0;
 
@@ -648,7 +648,7 @@ function MetadataValidator(metadata, cityName) {
                 // Cleaning up HTTP request and response
                 response.destroy();
         
-                if (response.statusCode !== 200) {
+                if (response.statusCode !== 200 && response.statusCode !== 307) {
                     if (fallbackRequest) {
                         fallbackRequest(url, requestParameters);
                     } else {


### PR DESCRIPTION
- Update data source URLs for Kleve and Basel.