### PR TITLE
Only check dependencies once a month to reduce email noise for maintainers.

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,7 +6,7 @@ updates:
   - package-ecosystem: "npm"
     directory: "/"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
     labels:
       - "Project setup"
     reviewers:


### PR DESCRIPTION
- Related: #446 