### PR TITLE
Update markets for Berlin (published 08.11.2023).

### DIFF
--- a/cities/berlin.json
+++ b/cities/berlin.json
@@ -3,50 +3,376 @@
         {
             "geometry": {
                 "coordinates": [
-                    13.52317,
-                    52.4764
+                    13.05696,
+                    52.40311
                 ],
                 "type": "Point"
             },
             "properties": {
-                "title": "11. Designbörse Berlin",
-                "location": "Treskowallee 159, 10318",
-                "opening_hours": null,
-                "opening_hours_unclassified": "30.09.-03.10.2023 Sa 17:00-21:00 So 11:00-17:00 Mo 11:00-17:00 Di 11:00-17:00",
-                "details_url": "http://design-boerse-berlin.de"
+                "title": "Wochenmarkt Am Nauener Tor 14467 Potsdam",
+                "location": "Hegelallee 55, 14467",
+                "opening_hours": "We,Sa 09:00-16:00",
+                "opening_hours_unclassified": null,
+                "details_url": "http://www.markt-am-nauener-tor.de"
             },
             "type": "Feature"
         },
         {
             "geometry": {
                 "coordinates": [
-                    13.125,
-                    52.47151
+                    13.05868,
+                    52.40114
                 ],
                 "type": "Point"
             },
             "properties": {
-                "title": "19. Kinderflohmarkt in der Landstadt Gatow",
-                "location": "Leonardo-da-Vinci-Straße, 14089",
-                "opening_hours": null,
-                "opening_hours_unclassified": "29.04.2023 10:00 - 14:00"
+                "title": "Wochenmarkt Potsdam Bassinplatz",
+                "location": "Am Bassin 6, 14467",
+                "opening_hours": "Mo-Fr 07:00-16:00;Sa 07:00-13:00",
+                "opening_hours_unclassified": null
             },
             "type": "Feature"
         },
         {
             "geometry": {
                 "coordinates": [
-                    13.52317,
-                    52.4764
+                    13.09485,
+                    52.39425
                 ],
                 "type": "Point"
             },
             "properties": {
-                "title": "2. Antiquariatsmesse Bücherlust",
-                "location": "Treskowallee 159, 10318",
+                "title": "Floh- und Bauernmarkt in Potsdam",
+                "location": "Weberplatz, 14482",
+                "opening_hours": "Sa 07:00-13:00",
+                "opening_hours_unclassified": null,
+                "details_url": "http://www.koscholke.de"
+            },
+            "type": "Feature"
+        },
+        {
+            "geometry": {
+                "coordinates": [
+                    13.75281,
+                    52.42248
+                ],
+                "type": "Point"
+            },
+            "properties": {
+                "title": "Wochenmarkt Friedrichstraße Erkner",
+                "location": "Friedrichstraße, 15537",
+                "opening_hours": "Th 09:00-14:00",
+                "opening_hours_unclassified": null
+            },
+            "type": "Feature"
+        },
+        {
+            "geometry": {
+                "coordinates": [
+                    13.70327,
+                    52.48223
+                ],
+                "type": "Point"
+            },
+            "properties": {
+                "title": "Wochenmarkt Dorfaue Schöneiche",
+                "location": "Dorfaue, 15566",
+                "opening_hours": "Th 09:00-14:00",
+                "opening_hours_unclassified": null
+            },
+            "type": "Feature"
+        },
+        {
+            "geometry": {
+                "coordinates": [
+                    13.30568,
+                    52.51731
+                ],
+                "type": "Point"
+            },
+            "properties": {
+                "title": "Wochenmarkt Richard-Wagner-Platz",
+                "location": "Richard-Wagner-Platz, 10585",
+                "opening_hours": "Mo,Th 08:00-13:00",
+                "opening_hours_unclassified": null
+            },
+            "type": "Feature"
+        },
+        {
+            "geometry": {
+                "coordinates": [
+                    13.29094,
+                    52.51765
+                ],
+                "type": "Point"
+            },
+            "properties": {
+                "title": "Wochenmarkt Klausenerplatz",
+                "location": "Klausenerplatz, 14059",
+                "opening_hours": "Tu,Fr 08:00-13:00",
+                "opening_hours_unclassified": null
+            },
+            "type": "Feature"
+        },
+        {
+            "geometry": {
+                "coordinates": [
+                    13.2594,
+                    52.51112
+                ],
+                "type": "Point"
+            },
+            "properties": {
+                "title": "Wochenmarkt Preußenallee",
+                "location": "Preußenallee, 14052",
+                "opening_hours": "Tu,Fr 08:00-13:00",
+                "opening_hours_unclassified": null
+            },
+            "type": "Feature"
+        },
+        {
+            "geometry": {
+                "coordinates": [
+                    13.31036,
+                    52.50848
+                ],
+                "type": "Point"
+            },
+            "properties": {
+                "title": "Wochenmarkt Karl-August-Platz",
+                "location": "Karl-August-Platz, 10625",
+                "opening_hours": "We 08:00-13:00;Sa 08:00-14:00",
+                "opening_hours_unclassified": null
+            },
+            "type": "Feature"
+        },
+        {
+            "geometry": {
+                "coordinates": [
+                    13.30481,
+                    52.5253
+                ],
+                "type": "Point"
+            },
+            "properties": {
+                "title": "Wochenmarkt Mierendorffplatz",
+                "location": "Mierendorffplatz, 10589",
+                "opening_hours": "We,Sa 08:00-13:00",
+                "opening_hours_unclassified": null
+            },
+            "type": "Feature"
+        },
+        {
+            "geometry": {
+                "coordinates": [
+                    13.29256,
+                    52.48858
+                ],
+                "type": "Point"
+            },
+            "properties": {
+                "title": "Wochenmarkt Charlottenbrunner Straße",
+                "location": "Charlottenbrunner Straße, 14193",
+                "opening_hours": "Mo,Th 09:00-14:00",
+                "opening_hours_unclassified": null
+            },
+            "type": "Feature"
+        },
+        {
+            "geometry": {
+                "coordinates": [
+                    13.31144,
+                    52.47344
+                ],
+                "type": "Point"
+            },
+            "properties": {
+                "title": "Wochenmarkt Eberbacher Straße",
+                "location": "Eberbacher Straße, 14197",
+                "opening_hours": "Tu,Fr 08:00-13:00",
+                "opening_hours_unclassified": null
+            },
+            "type": "Feature"
+        },
+        {
+            "geometry": {
+                "coordinates": [
+                    13.29939,
+                    52.49725
+                ],
+                "type": "Point"
+            },
+            "properties": {
+                "title": "Wochenmarkt Nestorstraße",
+                "location": "Nestorstraße, 10709",
+                "opening_hours": "Tu,Fr 08:00-13:00",
+                "opening_hours_unclassified": null
+            },
+            "type": "Feature"
+        },
+        {
+            "geometry": {
+                "coordinates": [
+                    13.3227741,
+                    52.4937867
+                ],
+                "type": "Point"
+            },
+            "properties": {
+                "title": "Wochenmarkt Hohenzollernplatz",
+                "location": "Hohenzollernplatz, 14129",
+                "opening_hours": "We,Sa 08:00-13:00",
+                "opening_hours_unclassified": null
+            },
+            "type": "Feature"
+        },
+        {
+            "geometry": {
+                "coordinates": [
+                    13.3488741,
+                    52.4909252
+                ],
+                "type": "Point"
+            },
+            "properties": {
+                "title": "Kinder-Baby-Trödel",
+                "location": "K.-Schrader-Str. 7 - 8, 10781",
                 "opening_hours": null,
-                "opening_hours_unclassified": "09.09.-10.09.2023 09:00 - 17:00",
-                "details_url": "https://www.bücherlust.com"
+                "opening_hours_unclassified": "25.03.2023 13.05.2023 14:00 - 17:00",
+                "details_url": "https://www.kiezoase.de/aktuelle-angebote/"
+            },
+            "type": "Feature"
+        },
+        {
+            "geometry": {
+                "coordinates": [
+                    13.3488741,
+                    52.4909252
+                ],
+                "type": "Point"
+            },
+            "properties": {
+                "title": "Kunst-Kreativ-Markt",
+                "location": "K.-Schrader-Str. 7 - 8, 10781",
+                "opening_hours": null,
+                "opening_hours_unclassified": "13.06.2023 13:00 - 17:00",
+                "details_url": "https://www.kiezoase.de/aktuelle-angebote/"
+            },
+            "type": "Feature"
+        },
+        {
+            "geometry": {
+                "coordinates": [
+                    13.329,
+                    52.47885
+                ],
+                "type": "Point"
+            },
+            "properties": {
+                "title": "Wochenmarkt Bundesplatz",
+                "location": "Bundesplatz, 10715",
+                "opening_hours": "Mo,Th 08:00-13:00",
+                "opening_hours_unclassified": null
+            },
+            "type": "Feature"
+        },
+        {
+            "geometry": {
+                "coordinates": [
+                    13.31322,
+                    52.4912
+                ],
+                "type": "Point"
+            },
+            "properties": {
+                "title": "Wochenmarkt Fehrbelliner Platz",
+                "location": "Fehrbelliner Platz, 10707",
+                "opening_hours": "Mo,Tu,Th 11:00-15:00",
+                "opening_hours_unclassified": null
+            },
+            "type": "Feature"
+        },
+        {
+            "geometry": {
+                "coordinates": [
+                    13.31322,
+                    52.4912
+                ],
+                "type": "Point"
+            },
+            "properties": {
+                "title": "Kunst- und Trödelmarkt Fehrbelliner Platz",
+                "location": "Fehrbelliner Platz, 10707",
+                "opening_hours": "Sa,Su 10:00-16:00",
+                "opening_hours_unclassified": null,
+                "details_url": "http://www.burdack-maerkte.de"
+            },
+            "type": "Feature"
+        },
+        {
+            "geometry": {
+                "coordinates": [
+                    13.29052,
+                    52.4769
+                ],
+                "type": "Point"
+            },
+            "properties": {
+                "title": "Wochenmarkt Kolberger Platz",
+                "location": "Kolberger Platz, 14199",
+                "opening_hours": "We,Sa 06:00-15:00",
+                "opening_hours_unclassified": null
+            },
+            "type": "Feature"
+        },
+        {
+            "geometry": {
+                "coordinates": [
+                    13.36845,
+                    52.51574
+                ],
+                "type": "Point"
+            },
+            "properties": {
+                "title": "Kunst- und Trödelmarkt  Straße des 17. Juni",
+                "location": "Straße des 17. Juni, 10785",
+                "opening_hours": "Sa,Su 10:00-17:00",
+                "opening_hours_unclassified": null,
+                "details_url": "http://www.berliner-troedelmarkt.de"
+            },
+            "type": "Feature"
+        },
+        {
+            "geometry": {
+                "coordinates": [
+                    13.31586,
+                    52.48215
+                ],
+                "type": "Point"
+            },
+            "properties": {
+                "title": "Trödelmarkt an der Mecklenburgischen Straße",
+                "location": "Mecklenburgische Straße, 14197",
+                "opening_hours": "Su 08:00-16:00",
+                "opening_hours_unclassified": null,
+                "details_url": "http://www.der-mecklenburger-troedelmarkt.de"
+            },
+            "type": "Feature"
+        },
+        {
+            "geometry": {
+                "coordinates": [
+                    13.2957,
+                    52.5074
+                ],
+                "type": "Point"
+            },
+            "properties": {
+                "title": "Wochenmarkt Suarezstraße",
+                "location": "Suarezstraße 48, 14057",
+                "opening_hours": "Th 08:00-14:00",
+                "opening_hours_unclassified": null,
+                "details_url": "http://www.treffpunkt-wochenmarkt.de"
             },
             "type": "Feature"
         },
@@ -64,107 +390,6 @@
                 "opening_hours": null,
                 "opening_hours_unclassified": "02.09.2023 12:00 - 20:00",
                 "details_url": "http://www.oldthing.de/suarezstrasse"
-            },
-            "type": "Feature"
-        },
-        {
-            "geometry": {
-                "coordinates": [
-                    13.52317,
-                    52.4764
-                ],
-                "type": "Point"
-            },
-            "properties": {
-                "title": "Antik- & Designgroßflohmarkt Trabrennbahn Karlshorst",
-                "location": "Treskowallee 159, 10318",
-                "opening_hours": null,
-                "opening_hours_unclassified": "01./02.04., 06./07.05., 27. - 29.05., 01./02.07., 05./06.08., 09./10.09., 01.-03.10., 04./05.11., 02. - 03.12.2023 09:00 - 17:00",
-                "details_url": "http://www.oldthing.de/riesenflohmarkt"
-            },
-            "type": "Feature"
-        },
-        {
-            "geometry": {
-                "coordinates": [
-                    13.39475,
-                    52.52082
-                ],
-                "type": "Point"
-            },
-            "properties": {
-                "title": "Antik- und Buchmarkt am Bodemuseum",
-                "location": "Am Kupfergraben, 10117",
-                "opening_hours": "Sa,Su,PH 11:00-17:00",
-                "opening_hours_unclassified": null
-            },
-            "type": "Feature"
-        },
-        {
-            "geometry": {
-                "coordinates": [
-                    13.31896,
-                    52.47249
-                ],
-                "type": "Point"
-            },
-            "properties": {
-                "title": "Antik- und Kunstmarkt am Rüdi",
-                "location": "Landauer Straße, 14197",
-                "opening_hours": null,
-                "opening_hours_unclassified": "27.05.2023 12:00 - 19:00",
-                "details_url": "http://www.markt-rix.de"
-            },
-            "type": "Feature"
-        },
-        {
-            "geometry": {
-                "coordinates": [
-                    13.31896,
-                    52.47249
-                ],
-                "type": "Point"
-            },
-            "properties": {
-                "title": "Antik- und Kunstmarkt am Rüdi",
-                "location": "Landauer Straße, 14197",
-                "opening_hours": null,
-                "opening_hours_unclassified": "28.05.2023 11:00 - 19:00",
-                "details_url": "http://www.markt-rix.de"
-            },
-            "type": "Feature"
-        },
-        {
-            "geometry": {
-                "coordinates": [
-                    13.31896,
-                    52.47249
-                ],
-                "type": "Point"
-            },
-            "properties": {
-                "title": "Antik- und Kunstmarkt am Rüdi",
-                "location": "Landauer Straße, 14197",
-                "opening_hours": null,
-                "opening_hours_unclassified": "16.09.2023 12:00 - 19:00",
-                "details_url": "http://www.markt-rix.de"
-            },
-            "type": "Feature"
-        },
-        {
-            "geometry": {
-                "coordinates": [
-                    13.31896,
-                    52.47249
-                ],
-                "type": "Point"
-            },
-            "properties": {
-                "title": "Antik- und Kunstmarkt am Rüdi",
-                "location": "Landauer Straße, 14197",
-                "opening_hours": null,
-                "opening_hours_unclassified": "17.09.2023 11:00 - 19:00",
-                "details_url": "http://www.markt-rix.de"
             },
             "type": "Feature"
         },
@@ -239,34 +464,85 @@
         {
             "geometry": {
                 "coordinates": [
-                    13.55133,
-                    52.50756
+                    13.31893,
+                    52.4725
                 ],
                 "type": "Point"
             },
             "properties": {
-                "title": "Antik- und Trödelmarkt Biesdorf-Center",
-                "location": "Weißenhöher Str. 88 - 108, 12683",
+                "title": "Antik- und Kunstmarkt am Rüdi",
+                "location": "Landauer Straße, 14197",
                 "opening_hours": null,
-                "opening_hours_unclassified": "15.01., 29.01., 12.02., 26.02.2023 08:00 - 15:00",
-                "details_url": "http://www.troedelfreunde.de"
+                "opening_hours_unclassified": "27.05.2023 12:00 - 19:00",
+                "details_url": "http://www.markt-rix.de"
             },
             "type": "Feature"
         },
         {
             "geometry": {
                 "coordinates": [
-                    13.52317,
-                    52.4764
+                    13.31893,
+                    52.4725
                 ],
                 "type": "Point"
             },
             "properties": {
-                "title": "Antikgroßflohmarkt Trabrennbahn Karlshorst",
-                "location": "Treskowallee 159, 10318",
-                "opening_hours": "Sa,Su 09:00-16:00",
-                "opening_hours_unclassified": null,
-                "details_url": "http://www.oldthing.de"
+                "title": "Antik- und Kunstmarkt am Rüdi",
+                "location": "Landauer Straße, 14197",
+                "opening_hours": null,
+                "opening_hours_unclassified": "28.05.2023 11:00 - 19:00",
+                "details_url": "http://www.markt-rix.de"
+            },
+            "type": "Feature"
+        },
+        {
+            "geometry": {
+                "coordinates": [
+                    13.31893,
+                    52.4725
+                ],
+                "type": "Point"
+            },
+            "properties": {
+                "title": "Antik- und Kunstmarkt am Rüdi",
+                "location": "Landauer Straße, 14197",
+                "opening_hours": null,
+                "opening_hours_unclassified": "16.09.2023 12:00 - 19:00",
+                "details_url": "http://www.markt-rix.de"
+            },
+            "type": "Feature"
+        },
+        {
+            "geometry": {
+                "coordinates": [
+                    13.31893,
+                    52.4725
+                ],
+                "type": "Point"
+            },
+            "properties": {
+                "title": "Antik- und Kunstmarkt am Rüdi",
+                "location": "Landauer Straße, 14197",
+                "opening_hours": null,
+                "opening_hours_unclassified": "17.09.2023 11:00 - 19:00",
+                "details_url": "http://www.markt-rix.de"
+            },
+            "type": "Feature"
+        },
+        {
+            "geometry": {
+                "coordinates": [
+                    13.32139,
+                    52.47538
+                ],
+                "type": "Point"
+            },
+            "properties": {
+                "title": "Frühjahrs-Trödelmarkt in der Ruppin Grundschule",
+                "location": "Offenbacher Str. 5a, 14197",
+                "opening_hours": null,
+                "opening_hours_unclassified": "25.03.2023 10:00-14:00",
+                "details_url": "http://www.ruppinfreunde.de"
             },
             "type": "Feature"
         },
@@ -290,34 +566,332 @@
         {
             "geometry": {
                 "coordinates": [
-                    13.35989,
-                    52.54752
+                    13.44146,
+                    52.51786
                 ],
                 "type": "Point"
             },
             "properties": {
-                "title": "Bauernmarkt Leopoldplatz",
-                "location": "Leopoldplatz, 13353",
-                "opening_hours": "Tu,Fr 10:00-17:00",
-                "opening_hours_unclassified": null,
-                "details_url": "http://www.bbm-maerkte.de"
+                "title": "Karl-Marx-Allee vor Nr. 93",
+                "location": "Karl-Marx-Allee 93, 10243",
+                "opening_hours": "Tu,Th 10:00-16:00",
+                "opening_hours_unclassified": null
             },
             "type": "Feature"
         },
         {
             "geometry": {
                 "coordinates": [
-                    13.40798,
-                    52.51674
+                    13.45871,
+                    52.51119
                 ],
                 "type": "Point"
             },
             "properties": {
-                "title": "Berlin-Brandenburger-Bauernmarkt -  Saisonmarkt auf dem Nikolaikirchplatz",
-                "location": "Nikolaikirchplatz, 10178",
+                "title": "Wochenmarkt Boxhagener Platz",
+                "location": "Boxhagener Platz, 10245",
+                "opening_hours": "Sa 09:00-15:30",
+                "opening_hours_unclassified": null
+            },
+            "type": "Feature"
+        },
+        {
+            "geometry": {
+                "coordinates": [
+                    13.43433,
+                    52.50955
+                ],
+                "type": "Point"
+            },
+            "properties": {
+                "title": "Wochenmarkt Am Kaufhof Ostbahnhof (Erich-Steinfurth-Straße)",
+                "location": "Ostbahnhof, 10243",
+                "opening_hours": "Mo-Sa 09:00-18:00",
+                "opening_hours_unclassified": null
+            },
+            "type": "Feature"
+        },
+        {
+            "geometry": {
+                "coordinates": [
+                    13.39088,
+                    52.48845
+                ],
+                "type": "Point"
+            },
+            "properties": {
+                "title": "Ökomarkt - Chamissoplatz",
+                "location": "Chamissoplatz, 10965",
+                "opening_hours": "Sa 09:00-15:00",
+                "opening_hours_unclassified": null,
+                "details_url": "http://www.oekomarkt-chamissoplatz.de"
+            },
+            "type": "Feature"
+        },
+        {
+            "geometry": {
+                "coordinates": [
+                    13.43372,
+                    52.50349
+                ],
+                "type": "Point"
+            },
+            "properties": {
+                "title": "Markthalle Neun",
+                "location": "Eisenbahnstraße 42/43, 10997",
+                "opening_hours": "Fr 12:00-18:00;Sa 10:00-18:00",
+                "opening_hours_unclassified": null,
+                "details_url": "http://www.markthalleneun.de"
+            },
+            "type": "Feature"
+        },
+        {
+            "geometry": {
+                "coordinates": [
+                    13.40655,
+                    52.48949
+                ],
+                "type": "Point"
+            },
+            "properties": {
+                "title": "Neuer Markt am Südstern",
+                "location": "Südstern, 10961",
+                "opening_hours": "Sa 10:00-16:00",
+                "opening_hours_unclassified": null,
+                "details_url": "http://www.diemarktplaner.de"
+            },
+            "type": "Feature"
+        },
+        {
+            "geometry": {
+                "coordinates": [
+                    13.39503,
+                    52.48959
+                ],
+                "type": "Point"
+            },
+            "properties": {
+                "title": "Trödelmarkt Bergmannstraße",
+                "location": "Marheinekeplatz, 10961",
+                "opening_hours": "Sa 10:00-16:00;Su 11:00-17:00",
+                "opening_hours_unclassified": null
+            },
+            "type": "Feature"
+        },
+        {
+            "geometry": {
+                "coordinates": [
+                    13.45999,
+                    52.51172
+                ],
+                "type": "Point"
+            },
+            "properties": {
+                "title": "Trödelmarkt Boxhagener Platz",
+                "location": "Grünberger Straße 75, 10245",
+                "opening_hours": "Su 10:00-18:00",
+                "opening_hours_unclassified": null
+            },
+            "type": "Feature"
+        },
+        {
+            "geometry": {
+                "coordinates": [
+                    13.42188,
+                    52.49118
+                ],
+                "type": "Point"
+            },
+            "properties": {
+                "title": "Ökomarkt Hohenstaufenplatz",
+                "location": "Zickenplatz, 10967",
+                "opening_hours": "Tu 12:00-18:00;Sa 09:00-15:00",
+                "opening_hours_unclassified": null,
+                "details_url": "http://www.mv-perske.de"
+            },
+            "type": "Feature"
+        },
+        {
+            "geometry": {
+                "coordinates": [
+                    13.43186,
+                    52.50044
+                ],
+                "type": "Point"
+            },
+            "properties": {
+                "title": "Ökomarkt Lausitzer Platz",
+                "location": "Lausitzer Platz, 10997",
+                "opening_hours": "Fr 12:00-18:00",
+                "opening_hours_unclassified": null,
+                "details_url": "http://www.mv-perske.de"
+            },
+            "type": "Feature"
+        },
+        {
+            "geometry": {
+                "coordinates": [
+                    13.47046,
+                    52.52862
+                ],
+                "type": "Point"
+            },
+            "properties": {
+                "title": "Wochenmarkt Anton-Saefkow-Platz",
+                "location": "Anton-Saefkow-Platz, 10369",
+                "opening_hours": "Tu,Th 09:00-18:00",
+                "opening_hours_unclassified": null
+            },
+            "type": "Feature"
+        },
+        {
+            "geometry": {
+                "coordinates": [
+                    13.5184,
+                    52.50801
+                ],
+                "type": "Point"
+            },
+            "properties": {
+                "title": "Wochenmarkt Bärenschaufenster (öffentl. Straßenland)",
+                "location": "Am Tierpark, 10319",
+                "opening_hours": "Mo,Th,Fr 08:00-18:00",
+                "opening_hours_unclassified": null,
+                "details_url": "http://www.brandenburger-wochenmaerkte.de"
+            },
+            "type": "Feature"
+        },
+        {
+            "geometry": {
+                "coordinates": [
+                    13.48405,
+                    52.52633
+                ],
+                "type": "Point"
+            },
+            "properties": {
+                "title": "Wochenmarkt Herzbergstraße / Weißenseer Weg (Roedernplatz)",
+                "location": "Herzbergstraße, 10367",
+                "opening_hours": "Tu,Fr 08:00-17:00",
+                "opening_hours_unclassified": null
+            },
+            "type": "Feature"
+        },
+        {
+            "geometry": {
+                "coordinates": [
+                    13.48555,
+                    52.51224
+                ],
+                "type": "Point"
+            },
+            "properties": {
+                "title": "Wochenmarkt Frankfurter Allee 172",
+                "location": "Frankfurter Allee 172, 10365",
+                "opening_hours": "We 09:00-16:00",
+                "opening_hours_unclassified": null,
+                "details_url": "http://www.brandenburger-wochenmaerkte.de"
+            },
+            "type": "Feature"
+        },
+        {
+            "geometry": {
+                "coordinates": [
+                    13.52866,
+                    52.48119
+                ],
+                "type": "Point"
+            },
+            "properties": {
+                "title": "Wochenmarkt Karlshorst",
+                "location": "Ehrenfelsstraße, 10318",
+                "opening_hours": "Tu,Fr 09:00-17:00",
+                "opening_hours_unclassified": null,
+                "details_url": "http://www.gakenholz-gellesch.de"
+            },
+            "type": "Feature"
+        },
+        {
+            "geometry": {
+                "coordinates": [
+                    13.52016,
+                    52.51358
+                ],
+                "type": "Point"
+            },
+            "properties": {
+                "title": "Wochenmarkt Friedrichsfelde Ost",
+                "location": "Seddiner Straße, 10315",
+                "opening_hours": "Mo-Fr 08:00-18:00",
+                "opening_hours_unclassified": null
+            },
+            "type": "Feature"
+        },
+        {
+            "geometry": {
+                "coordinates": [
+                    13.50211,
+                    52.56538
+                ],
+                "type": "Point"
+            },
+            "properties": {
+                "title": "Wochenmarkt Zingster Straße",
+                "location": "Zingster Straße, 13051",
+                "opening_hours": "Sa 09:00-13:00",
+                "opening_hours_unclassified": null,
+                "details_url": "http://www.markt-veranstaltungen.de"
+            },
+            "type": "Feature"
+        },
+        {
+            "geometry": {
+                "coordinates": [
+                    13.50498,
+                    52.56518
+                ],
+                "type": "Point"
+            },
+            "properties": {
+                "title": "Wochenmarkt Prerower Platz",
+                "location": "Prerower Platz, 13051",
+                "opening_hours": "We 09:00-17:00",
+                "opening_hours_unclassified": null,
+                "details_url": "http://www.markt-veranstaltungen.de"
+            },
+            "type": "Feature"
+        },
+        {
+            "geometry": {
+                "coordinates": [
+                    13.52317,
+                    52.4764
+                ],
+                "type": "Point"
+            },
+            "properties": {
+                "title": "Antik- & Designgroßflohmarkt Trabrennbahn Karlshorst",
+                "location": "Treskowallee 159, 10318",
                 "opening_hours": null,
-                "opening_hours_unclassified": "März - Oktober 10:00 - 17:00",
-                "details_url": "http://www.bbm-maerkte.de"
+                "opening_hours_unclassified": "01./02.04., 06./07.05., 27. - 29.05., 01./02.07., 05./06.08., 09./10.09., 01.-03.10., 04./05.11., 02. - 03.12.2023 09:00 - 17:00",
+                "details_url": "http://www.oldthing.de/riesenflohmarkt"
+            },
+            "type": "Feature"
+        },
+        {
+            "geometry": {
+                "coordinates": [
+                    13.52317,
+                    52.4764
+                ],
+                "type": "Point"
+            },
+            "properties": {
+                "title": "Antikgroßflohmarkt Trabrennbahn Karlshorst",
+                "location": "Treskowallee 159, 10318",
+                "opening_hours": "Sa,Su 09:00-16:00",
+                "opening_hours_unclassified": null,
+                "details_url": "http://www.oldthing.de"
             },
             "type": "Feature"
         },
@@ -347,416 +921,11 @@
                 "type": "Point"
             },
             "properties": {
-                "title": "Berliner Spielzeugbörse für Modellbahn & altes Spielzeug",
+                "title": "Oldthing Sammlerbörse für Ansichtskarten, Briefmarken und Münzen",
                 "location": "Treskowallee 159, 10318",
                 "opening_hours": null,
-                "opening_hours_unclassified": "02.12.-03.12.2023 09:00-16:00",
-                "details_url": "http://berliner-spielzeugboerse.de"
-            },
-            "type": "Feature"
-        },
-        {
-            "geometry": {
-                "coordinates": [
-                    13.20832,
-                    52.55769
-                ],
-                "type": "Point"
-            },
-            "properties": {
-                "title": "Carossa-Markt",
-                "location": "Streitstr. 13, 13587",
-                "opening_hours": "Tu,Fr 10:00-18:00",
-                "opening_hours_unclassified": null,
-                "details_url": "http://www.mv-perske.de"
-            },
-            "type": "Feature"
-        },
-        {
-            "geometry": {
-                "coordinates": [
-                    13.43798,
-                    52.466
-                ],
-                "type": "Point"
-            },
-            "properties": {
-                "title": "Die Dicke Linda",
-                "location": "Kranoldplatz, 12051",
-                "opening_hours": "Sa 10:00-16:00",
-                "opening_hours_unclassified": null,
-                "details_url": "http://www.dicke-linda-markt.de"
-            },
-            "type": "Feature"
-        },
-        {
-            "geometry": {
-                "coordinates": [
-                    13.14129,
-                    52.41211
-                ],
-                "type": "Point"
-            },
-            "properties": {
-                "title": "Dorfmarkt Wannsee",
-                "location": "Wilhelmplatz, 14109",
-                "opening_hours": "Fr 14:00-18:00",
-                "opening_hours_unclassified": null,
-                "details_url": "http://www.diemarktplaner.de"
-            },
-            "type": "Feature"
-        },
-        {
-            "geometry": {
-                "coordinates": [
-                    13.09485,
-                    52.39425
-                ],
-                "type": "Point"
-            },
-            "properties": {
-                "title": "Floh- und Bauernmarkt in Potsdam",
-                "location": "Weberplatz, 14482",
-                "opening_hours": "Sa 07:00-13:00",
-                "opening_hours_unclassified": null,
-                "details_url": "http://www.koscholke.de"
-            },
-            "type": "Feature"
-        },
-        {
-            "geometry": {
-                "coordinates": [
-                    13.17734,
-                    52.54814
-                ],
-                "type": "Point"
-            },
-            "properties": {
-                "title": "Flohmarkt Falkenseer Chaussee, Siegener Straße",
-                "location": "Falkenseer Chaussee 239, 13583",
-                "opening_hours": "Su 08:00-16:00",
-                "opening_hours_unclassified": null,
-                "details_url": "https://icktroedel.de"
-            },
-            "type": "Feature"
-        },
-        {
-            "geometry": {
-                "coordinates": [
-                    13.37904,
-                    52.43085
-                ],
-                "type": "Point"
-            },
-            "properties": {
-                "title": "Flohmarkt Marienfelde, Hornbach-Parkplatz",
-                "location": "Großbeerenstr. 133, 12107",
-                "opening_hours": "Su 09:00-15:00",
-                "opening_hours_unclassified": null,
-                "details_url": "http://www.ayvaz.de"
-            },
-            "type": "Feature"
-        },
-        {
-            "geometry": {
-                "coordinates": [
-                    13.54452,
-                    52.39732
-                ],
-                "type": "Point"
-            },
-            "properties": {
-                "title": "Flohmarkt Schönefeld",
-                "location": "Grünbergallee 279, 12526",
-                "opening_hours": "Su 09:00-15:00",
-                "opening_hours_unclassified": null,
-                "details_url": "http://www.ayvaz.de"
-            },
-            "type": "Feature"
-        },
-        {
-            "geometry": {
-                "coordinates": [
-                    13.62555,
-                    52.45754
-                ],
-                "type": "Point"
-            },
-            "properties": {
-                "title": "Flohmarkt am S-Bhf. Friedrichshagen",
-                "location": "Schöneicher Str./Dahlwitzer Landstr., 12587",
-                "opening_hours": "Su 08:00-16:00",
-                "opening_hours_unclassified": null,
-                "details_url": "http://www.oldthing.de/berlin"
-            },
-            "type": "Feature"
-        },
-        {
-            "geometry": {
-                "coordinates": [
-                    13.62555,
-                    52.45754
-                ],
-                "type": "Point"
-            },
-            "properties": {
-                "title": "Flohmarkt am S-Bhf. Friedrichshagen",
-                "location": "Schöneicherstr./Dahlwitzer Landstraße, 12587",
-                "opening_hours": "Su 08:00-16:00",
-                "opening_hours_unclassified": null,
-                "details_url": "http://www.oldthing.de"
-            },
-            "type": "Feature"
-        },
-        {
-            "geometry": {
-                "coordinates": [
-                    13.39364,
-                    52.53754
-                ],
-                "type": "Point"
-            },
-            "properties": {
-                "title": "Flohmarkt im Mauerpark",
-                "location": "Bernauer Straße 63-64, 13355",
-                "opening_hours": "Su 10:00-18:00",
-                "opening_hours_unclassified": null,
-                "details_url": "http://www.flohmarktimmauerpark.de"
-            },
-            "type": "Feature"
-        },
-        {
-            "geometry": {
-                "coordinates": [
-                    13.35261,
-                    52.49186
-                ],
-                "type": "Point"
-            },
-            "properties": {
-                "title": "Frauentrödel",
-                "location": "Barbarossastr. 65, 10781",
-                "opening_hours": null,
-                "opening_hours_unclassified": "25.03.2023 13.05.2023 12:00 - 16:00",
-                "details_url": "https://www.kiezoase.de/aktuelle-angebote/"
-            },
-            "type": "Feature"
-        },
-        {
-            "geometry": {
-                "coordinates": [
-                    13.26433,
-                    52.41171
-                ],
-                "type": "Point"
-            },
-            "properties": {
-                "title": "Frischemarkt Andréezeile",
-                "location": "Ladiusstraße, 14165",
-                "opening_hours": "Sa 08:00-13:00",
-                "opening_hours_unclassified": null,
-                "details_url": "http://www.diemarktplaner.de"
-            },
-            "type": "Feature"
-        },
-        {
-            "geometry": {
-                "coordinates": [
-                    13.32113,
-                    52.47535
-                ],
-                "type": "Point"
-            },
-            "properties": {
-                "title": "Frühjahrs-Trödelmarkt in der Ruppin Grundschule",
-                "location": "Offenbacher Str. 5a, 14197",
-                "opening_hours": null,
-                "opening_hours_unclassified": "25.03.2023 10:00-14:00",
-                "details_url": "http://www.ruppinfreunde.de"
-            },
-            "type": "Feature"
-        },
-        {
-            "geometry": {
-                "coordinates": [
-                    13.40058,
-                    52.5373
-                ],
-                "type": "Point"
-            },
-            "properties": {
-                "title": "Großer Trödelmarkt am Arkonaplatz",
-                "location": "Arkonaplatz, 10435",
-                "opening_hours": "Su 10:00-16:00",
-                "opening_hours_unclassified": null,
-                "details_url": "http://www.troedelmarkt-arkonaplatz.de"
-            },
-            "type": "Feature"
-        },
-        {
-            "geometry": {
-                "coordinates": [
-                    13.62475,
-                    52.44832
-                ],
-                "type": "Point"
-            },
-            "properties": {
-                "title": "Großer Trödeölmarkt am Bölschestraßenfest",
-                "location": "Bölschestraße, 12587",
-                "opening_hours": null,
-                "opening_hours_unclassified": "13.-14.05.2023 10:00 - 18:00",
-                "details_url": "http://www.oldthing.de"
-            },
-            "type": "Feature"
-        },
-        {
-            "geometry": {
-                "coordinates": [
-                    13.57442,
-                    52.4447
-                ],
-                "type": "Point"
-            },
-            "properties": {
-                "title": "Grüner Wochenmarkt",
-                "location": "Schloßplatz Köpenick, 12557",
-                "opening_hours": "Tu,Th 09:00-16:00",
-                "opening_hours_unclassified": null,
-                "details_url": "http://www.markt-veranstaltungen.de"
-            },
-            "type": "Feature"
-        },
-        {
-            "geometry": {
-                "coordinates": [
-                    13.44146,
-                    52.51786
-                ],
-                "type": "Point"
-            },
-            "properties": {
-                "title": "Karl-Marx-Allee vor Nr. 93",
-                "location": "Karl-Marx-Allee 93, 10243",
-                "opening_hours": "Tu,Th 10:00-16:00",
-                "opening_hours_unclassified": null
-            },
-            "type": "Feature"
-        },
-        {
-            "geometry": {
-                "coordinates": [
-                    13.48169,
-                    52.46256
-                ],
-                "type": "Point"
-            },
-            "properties": {
-                "title": "Kinder-Baby-Trödel",
-                "location": "K.-Schrader-Str. 7 - 8, 10781",
-                "opening_hours": null,
-                "opening_hours_unclassified": "25.03.2023 13.05.2023 14:00 - 17:00",
-                "details_url": "https://www.kiezoase.de/aktuelle-angebote/"
-            },
-            "type": "Feature"
-        },
-        {
-            "geometry": {
-                "coordinates": [
-                    13.36845,
-                    52.51574
-                ],
-                "type": "Point"
-            },
-            "properties": {
-                "title": "Kunst- und Trödelmarkt  Straße des 17. Juni",
-                "location": "Straße des 17. Juni, 10785",
-                "opening_hours": "Sa,Su 10:00-17:00",
-                "opening_hours_unclassified": null,
-                "details_url": "http://www.berliner-troedelmarkt.de"
-            },
-            "type": "Feature"
-        },
-        {
-            "geometry": {
-                "coordinates": [
-                    13.31322,
-                    52.4912
-                ],
-                "type": "Point"
-            },
-            "properties": {
-                "title": "Kunst- und Trödelmarkt Fehrbelliner Platz",
-                "location": "Fehrbelliner Platz, 10707",
-                "opening_hours": "Sa,Su 10:00-16:00",
-                "opening_hours_unclassified": null,
-                "details_url": "http://www.burdack-maerkte.de"
-            },
-            "type": "Feature"
-        },
-        {
-            "geometry": {
-                "coordinates": [
-                    13.48169,
-                    52.46256
-                ],
-                "type": "Point"
-            },
-            "properties": {
-                "title": "Kunst-Kreativ-Markt",
-                "location": "K.-Schrader-Str. 7 - 8, 10781",
-                "opening_hours": null,
-                "opening_hours_unclassified": "13.06.2023 13:00 - 17:00",
-                "details_url": "https://www.kiezoase.de/aktuelle-angebote/"
-            },
-            "type": "Feature"
-        },
-        {
-            "geometry": {
-                "coordinates": [
-                    13.39694,
-                    52.51815
-                ],
-                "type": "Point"
-            },
-            "properties": {
-                "title": "Kunstmarkt am Zeughaus",
-                "location": "Unter den Linden 2, 10117",
-                "opening_hours": "Sa,Su,PH 11:00-17:00",
-                "opening_hours_unclassified": null
-            },
-            "type": "Feature"
-        },
-        {
-            "geometry": {
-                "coordinates": [
-                    13.21476,
-                    52.43791
-                ],
-                "type": "Point"
-            },
-            "properties": {
-                "title": "Markt Schlachtensee (Wochenmarkt)",
-                "location": "Matterhornstr. 52/54, 14129",
-                "opening_hours": "Tu,Fr 08:00-14:00",
-                "opening_hours_unclassified": null
-            },
-            "type": "Feature"
-        },
-        {
-            "geometry": {
-                "coordinates": [
-                    13.43372,
-                    52.50349
-                ],
-                "type": "Point"
-            },
-            "properties": {
-                "title": "Markthalle Neun",
-                "location": "Eisenbahnstraße 42/43, 10997",
-                "opening_hours": "Fr 12:00-18:00;Sa 10:00-18:00",
-                "opening_hours_unclassified": null,
-                "details_url": "http://www.markthalleneun.de"
+                "opening_hours_unclassified": "02.04.2023 09:00 - 17:00",
+                "details_url": "http://www.oldthing.de/riesenflohmarkt"
             },
             "type": "Feature"
         },
@@ -780,15 +949,484 @@
         {
             "geometry": {
                 "coordinates": [
-                    13.40655,
-                    52.48949
+                    13.52317,
+                    52.4764
                 ],
                 "type": "Point"
             },
             "properties": {
-                "title": "Neuer Markt am Südstern",
-                "location": "Südstern, 10961",
+                "title": "2. Antiquariatsmesse Bücherlust",
+                "location": "Treskowallee 159, 10318",
+                "opening_hours": null,
+                "opening_hours_unclassified": "09.09.-10.09.2023 09:00 - 17:00",
+                "details_url": "https://www.bücherlust.com"
+            },
+            "type": "Feature"
+        },
+        {
+            "geometry": {
+                "coordinates": [
+                    13.52317,
+                    52.4764
+                ],
+                "type": "Point"
+            },
+            "properties": {
+                "title": "11. Designbörse Berlin",
+                "location": "Treskowallee 159, 10318",
+                "opening_hours": null,
+                "opening_hours_unclassified": "30.09.-03.10.2023 Sa 17:00-21:00 So 11:00-17:00 Mo 11:00-17:00 Di 11:00-17:00",
+                "details_url": "http://design-boerse-berlin.de"
+            },
+            "type": "Feature"
+        },
+        {
+            "geometry": {
+                "coordinates": [
+                    13.52317,
+                    52.4764
+                ],
+                "type": "Point"
+            },
+            "properties": {
+                "title": "Oldthing Sammlerbörse für Ansichtskarten, Briefmarken & Münzen",
+                "location": "Treskowallee 159, 10318",
+                "opening_hours": null,
+                "opening_hours_unclassified": "04.11.-05.11.2023 09:00-16:00",
+                "details_url": "http://www.oldthing.de/riesenflohmarkt"
+            },
+            "type": "Feature"
+        },
+        {
+            "geometry": {
+                "coordinates": [
+                    13.52317,
+                    52.4764
+                ],
+                "type": "Point"
+            },
+            "properties": {
+                "title": "Berliner Spielzeugbörse für Modellbahn & altes Spielzeug",
+                "location": "Treskowallee 159, 10318",
+                "opening_hours": null,
+                "opening_hours_unclassified": "02.12.-03.12.2023 09:00-16:00",
+                "details_url": "http://berliner-spielzeugboerse.de"
+            },
+            "type": "Feature"
+        },
+        {
+            "geometry": {
+                "coordinates": [
+                    13.52317,
+                    52.4764
+                ],
+                "type": "Point"
+            },
+            "properties": {
+                "title": "Riesenflohmarkt Event",
+                "location": "Treskowallee 159, 10318",
+                "opening_hours": null,
+                "opening_hours_unclassified": "27.-29.05., 01.-03.10.2023 09:00 - 17:00",
+                "details_url": "http://www.oldthing.de/riesenflohmarkt"
+            },
+            "type": "Feature"
+        },
+        {
+            "geometry": {
+                "coordinates": [
+                    13.51288,
+                    52.53363
+                ],
+                "type": "Point"
+            },
+            "properties": {
+                "title": "Trödelmarkt Landsberger Allee auf dem IKEA Parkplatz",
+                "location": "Landsberger Allee 364, 10365",
+                "opening_hours": "Su 09:00-15:00",
+                "opening_hours_unclassified": null,
+                "details_url": "http://www.bbm-maerkte.de"
+            },
+            "type": "Feature"
+        },
+        {
+            "geometry": {
+                "coordinates": [
+                    13.60735,
+                    52.53841
+                ],
+                "type": "Point"
+            },
+            "properties": {
+                "title": "Wochenmarkt Helle Mitte",
+                "location": "Peter-Weiss-Gasse, 12627",
+                "opening_hours": "We,Fr 08:00-17:00",
+                "opening_hours_unclassified": null
+            },
+            "type": "Feature"
+        },
+        {
+            "geometry": {
+                "coordinates": [
+                    13.59142,
+                    52.48471
+                ],
+                "type": "Point"
+            },
+            "properties": {
+                "title": "Wochenmarkt Mahlsdorf Roedernstraße / Hultschiner Damm",
+                "location": "Roedernstraße, 12623",
+                "opening_hours": "Th 07:00-15:00",
+                "opening_hours_unclassified": null
+            },
+            "type": "Feature"
+        },
+        {
+            "geometry": {
+                "coordinates": [
+                    13.54223,
+                    52.52655
+                ],
+                "type": "Point"
+            },
+            "properties": {
+                "title": "Wochenmarkt Helene-Weigel-Platz",
+                "location": "Helene-Weigel-Platz, 12681",
+                "opening_hours": "Mo-Sa 09:00-17:00",
+                "opening_hours_unclassified": null,
+                "details_url": "http://www.markt-veranstaltungen.de"
+            },
+            "type": "Feature"
+        },
+        {
+            "geometry": {
+                "coordinates": [
+                    13.55059,
+                    52.54396
+                ],
+                "type": "Point"
+            },
+            "properties": {
+                "title": "Wochenmarkt Marzahner Promenade",
+                "location": "Marzahner Promenade 30-33, 12679",
+                "opening_hours": "Mo,We,Fr 08:30-17:00",
+                "opening_hours_unclassified": null,
+                "details_url": "http://www.markt-veranstaltungen.de"
+            },
+            "type": "Feature"
+        },
+        {
+            "geometry": {
+                "coordinates": [
+                    13.58981,
+                    52.51901
+                ],
+                "type": "Point"
+            },
+            "properties": {
+                "title": "Wochenmarkt Cecilienplatz",
+                "location": "Ernst-Bloch-Straße, 12619",
+                "opening_hours": "Mo,We,Fr 09:00-18:00",
+                "opening_hours_unclassified": null
+            },
+            "type": "Feature"
+        },
+        {
+            "geometry": {
+                "coordinates": [
+                    13.55133,
+                    52.50756
+                ],
+                "type": "Point"
+            },
+            "properties": {
+                "title": "Antik- und Trödelmarkt Biesdorf-Center",
+                "location": "Weißenhöher Str. 88 - 108, 12683",
+                "opening_hours": null,
+                "opening_hours_unclassified": "15.01., 29.01., 12.02., 26.02.2023 08:00 - 15:00",
+                "details_url": "http://www.troedelfreunde.de"
+            },
+            "type": "Feature"
+        },
+        {
+            "geometry": {
+                "coordinates": [
+                    13.40221,
+                    52.51234
+                ],
+                "type": "Point"
+            },
+            "properties": {
+                "title": "Wochenmarkt Markt am Spittelmarkt",
+                "location": "Spittelmarkt, 10179",
+                "opening_hours": "We,Fr 10:00-15:00",
+                "opening_hours_unclassified": null,
+                "details_url": "http://www.bbm-maerkte.de"
+            },
+            "type": "Feature"
+        },
+        {
+            "geometry": {
+                "coordinates": [
+                    13.3516,
+                    52.54621
+                ],
+                "type": "Point"
+            },
+            "properties": {
+                "title": "Wochenmarkt am Rathaus Wedding",
+                "location": "Ostender Straße, 13353",
+                "opening_hours": "We,Sa 07:00-16:00",
+                "opening_hours_unclassified": null,
+                "details_url": "http://www.brandenburger-wochenmaerkte.de"
+            },
+            "type": "Feature"
+        },
+        {
+            "geometry": {
+                "coordinates": [
+                    13.35989,
+                    52.54752
+                ],
+                "type": "Point"
+            },
+            "properties": {
+                "title": "Wochenmarkt Leopoldplatz",
+                "location": "Leopoldplatz, 13353",
+                "opening_hours": "Th 11:00-17:00",
+                "opening_hours_unclassified": null,
+                "details_url": "http://www.bbm-maerkte.de"
+            },
+            "type": "Feature"
+        },
+        {
+            "geometry": {
+                "coordinates": [
+                    13.35989,
+                    52.54752
+                ],
+                "type": "Point"
+            },
+            "properties": {
+                "title": "Trödelmarkt auf dem Leopoldplatz",
+                "location": "Leopoldplatz, 13353",
                 "opening_hours": "Sa 10:00-16:00",
+                "opening_hours_unclassified": null,
+                "details_url": "http://www.bbm-maerkte.de"
+            },
+            "type": "Feature"
+        },
+        {
+            "geometry": {
+                "coordinates": [
+                    13.35989,
+                    52.54752
+                ],
+                "type": "Point"
+            },
+            "properties": {
+                "title": "Bauernmarkt Leopoldplatz",
+                "location": "Leopoldplatz, 13353",
+                "opening_hours": "Tu,Fr 10:00-17:00",
+                "opening_hours_unclassified": null,
+                "details_url": "http://www.bbm-maerkte.de"
+            },
+            "type": "Feature"
+        },
+        {
+            "geometry": {
+                "coordinates": [
+                    13.40191,
+                    52.52348
+                ],
+                "type": "Point"
+            },
+            "properties": {
+                "title": "Wochenmarkt am Hackeschen Markt",
+                "location": "Hackescher Markt, 10178",
+                "opening_hours": "Th 09:00-18:00",
+                "opening_hours_unclassified": null
+            },
+            "type": "Feature"
+        },
+        {
+            "geometry": {
+                "coordinates": [
+                    13.40191,
+                    52.52348
+                ],
+                "type": "Point"
+            },
+            "properties": {
+                "title": "Wochenmarkt am Hackeschen Markt",
+                "location": "Hackescher Markt, 10178",
+                "opening_hours": "Sa 10:00-18:00",
+                "opening_hours_unclassified": null
+            },
+            "type": "Feature"
+        },
+        {
+            "geometry": {
+                "coordinates": [
+                    13.34425,
+                    52.51775
+                ],
+                "type": "Point"
+            },
+            "properties": {
+                "title": "Ökomarkt im Hansaviertel",
+                "location": "Altonaer Straße, 10557",
+                "opening_hours": "Fr 12:00-18:30",
+                "opening_hours_unclassified": null,
+                "details_url": "http://www.marktzeit.berlin"
+            },
+            "type": "Feature"
+        },
+        {
+            "geometry": {
+                "coordinates": [
+                    13.3872,
+                    52.53245
+                ],
+                "type": "Point"
+            },
+            "properties": {
+                "title": "Ökomarkt & mehr am Nordbahnhof",
+                "location": "Elisabeth-Schwarzhaupt-Platz, 10115",
+                "opening_hours": "We 11:00-17:00",
+                "opening_hours_unclassified": null,
+                "details_url": "http://www.marktzeit.berlin"
+            },
+            "type": "Feature"
+        },
+        {
+            "geometry": {
+                "coordinates": [
+                    13.40058,
+                    52.5373
+                ],
+                "type": "Point"
+            },
+            "properties": {
+                "title": "Großer Trödelmarkt am Arkonaplatz",
+                "location": "Arkonaplatz, 10435",
+                "opening_hours": "Su 10:00-16:00",
+                "opening_hours_unclassified": null,
+                "details_url": "http://www.troedelmarkt-arkonaplatz.de"
+            },
+            "type": "Feature"
+        },
+        {
+            "geometry": {
+                "coordinates": [
+                    13.39475,
+                    52.52082
+                ],
+                "type": "Point"
+            },
+            "properties": {
+                "title": "Antik- und Buchmarkt am Bodemuseum",
+                "location": "Am Kupfergraben, 10117",
+                "opening_hours": "Sa,Su,PH 11:00-17:00",
+                "opening_hours_unclassified": null
+            },
+            "type": "Feature"
+        },
+        {
+            "geometry": {
+                "coordinates": [
+                    13.39364,
+                    52.53754
+                ],
+                "type": "Point"
+            },
+            "properties": {
+                "title": "Flohmarkt im Mauerpark",
+                "location": "Bernauer Straße 63-64, 13355",
+                "opening_hours": "Su 10:00-18:00",
+                "opening_hours_unclassified": null,
+                "details_url": "http://www.flohmarktimmauerpark.de"
+            },
+            "type": "Feature"
+        },
+        {
+            "geometry": {
+                "coordinates": [
+                    13.39694,
+                    52.51815
+                ],
+                "type": "Point"
+            },
+            "properties": {
+                "title": "Kunstmarkt am Zeughaus",
+                "location": "Unter den Linden 2, 10117",
+                "opening_hours": "Sa,Su,PH 11:00-17:00",
+                "opening_hours_unclassified": null
+            },
+            "type": "Feature"
+        },
+        {
+            "geometry": {
+                "coordinates": [
+                    13.40798,
+                    52.51674
+                ],
+                "type": "Point"
+            },
+            "properties": {
+                "title": "Berlin-Brandenburger-Bauernmarkt -  Saisonmarkt auf dem Nikolaikirchplatz",
+                "location": "Nikolaikirchplatz, 10178",
+                "opening_hours": null,
+                "opening_hours_unclassified": "März - Oktober 10:00 - 17:00",
+                "details_url": "http://www.bbm-maerkte.de"
+            },
+            "type": "Feature"
+        },
+        {
+            "geometry": {
+                "coordinates": [
+                    13.33984,
+                    52.52605
+                ],
+                "type": "Point"
+            },
+            "properties": {
+                "title": "Ökomarkt & mehr an der Thusnelda-Allee",
+                "location": "Thusnelda-Allee 1, 10555",
+                "opening_hours": "We 12:00-18:00",
+                "opening_hours_unclassified": null,
+                "details_url": "http://www.marktzeit.berlin/"
+            },
+            "type": "Feature"
+        },
+        {
+            "geometry": {
+                "coordinates": [
+                    13.442,
+                    52.47367
+                ],
+                "type": "Point"
+            },
+            "properties": {
+                "title": "Neuköllner Wochenmärkte Rixdorf \"Gesunder Genuss auf dem Rixdorfer Markt\"",
+                "location": "Karl-Marx-Platz, 12043",
+                "opening_hours": "We 11:00-18:00;Sa 08:00-15:00",
+                "opening_hours_unclassified": null,
+                "details_url": "http://www.diemarktplaner.de"
+            },
+            "type": "Feature"
+        },
+        {
+            "geometry": {
+                "coordinates": [
+                    13.49285,
+                    52.42252
+                ],
+                "type": "Point"
+            },
+            "properties": {
+                "title": "Neuköllner Wochenmärkte Rudow \"Regionale Qualität in Rudow\"",
+                "location": "Prierosser Straße, 12355",
+                "opening_hours": "We,Sa 08:00-13:00",
                 "opening_hours_unclassified": null,
                 "details_url": "http://www.diemarktplaner.de"
             },
@@ -865,40 +1503,6 @@
         {
             "geometry": {
                 "coordinates": [
-                    13.442,
-                    52.47367
-                ],
-                "type": "Point"
-            },
-            "properties": {
-                "title": "Neuköllner Wochenmärkte Rixdorf \"Gesunder Genuss auf dem Rixdorfer Markt\"",
-                "location": "Karl-Marx-Platz, 12043",
-                "opening_hours": "We 11:00-18:00;Sa 08:00-15:00",
-                "opening_hours_unclassified": null,
-                "details_url": "http://www.diemarktplaner.de"
-            },
-            "type": "Feature"
-        },
-        {
-            "geometry": {
-                "coordinates": [
-                    13.49285,
-                    52.42252
-                ],
-                "type": "Point"
-            },
-            "properties": {
-                "title": "Neuköllner Wochenmärkte Rudow \"Regionale Qualität in Rudow\"",
-                "location": "Prierosser Straße, 12355",
-                "opening_hours": "We,Sa 08:00-13:00",
-                "opening_hours_unclassified": null,
-                "details_url": "http://www.diemarktplaner.de"
-            },
-            "type": "Feature"
-        },
-        {
-            "geometry": {
-                "coordinates": [
                     13.47461,
                     52.4233
                 ],
@@ -910,6 +1514,40 @@
                 "opening_hours": "We 08:00-14:00;Sa 08:00-13:00",
                 "opening_hours_unclassified": null,
                 "details_url": "http://www.diemarktplaner.de"
+            },
+            "type": "Feature"
+        },
+        {
+            "geometry": {
+                "coordinates": [
+                    13.423,
+                    52.47698
+                ],
+                "type": "Point"
+            },
+            "properties": {
+                "title": "Wochenmarkt Schillermarkt am Herrfurthplatz",
+                "location": "Herrfurthplatz, 12049",
+                "opening_hours": "We 10:00-18:00",
+                "opening_hours_unclassified": null,
+                "details_url": "http://www.mv-perske.de"
+            },
+            "type": "Feature"
+        },
+        {
+            "geometry": {
+                "coordinates": [
+                    13.43798,
+                    52.466
+                ],
+                "type": "Point"
+            },
+            "properties": {
+                "title": "Die Dicke Linda",
+                "location": "Kranoldplatz, 12051",
+                "opening_hours": "Sa 10:00-16:00",
+                "opening_hours_unclassified": null,
+                "details_url": "http://www.dicke-linda-markt.de"
             },
             "type": "Feature"
         },
@@ -933,68 +1571,625 @@
         {
             "geometry": {
                 "coordinates": [
-                    13.52317,
-                    52.4764
+                    13.41693,
+                    52.53632
                 ],
                 "type": "Point"
             },
             "properties": {
-                "title": "Oldthing Sammlerbörse für Ansichtskarten, Briefmarken & Münzen",
-                "location": "Treskowallee 159, 10318",
-                "opening_hours": null,
-                "opening_hours_unclassified": "04.11.-05.11.2023 09:00-16:00",
-                "details_url": "http://www.oldthing.de/riesenflohmarkt"
+                "title": "Ökomarkt am Kollwitzplatz der GRÜNEN LIGA Berlin e. V.",
+                "location": "Kollwitzplatz, 10435",
+                "opening_hours": "Th 12:00-19:00",
+                "opening_hours_unclassified": null,
+                "details_url": "http://www.grueneliga-berlin.de"
             },
             "type": "Feature"
         },
         {
             "geometry": {
                 "coordinates": [
-                    13.52317,
-                    52.4764
+                    13.41693,
+                    52.53632
                 ],
                 "type": "Point"
             },
             "properties": {
-                "title": "Oldthing Sammlerbörse für Ansichtskarten, Briefmarken und Münzen",
-                "location": "Treskowallee 159, 10318",
-                "opening_hours": null,
-                "opening_hours_unclassified": "02.04.2023 09:00 - 17:00",
-                "details_url": "http://www.oldthing.de/riesenflohmarkt"
+                "title": "Wochenmarkt Neuer Markt am Kollwitzplatz",
+                "location": "Kollwitzplatz, 10435",
+                "opening_hours": "Sa 10:30-16:30",
+                "opening_hours_unclassified": null
             },
             "type": "Feature"
         },
         {
             "geometry": {
                 "coordinates": [
-                    13.52317,
-                    52.4764
+                    13.40528,
+                    52.57019
                 ],
                 "type": "Point"
             },
             "properties": {
-                "title": "Riesenflohmarkt Event",
-                "location": "Treskowallee 159, 10318",
-                "opening_hours": null,
-                "opening_hours_unclassified": "27.-29.05., 01.-03.10.2023 09:00 - 17:00",
-                "details_url": "http://www.oldthing.de/riesenflohmarkt"
+                "title": "Wochenmarkt Breite Straße",
+                "location": "Breite Str. 17, 13187",
+                "opening_hours": "Tu 08:00-14:00;We 09:00-17:00;Fr 08:00-16:00;Sa 08:00-15:00",
+                "opening_hours_unclassified": null
             },
             "type": "Feature"
         },
         {
             "geometry": {
                 "coordinates": [
-                    13.36423,
-                    52.49019
+                    13.42012,
+                    52.60728
                 ],
                 "type": "Point"
             },
             "properties": {
-                "title": "Schoeneboerg Flowmarkt",
-                "location": "Crellestr. 25, 10827",
+                "title": "Wochenmarkt Markt am Hugenottenplatz",
+                "location": "Hugenottenplatz, 13127",
+                "opening_hours": "Sa 09:00-13:00",
+                "opening_hours_unclassified": null
+            },
+            "type": "Feature"
+        },
+        {
+            "geometry": {
+                "coordinates": [
+                    13.36725,
+                    52.58554
+                ],
+                "type": "Point"
+            },
+            "properties": {
+                "title": "Wochenmarkt Hauptstraße / Goethestraße Wilhelmsruh",
+                "location": "Hauptstraße, 13158",
+                "opening_hours": "We,Fr 08:00-14:00",
+                "opening_hours_unclassified": null
+            },
+            "type": "Feature"
+        },
+        {
+            "geometry": {
+                "coordinates": [
+                    13.41085,
+                    52.55215
+                ],
+                "type": "Point"
+            },
+            "properties": {
+                "title": "Wochenmarkt Seelower Straße",
+                "location": "Seelower Straße, 10439",
+                "opening_hours": "Sa 09:00-16:00",
+                "opening_hours_unclassified": null,
+                "details_url": "http://www.bbm-maerkte.de"
+            },
+            "type": "Feature"
+        },
+        {
+            "geometry": {
+                "coordinates": [
+                    13.4358,
+                    52.5323
+                ],
+                "type": "Point"
+            },
+            "properties": {
+                "title": "Wochenmarkt Markt am Stierbrunnen",
+                "location": "Pasteurstraße 32, 10407",
+                "opening_hours": "Sa 09:00-15:00",
+                "opening_hours_unclassified": null
+            },
+            "type": "Feature"
+        },
+        {
+            "geometry": {
+                "coordinates": [
+                    13.41965,
+                    52.54313
+                ],
+                "type": "Point"
+            },
+            "properties": {
+                "title": "Wochenmarkt Markt am Helmholtzplatz",
+                "location": "Helmholtzplatz, 10437",
+                "opening_hours": "Sa 09:00-16:00",
+                "opening_hours_unclassified": null
+            },
+            "type": "Feature"
+        },
+        {
+            "geometry": {
+                "coordinates": [
+                    13.48712,
+                    52.61745
+                ],
+                "type": "Point"
+            },
+            "properties": {
+                "title": "Wochenmarkt Bucher Chaussee / Achillesstraße",
+                "location": "Bucher Chaussee, 13125",
+                "opening_hours": "Th 08:00-16:30;Sa 08:00-14:30",
+                "opening_hours_unclassified": null
+            },
+            "type": "Feature"
+        },
+        {
+            "geometry": {
+                "coordinates": [
+                    13.45105,
+                    52.54853
+                ],
+                "type": "Point"
+            },
+            "properties": {
+                "title": "Wochenmarkt Antonplatz",
+                "location": "Antonplatz, 13086",
+                "opening_hours": "Mo,Tu,Th,Fr 09:00-18:00",
+                "opening_hours_unclassified": null,
+                "details_url": "http://www.mv-perske.de"
+            },
+            "type": "Feature"
+        },
+        {
+            "geometry": {
+                "coordinates": [
+                    13.43049,
+                    52.55249
+                ],
+                "type": "Point"
+            },
+            "properties": {
+                "title": "Wochenmarkt Caligariplatz",
+                "location": "Caligariplatz, 10119",
+                "opening_hours": "We,Fr 08:00-18:00",
+                "opening_hours_unclassified": null
+            },
+            "type": "Feature"
+        },
+        {
+            "geometry": {
+                "coordinates": [
+                    13.44073,
+                    52.54321
+                ],
+                "type": "Point"
+            },
+            "properties": {
+                "title": "Wochenmarkt Greifswalder Straße / Thomas-Mann-Straße",
+                "location": "Greifswalder Straße 157, 10409",
+                "opening_hours": "Tu 08:00-18:00;Th 08:00-18:00;Sa 08:00-14:00",
+                "opening_hours_unclassified": null
+            },
+            "type": "Feature"
+        },
+        {
+            "geometry": {
+                "coordinates": [
+                    13.29298,
+                    52.63135
+                ],
+                "type": "Point"
+            },
+            "properties": {
+                "title": "Wochenmarkt Burgfrauenstraße",
+                "location": "Burgfrauenstraße, 13465",
+                "opening_hours": "Th-Sa 08:00-13:00",
+                "opening_hours_unclassified": null
+            },
+            "type": "Feature"
+        },
+        {
+            "geometry": {
+                "coordinates": [
+                    13.32806,
+                    52.57014
+                ],
+                "type": "Point"
+            },
+            "properties": {
+                "title": "Trödelmarkt Ollenhauerstraße",
+                "location": "Ollenhauerstraße 107, 13403",
+                "opening_hours": "Su 08:00-16:00",
+                "opening_hours_unclassified": null,
+                "details_url": "https://icktroedel.de"
+            },
+            "type": "Feature"
+        },
+        {
+            "geometry": {
+                "coordinates": [
+                    13.30815,
+                    52.61603
+                ],
+                "type": "Point"
+            },
+            "properties": {
+                "title": "Wochenmarkt Fellbacher Straße",
+                "location": "Fellbacher Str. 30a, 13467",
+                "opening_hours": "Fr 10:00-18:00",
+                "opening_hours_unclassified": null,
+                "details_url": "http://www.treffpunkt-wochenmarkt.de"
+            },
+            "type": "Feature"
+        },
+        {
+            "geometry": {
+                "coordinates": [
+                    13.20429,
+                    52.537
+                ],
+                "type": "Point"
+            },
+            "properties": {
+                "title": "Wochenmarkt Rathausvorplatz",
+                "location": "Markt 3, 13597",
+                "opening_hours": "We 08:00-18:00;Sa 08:00-16:00",
+                "opening_hours_unclassified": null
+            },
+            "type": "Feature"
+        },
+        {
+            "geometry": {
+                "coordinates": [
+                    13.20429,
+                    52.537
+                ],
+                "type": "Point"
+            },
+            "properties": {
+                "title": "Wochenmarkt Altstadt Spandau - Markt Havelländischer Land- und Bauernmarkt",
+                "location": "Markt 3, 13597",
+                "opening_hours": "Mo,Tu,Th,Fr 09:00+",
+                "opening_hours_unclassified": null,
+                "details_url": "http://www.wirtschaftshof-spandau.de"
+            },
+            "type": "Feature"
+        },
+        {
+            "geometry": {
+                "coordinates": [
+                    13.20605,
+                    52.55923
+                ],
+                "type": "Point"
+            },
+            "properties": {
+                "title": "Wochenmarkt Hakenfelde",
+                "location": "Michelstadter Weg, 13587",
+                "opening_hours": "Th 08:00-13:00",
+                "opening_hours_unclassified": null
+            },
+            "type": "Feature"
+        },
+        {
+            "geometry": {
+                "coordinates": [
+                    13.15637,
+                    52.53259
+                ],
+                "type": "Point"
+            },
+            "properties": {
+                "title": "Wochenmarkt Brunsbütteler Damm 265",
+                "location": "Brunsbütteler Damm 265, 13591",
+                "opening_hours": "Fr 08:00-15:00",
+                "opening_hours_unclassified": null,
+                "details_url": "http://www.brandenburger-wochenmaerkte.de"
+            },
+            "type": "Feature"
+        },
+        {
+            "geometry": {
+                "coordinates": [
+                    13.16358,
+                    52.52234
+                ],
+                "type": "Point"
+            },
+            "properties": {
+                "title": "Wochenmarkt Einkaufscenter Staaken",
+                "location": "Obstallee 28, 13593",
+                "opening_hours": "Tu,Fr 09:00-15:00",
+                "opening_hours_unclassified": null
+            },
+            "type": "Feature"
+        },
+        {
+            "geometry": {
+                "coordinates": [
+                    13.2448,
+                    52.5423
+                ],
+                "type": "Point"
+            },
+            "properties": {
+                "title": "Trödelmarkt METRO Spandau",
+                "location": "Nonnendammallee 135, 13599",
+                "opening_hours": "Su 07:00-14:00",
+                "opening_hours_unclassified": null,
+                "details_url": "http://www.hoefges.de"
+            },
+            "type": "Feature"
+        },
+        {
+            "geometry": {
+                "coordinates": [
+                    13.17734,
+                    52.54814
+                ],
+                "type": "Point"
+            },
+            "properties": {
+                "title": "Flohmarkt Falkenseer Chaussee, Siegener Straße",
+                "location": "Falkenseer Chaussee 239, 13583",
+                "opening_hours": "Su 08:00-16:00",
+                "opening_hours_unclassified": null,
+                "details_url": "https://icktroedel.de"
+            },
+            "type": "Feature"
+        },
+        {
+            "geometry": {
+                "coordinates": [
+                    13.20832,
+                    52.55769
+                ],
+                "type": "Point"
+            },
+            "properties": {
+                "title": "Carossa-Markt",
+                "location": "Streitstr. 13, 13587",
+                "opening_hours": "Tu,Fr 10:00-18:00",
+                "opening_hours_unclassified": null,
+                "details_url": "http://www.mv-perske.de"
+            },
+            "type": "Feature"
+        },
+        {
+            "geometry": {
+                "coordinates": [
+                    13.125,
+                    52.47151
+                ],
+                "type": "Point"
+            },
+            "properties": {
+                "title": "19. Kinderflohmarkt in der Landstadt Gatow",
+                "location": "Leonardo-da-Vinci-Straße, 14089",
                 "opening_hours": null,
-                "opening_hours_unclassified": "16.04., 30.04., 14.05., 28.05., 11.06., 25.06., 09.07., 20.08., 03.09., 17.09., 01.10., 15.10.2023 10:30 - 17:00",
-                "details_url": "http://www.flowmarkt.de/nowkoelln.de"
+                "opening_hours_unclassified": "29.04.2023 10:00 - 14:00"
+            },
+            "type": "Feature"
+        },
+        {
+            "geometry": {
+                "coordinates": [
+                    13.19329,
+                    52.52733
+                ],
+                "type": "Point"
+            },
+            "properties": {
+                "title": "Trödelmarkt Wilhelmstraße",
+                "location": "Wilhelmstr. 8, 13595",
+                "opening_hours": "Su 08:00-16:00",
+                "opening_hours_unclassified": null,
+                "details_url": "https://icktroedel.de"
+            },
+            "type": "Feature"
+        },
+        {
+            "geometry": {
+                "coordinates": [
+                    13.32198,
+                    52.45681
+                ],
+                "type": "Point"
+            },
+            "properties": {
+                "title": "Wochenmarkt Hermann-Ehlers-Platz",
+                "location": "Hermann-Ehlers-Platz, 12165",
+                "opening_hours": "Tu 08:00-14:00;Sa 08:00-14:00;Th 08:00-18:00",
+                "opening_hours_unclassified": null
+            },
+            "type": "Feature"
+        },
+        {
+            "geometry": {
+                "coordinates": [
+                    13.32198,
+                    52.45681
+                ],
+                "type": "Point"
+            },
+            "properties": {
+                "title": "Trödelmarkt auf dem Hermann-Ehlers-Platz",
+                "location": "Hermann-Ehlers-Platz, 12165",
+                "opening_hours": "Su 07:00-16:00",
+                "opening_hours_unclassified": null
+            },
+            "type": "Feature"
+        },
+        {
+            "geometry": {
+                "coordinates": [
+                    13.32686,
+                    52.42795
+                ],
+                "type": "Point"
+            },
+            "properties": {
+                "title": "Wochenmarkt Lichterfelde, Kranoldplatz",
+                "location": "Kranoldplatz, 12209",
+                "opening_hours": "We,Sa 08:00-14:00",
+                "opening_hours_unclassified": null
+            },
+            "type": "Feature"
+        },
+        {
+            "geometry": {
+                "coordinates": [
+                    13.33783,
+                    52.44442
+                ],
+                "type": "Point"
+            },
+            "properties": {
+                "title": "Wochenmarkt Rathaus Lankwitz",
+                "location": "Leonorenstraße, 12247",
+                "opening_hours": "Mo,Fr 08:00-13:00",
+                "opening_hours_unclassified": null
+            },
+            "type": "Feature"
+        },
+        {
+            "geometry": {
+                "coordinates": [
+                    13.31202,
+                    52.44286
+                ],
+                "type": "Point"
+            },
+            "properties": {
+                "title": "Wochenmarkt Ludwig-Beck-Platz",
+                "location": "Ludwig-Beck-Platz, 12203",
+                "opening_hours": "Fr,Sa 08:00-13:00",
+                "opening_hours_unclassified": null
+            },
+            "type": "Feature"
+        },
+        {
+            "geometry": {
+                "coordinates": [
+                    13.21476,
+                    52.43791
+                ],
+                "type": "Point"
+            },
+            "properties": {
+                "title": "Markt Schlachtensee (Wochenmarkt)",
+                "location": "Matterhornstr. 52/54, 14129",
+                "opening_hours": "Tu,Fr 08:00-14:00",
+                "opening_hours_unclassified": null
+            },
+            "type": "Feature"
+        },
+        {
+            "geometry": {
+                "coordinates": [
+                    13.2884,
+                    52.45871
+                ],
+                "type": "Point"
+            },
+            "properties": {
+                "title": "Öko-Wochenmarkt Domäne Dahlem",
+                "location": "Königin-Luise-Str. 49, 14195",
+                "opening_hours": "Sa 08:00-13:00",
+                "opening_hours_unclassified": null,
+                "details_url": "http://www.domaene-dahlem.de"
+            },
+            "type": "Feature"
+        },
+        {
+            "geometry": {
+                "coordinates": [
+                    13.23283,
+                    52.43756
+                ],
+                "type": "Point"
+            },
+            "properties": {
+                "title": "Wochenmarkt Mexikoplatz",
+                "location": "Mexikoplatz, 14163",
+                "opening_hours": "Sa 09:00-15:00",
+                "opening_hours_unclassified": null
+            },
+            "type": "Feature"
+        },
+        {
+            "geometry": {
+                "coordinates": [
+                    13.25189,
+                    52.44943
+                ],
+                "type": "Point"
+            },
+            "properties": {
+                "title": "Wochenmarkt Onkel-Toms-Hütte",
+                "location": "Onkel-Tom-Str. 99, 14169",
+                "opening_hours": "Th 12:00-18:30",
+                "opening_hours_unclassified": null,
+                "details_url": "http://www.diemarktplaner.de"
+            },
+            "type": "Feature"
+        },
+        {
+            "geometry": {
+                "coordinates": [
+                    13.25867,
+                    52.4311
+                ],
+                "type": "Point"
+            },
+            "properties": {
+                "title": "Zehlendorf Frische Markt zwischen Teltower Damm und Postplatz direkt am S-Bahnhof Zehlendorf",
+                "location": "S-Bahnhof Zehlendorf, 14163",
+                "opening_hours": "Sa 09:00-16:00",
+                "opening_hours_unclassified": null,
+                "details_url": "http://www.zehlendorfer-wochenmarkt.de"
+            },
+            "type": "Feature"
+        },
+        {
+            "geometry": {
+                "coordinates": [
+                    13.26433,
+                    52.41171
+                ],
+                "type": "Point"
+            },
+            "properties": {
+                "title": "Frischemarkt Andréezeile",
+                "location": "Ladiusstraße, 14165",
+                "opening_hours": "Sa 08:00-13:00",
+                "opening_hours_unclassified": null,
+                "details_url": "http://www.diemarktplaner.de"
+            },
+            "type": "Feature"
+        },
+        {
+            "geometry": {
+                "coordinates": [
+                    13.14129,
+                    52.41211
+                ],
+                "type": "Point"
+            },
+            "properties": {
+                "title": "Dorfmarkt Wannsee",
+                "location": "Wilhelmplatz, 14109",
+                "opening_hours": "Fr 14:00-18:00",
+                "opening_hours_unclassified": null,
+                "details_url": "http://www.diemarktplaner.de"
+            },
+            "type": "Feature"
+        },
+        {
+            "geometry": {
+                "coordinates": [
+                    13.28578,
+                    52.41753
+                ],
+                "type": "Point"
+            },
+            "properties": {
+                "title": "Trödelmarkt OBI Steglitz",
+                "location": "Goerzallee 189 - 223, 14167",
+                "opening_hours": null,
+                "opening_hours_unclassified": "So ab 05.03.2023 07:00 - 14:00",
+                "details_url": "http://www.hoefges.de"
             },
             "type": "Feature"
         },
@@ -1018,47 +2213,151 @@
         {
             "geometry": {
                 "coordinates": [
-                    13.39503,
-                    52.48959
+                    13.30762,
+                    52.46698
                 ],
                 "type": "Point"
             },
             "properties": {
-                "title": "Trödelmarkt Bergmannstraße",
-                "location": "Marheinekeplatz, 10961",
-                "opening_hours": "Sa 10:00-16:00;Su 11:00-17:00",
-                "opening_hours_unclassified": null
+                "title": "anZiehmarkt",
+                "location": "Breitenbachplatz, 14195",
+                "opening_hours": null,
+                "opening_hours_unclassified": "16.04., 21.05., 18.06., 16.07., 20.08., 17.09., 15.10., 12.11.2023 10:30-15:00",
+                "details_url": "http://www.markttag-berlin.de"
             },
             "type": "Feature"
         },
         {
             "geometry": {
                 "coordinates": [
-                    13.45999,
-                    52.51172
+                    13.38107,
+                    52.4436
                 ],
                 "type": "Point"
             },
             "properties": {
-                "title": "Trödelmarkt Boxhagener Platz",
-                "location": "Grünberger Straße 75, 10245",
-                "opening_hours": "Su 10:00-18:00",
-                "opening_hours_unclassified": null
+                "title": "Wochenmarkt Mariendorfer Damm / Prinzenstraße",
+                "location": "Prinzenstraße, 12109",
+                "opening_hours": "We,Sa 08:00-13:00",
+                "opening_hours_unclassified": null,
+                "details_url": "http://www.berlin.de/ba-tempelhof-schoeneberg/politik-und-verwaltung/aemter/ordnungsamt/maerkte"
             },
             "type": "Feature"
         },
         {
             "geometry": {
                 "coordinates": [
-                    13.51288,
-                    52.53363
+                    13.35448,
+                    52.49574
                 ],
                 "type": "Point"
             },
             "properties": {
-                "title": "Trödelmarkt Landsberger Allee auf dem IKEA Parkplatz",
-                "location": "Landsberger Allee 364, 10365",
-                "opening_hours": "Su 09:00-15:00",
+                "title": "Wochenmarkt Winterfeldtplatz",
+                "location": "Winterfeldtplatz, 10781",
+                "opening_hours": "We 08:00-14:00;Sa 08:00-16:00",
+                "opening_hours_unclassified": null,
+                "details_url": "http://www.berlin.de/ba-tempelhof-schoeneberg/politik-und-verwaltung/aemter/ordnungsamt/maerkte"
+            },
+            "type": "Feature"
+        },
+        {
+            "geometry": {
+                "coordinates": [
+                    13.34362,
+                    52.48489
+                ],
+                "type": "Point"
+            },
+            "properties": {
+                "title": "Wochenmarkt John-F.-Kennedy-Platz",
+                "location": "John-F.-Kennedy-Platz 1, 10825",
+                "opening_hours": "Tu,Fr 08:00-13:00",
+                "opening_hours_unclassified": null,
+                "details_url": "http://www.berlin.de/ba-tempelhof-schoeneberg/politik-und-verwaltung/aemter/ordnungsamt/maerkte"
+            },
+            "type": "Feature"
+        },
+        {
+            "geometry": {
+                "coordinates": [
+                    13.34362,
+                    52.48489
+                ],
+                "type": "Point"
+            },
+            "properties": {
+                "title": "Trödelmarkt auf dem John-F.-Kennedy-Platz",
+                "location": "John-F.-Kennedy-Platz 1, 10825",
+                "opening_hours": "Sa,Su 08:00-16:00",
+                "opening_hours_unclassified": null,
+                "details_url": "http://www.berlin-flohmaerkte.de"
+            },
+            "type": "Feature"
+        },
+        {
+            "geometry": {
+                "coordinates": [
+                    13.3355,
+                    52.47233
+                ],
+                "type": "Point"
+            },
+            "properties": {
+                "title": "Wochenmarkt Breslauer Platz",
+                "location": "Breslauer Platz, 12159",
+                "opening_hours": null,
+                "opening_hours_unclassified": "Mi, Sa Do 08:00 - 14:00 12:00 - 18:00",
+                "details_url": "http://www.berlin.de/ba-tempelhof-schoeneberg/politik-und-verwaltung/aemter/ordnungsamt/maerkte"
+            },
+            "type": "Feature"
+        },
+        {
+            "geometry": {
+                "coordinates": [
+                    13.36551,
+                    52.49103
+                ],
+                "type": "Point"
+            },
+            "properties": {
+                "title": "Wochenmarkt Crellestraße",
+                "location": "Crellestraße 24, 10827",
+                "opening_hours": "We,Sa 10:00-15:00",
+                "opening_hours_unclassified": null,
+                "details_url": "http://www.berlin.de/ba-tempelhof-schoeneberg/politik-und-verwaltung/aemter/ordnungsamt/maerkte"
+            },
+            "type": "Feature"
+        },
+        {
+            "geometry": {
+                "coordinates": [
+                    13.34315,
+                    52.50213
+                ],
+                "type": "Point"
+            },
+            "properties": {
+                "title": "Wochenmarkt Wittenbergplatz (Nordseite)",
+                "location": "Wittenbergplatz 5, 10789",
+                "opening_hours": "Tu,Fr 08:00-15:00",
+                "opening_hours_unclassified": null,
+                "details_url": "http://www.berlin.de/ba-tempelhof-schoeneberg/politik-und-verwaltung/aemter/ordnungsamt/maerkte"
+            },
+            "type": "Feature"
+        },
+        {
+            "geometry": {
+                "coordinates": [
+                    13.34315,
+                    52.50213
+                ],
+                "type": "Point"
+            },
+            "properties": {
+                "title": "Wittenbergplatz (Nordseite) Brandenburger Bauernmarkt",
+                "location": "Wittenbergplatz 5, 10789",
+                "opening_hours": "Th 09:00-17:00",
                 "opening_hours_unclassified": null,
                 "details_url": "http://www.bbm-maerkte.de"
             },
@@ -1084,1182 +2383,68 @@
         {
             "geometry": {
                 "coordinates": [
-                    13.2448,
-                    52.5423
+                    13.37904,
+                    52.43085
                 ],
                 "type": "Point"
             },
             "properties": {
-                "title": "Trödelmarkt METRO Spandau",
-                "location": "Nonnendammallee 135, 13599",
-                "opening_hours": "Su 07:00-14:00",
+                "title": "Flohmarkt Marienfelde, Hornbach-Parkplatz",
+                "location": "Großbeerenstr. 133, 12107",
+                "opening_hours": "Su 09:00-15:00",
                 "opening_hours_unclassified": null,
-                "details_url": "http://www.hoefges.de"
+                "details_url": "http://www.ayvaz.de"
             },
             "type": "Feature"
         },
         {
             "geometry": {
                 "coordinates": [
-                    13.28578,
-                    52.41753
+                    13.3537,
+                    52.48908
                 ],
                 "type": "Point"
             },
             "properties": {
-                "title": "Trödelmarkt OBI Steglitz",
-                "location": "Goerzallee 189 - 223, 14167",
+                "title": "Ökomarkt & mehr an der Akazienstraße",
+                "location": "Akazienstraße 15, 10823",
+                "opening_hours": "Th 12:00-18:00",
+                "opening_hours_unclassified": null,
+                "details_url": "http://www.marktzeit.berlin/"
+            },
+            "type": "Feature"
+        },
+        {
+            "geometry": {
+                "coordinates": [
+                    13.36423,
+                    52.49019
+                ],
+                "type": "Point"
+            },
+            "properties": {
+                "title": "Schoeneboerg Flowmarkt",
+                "location": "Crellestr. 25, 10827",
                 "opening_hours": null,
-                "opening_hours_unclassified": "So ab 05.03.2023 07:00 - 14:00",
-                "details_url": "http://www.hoefges.de"
+                "opening_hours_unclassified": "16.04., 30.04., 14.05., 28.05., 11.06., 25.06., 09.07., 20.08., 03.09., 17.09., 01.10., 15.10.2023 10:30 - 17:00",
+                "details_url": "http://www.flowmarkt.de/nowkoelln.de"
             },
             "type": "Feature"
         },
         {
             "geometry": {
                 "coordinates": [
-                    13.32806,
-                    52.57014
+                    13.35261,
+                    52.49186
                 ],
                 "type": "Point"
             },
             "properties": {
-                "title": "Trödelmarkt Ollenhauerstraße",
-                "location": "Ollenhauerstraße 107, 13403",
-                "opening_hours": "Su 08:00-16:00",
-                "opening_hours_unclassified": null,
-                "details_url": "https://icktroedel.de"
-            },
-            "type": "Feature"
-        },
-        {
-            "geometry": {
-                "coordinates": [
-                    13.19329,
-                    52.52733
-                ],
-                "type": "Point"
-            },
-            "properties": {
-                "title": "Trödelmarkt Wilhelmstraße",
-                "location": "Wilhelmstr. 8, 13595",
-                "opening_hours": "Su 08:00-16:00",
-                "opening_hours_unclassified": null,
-                "details_url": "https://icktroedel.de"
-            },
-            "type": "Feature"
-        },
-        {
-            "geometry": {
-                "coordinates": [
-                    13.31586,
-                    52.48215
-                ],
-                "type": "Point"
-            },
-            "properties": {
-                "title": "Trödelmarkt an der Mecklenburgischen Straße",
-                "location": "Mecklenburgische Straße, 14197",
-                "opening_hours": "Su 08:00-16:00",
-                "opening_hours_unclassified": null,
-                "details_url": "http://www.der-mecklenburger-troedelmarkt.de"
-            },
-            "type": "Feature"
-        },
-        {
-            "geometry": {
-                "coordinates": [
-                    13.32198,
-                    52.45681
-                ],
-                "type": "Point"
-            },
-            "properties": {
-                "title": "Trödelmarkt auf dem Hermann-Ehlers-Platz",
-                "location": "Hermann-Ehlers-Platz, 12165",
-                "opening_hours": "Su 07:00-16:00",
-                "opening_hours_unclassified": null
-            },
-            "type": "Feature"
-        },
-        {
-            "geometry": {
-                "coordinates": [
-                    13.34362,
-                    52.48489
-                ],
-                "type": "Point"
-            },
-            "properties": {
-                "title": "Trödelmarkt auf dem John-F.-Kennedy-Platz",
-                "location": "John-F.-Kennedy-Platz 1, 10825",
-                "opening_hours": "Sa,Su 08:00-16:00",
-                "opening_hours_unclassified": null,
-                "details_url": "http://www.berlin-flohmaerkte.de"
-            },
-            "type": "Feature"
-        },
-        {
-            "geometry": {
-                "coordinates": [
-                    13.35989,
-                    52.54752
-                ],
-                "type": "Point"
-            },
-            "properties": {
-                "title": "Trödelmarkt auf dem Leopoldplatz",
-                "location": "Leopoldplatz, 13353",
-                "opening_hours": "Sa 10:00-16:00",
-                "opening_hours_unclassified": null,
-                "details_url": "http://www.bbm-maerkte.de"
-            },
-            "type": "Feature"
-        },
-        {
-            "geometry": {
-                "coordinates": [
-                    13.34315,
-                    52.50213
-                ],
-                "type": "Point"
-            },
-            "properties": {
-                "title": "Wittenbergplatz (Nordseite) Brandenburger Bauernmarkt",
-                "location": "Wittenbergplatz 5, 10789",
-                "opening_hours": "Th 09:00-17:00",
-                "opening_hours_unclassified": null,
-                "details_url": "http://www.bbm-maerkte.de"
-            },
-            "type": "Feature"
-        },
-        {
-            "geometry": {
-                "coordinates": [
-                    13.54325,
-                    52.43632
-                ],
-                "type": "Point"
-            },
-            "properties": {
-                "title": "Wochenmarkt Adlershof",
-                "location": "Dörpfeldstraße, 12489",
-                "opening_hours": "We,Th 08:00-16:00",
-                "opening_hours_unclassified": null,
-                "details_url": "http://www.gakenholz-gellesch.de"
-            },
-            "type": "Feature"
-        },
-        {
-            "geometry": {
-                "coordinates": [
-                    13.20429,
-                    52.537
-                ],
-                "type": "Point"
-            },
-            "properties": {
-                "title": "Wochenmarkt Altstadt Spandau - Markt Havelländischer Land- und Bauernmarkt",
-                "location": "Markt 3, 13597",
-                "opening_hours": "Mo,Tu,Th,Fr 09:00+",
-                "opening_hours_unclassified": null,
-                "details_url": "http://www.wirtschaftshof-spandau.de"
-            },
-            "type": "Feature"
-        },
-        {
-            "geometry": {
-                "coordinates": [
-                    13.43433,
-                    52.50955
-                ],
-                "type": "Point"
-            },
-            "properties": {
-                "title": "Wochenmarkt Am Kaufhof Ostbahnhof (Erich-Steinfurth-Straße)",
-                "location": "Ostbahnhof, 10243",
-                "opening_hours": "Mo-Sa 09:00-18:00",
-                "opening_hours_unclassified": null
-            },
-            "type": "Feature"
-        },
-        {
-            "geometry": {
-                "coordinates": [
-                    13.05696,
-                    52.40311
-                ],
-                "type": "Point"
-            },
-            "properties": {
-                "title": "Wochenmarkt Am Nauener Tor 14467 Potsdam",
-                "location": "Hegelallee 55, 14467",
-                "opening_hours": "We,Sa 09:00-16:00",
-                "opening_hours_unclassified": null,
-                "details_url": "http://www.markt-am-nauener-tor.de"
-            },
-            "type": "Feature"
-        },
-        {
-            "geometry": {
-                "coordinates": [
-                    13.47046,
-                    52.52862
-                ],
-                "type": "Point"
-            },
-            "properties": {
-                "title": "Wochenmarkt Anton-Saefkow-Platz",
-                "location": "Anton-Saefkow-Platz, 10369",
-                "opening_hours": "Tu,Th 09:00-18:00",
-                "opening_hours_unclassified": null
-            },
-            "type": "Feature"
-        },
-        {
-            "geometry": {
-                "coordinates": [
-                    13.45105,
-                    52.54853
-                ],
-                "type": "Point"
-            },
-            "properties": {
-                "title": "Wochenmarkt Antonplatz",
-                "location": "Antonplatz, 13086",
-                "opening_hours": "Mo,Tu,Th,Fr 09:00-18:00",
-                "opening_hours_unclassified": null,
-                "details_url": "http://www.mv-perske.de"
-            },
-            "type": "Feature"
-        },
-        {
-            "geometry": {
-                "coordinates": [
-                    13.52667,
-                    52.45864
-                ],
-                "type": "Point"
-            },
-            "properties": {
-                "title": "Wochenmarkt Berlin-Oberschöneweide",
-                "location": "Rathenaustraße 2A (Rathenauplatz), 12459",
-                "opening_hours": "We 09:00-16:00",
-                "opening_hours_unclassified": null,
-                "details_url": "http://www.brandenburger-wochenmaerkte.de"
-            },
-            "type": "Feature"
-        },
-        {
-            "geometry": {
-                "coordinates": [
-                    13.45871,
-                    52.51119
-                ],
-                "type": "Point"
-            },
-            "properties": {
-                "title": "Wochenmarkt Boxhagener Platz",
-                "location": "Boxhagener Platz, 10245",
-                "opening_hours": "Sa 09:00-15:30",
-                "opening_hours_unclassified": null
-            },
-            "type": "Feature"
-        },
-        {
-            "geometry": {
-                "coordinates": [
-                    13.40528,
-                    52.57019
-                ],
-                "type": "Point"
-            },
-            "properties": {
-                "title": "Wochenmarkt Breite Straße",
-                "location": "Breite Str. 17, 13187",
-                "opening_hours": "Tu 08:00-14:00;We 09:00-17:00;Fr 08:00-16:00;Sa 08:00-15:00",
-                "opening_hours_unclassified": null
-            },
-            "type": "Feature"
-        },
-        {
-            "geometry": {
-                "coordinates": [
-                    13.3355,
-                    52.47233
-                ],
-                "type": "Point"
-            },
-            "properties": {
-                "title": "Wochenmarkt Breslauer Platz",
-                "location": "Breslauer Platz, 12159",
+                "title": "Frauentrödel",
+                "location": "Barbarossastr. 65, 10781",
                 "opening_hours": null,
-                "opening_hours_unclassified": "Mi, Sa Do 08:00 - 14:00 12:00 - 18:00",
-                "details_url": "http://www.berlin.de/ba-tempelhof-schoeneberg/politik-und-verwaltung/aemter/ordnungsamt/maerkte"
-            },
-            "type": "Feature"
-        },
-        {
-            "geometry": {
-                "coordinates": [
-                    13.15637,
-                    52.53259
-                ],
-                "type": "Point"
-            },
-            "properties": {
-                "title": "Wochenmarkt Brunsbütteler Damm 265",
-                "location": "Brunsbütteler Damm 265, 13591",
-                "opening_hours": "Fr 08:00-15:00",
-                "opening_hours_unclassified": null,
-                "details_url": "http://www.brandenburger-wochenmaerkte.de"
-            },
-            "type": "Feature"
-        },
-        {
-            "geometry": {
-                "coordinates": [
-                    13.48712,
-                    52.61745
-                ],
-                "type": "Point"
-            },
-            "properties": {
-                "title": "Wochenmarkt Bucher Chaussee / Achillesstraße",
-                "location": "Bucher Chaussee, 13125",
-                "opening_hours": "Th 08:00-16:30;Sa 08:00-14:30",
-                "opening_hours_unclassified": null
-            },
-            "type": "Feature"
-        },
-        {
-            "geometry": {
-                "coordinates": [
-                    13.329,
-                    52.47885
-                ],
-                "type": "Point"
-            },
-            "properties": {
-                "title": "Wochenmarkt Bundesplatz",
-                "location": "Bundesplatz, 10715",
-                "opening_hours": "Mo,Th 08:00-13:00",
-                "opening_hours_unclassified": null
-            },
-            "type": "Feature"
-        },
-        {
-            "geometry": {
-                "coordinates": [
-                    13.29298,
-                    52.63135
-                ],
-                "type": "Point"
-            },
-            "properties": {
-                "title": "Wochenmarkt Burgfrauenstraße",
-                "location": "Burgfrauenstraße, 13465",
-                "opening_hours": "Th-Sa 08:00-13:00",
-                "opening_hours_unclassified": null
-            },
-            "type": "Feature"
-        },
-        {
-            "geometry": {
-                "coordinates": [
-                    13.51857,
-                    52.508
-                ],
-                "type": "Point"
-            },
-            "properties": {
-                "title": "Wochenmarkt Bärenschaufenster (öffentl. Straßenland)",
-                "location": "Am Tierpark, 10319",
-                "opening_hours": "Mo,Th,Fr 08:00-18:00",
-                "opening_hours_unclassified": null,
-                "details_url": "http://www.brandenburger-wochenmaerkte.de"
-            },
-            "type": "Feature"
-        },
-        {
-            "geometry": {
-                "coordinates": [
-                    13.43049,
-                    52.55249
-                ],
-                "type": "Point"
-            },
-            "properties": {
-                "title": "Wochenmarkt Caligariplatz",
-                "location": "Caligariplatz, 10119",
-                "opening_hours": "We,Fr 08:00-18:00",
-                "opening_hours_unclassified": null
-            },
-            "type": "Feature"
-        },
-        {
-            "geometry": {
-                "coordinates": [
-                    13.58981,
-                    52.51901
-                ],
-                "type": "Point"
-            },
-            "properties": {
-                "title": "Wochenmarkt Cecilienplatz",
-                "location": "Ernst-Bloch-Straße, 12619",
-                "opening_hours": "Mo,We,Fr 09:00-18:00",
-                "opening_hours_unclassified": null
-            },
-            "type": "Feature"
-        },
-        {
-            "geometry": {
-                "coordinates": [
-                    13.29365,
-                    52.48864
-                ],
-                "type": "Point"
-            },
-            "properties": {
-                "title": "Wochenmarkt Charlottenbrunner Straße",
-                "location": "Charlottenbrunner Straße, 14193",
-                "opening_hours": "Mo,Th 09:00-14:00",
-                "opening_hours_unclassified": null
-            },
-            "type": "Feature"
-        },
-        {
-            "geometry": {
-                "coordinates": [
-                    13.36551,
-                    52.49103
-                ],
-                "type": "Point"
-            },
-            "properties": {
-                "title": "Wochenmarkt Crellestraße",
-                "location": "Crellestraße 24, 10827",
-                "opening_hours": "We,Sa 10:00-15:00",
-                "opening_hours_unclassified": null,
-                "details_url": "http://www.berlin.de/ba-tempelhof-schoeneberg/politik-und-verwaltung/aemter/ordnungsamt/maerkte"
-            },
-            "type": "Feature"
-        },
-        {
-            "geometry": {
-                "coordinates": [
-                    13.70327,
-                    52.48223
-                ],
-                "type": "Point"
-            },
-            "properties": {
-                "title": "Wochenmarkt Dorfaue Schöneiche",
-                "location": "Dorfaue, 15566",
-                "opening_hours": "Th 09:00-14:00",
-                "opening_hours_unclassified": null
-            },
-            "type": "Feature"
-        },
-        {
-            "geometry": {
-                "coordinates": [
-                    13.31144,
-                    52.47344
-                ],
-                "type": "Point"
-            },
-            "properties": {
-                "title": "Wochenmarkt Eberbacher Straße",
-                "location": "Eberbacher Straße, 14197",
-                "opening_hours": "Tu,Fr 08:00-13:00",
-                "opening_hours_unclassified": null
-            },
-            "type": "Feature"
-        },
-        {
-            "geometry": {
-                "coordinates": [
-                    13.16358,
-                    52.52234
-                ],
-                "type": "Point"
-            },
-            "properties": {
-                "title": "Wochenmarkt Einkaufscenter Staaken",
-                "location": "Obstallee 28, 13593",
-                "opening_hours": "Tu,Fr 09:00-15:00",
-                "opening_hours_unclassified": null
-            },
-            "type": "Feature"
-        },
-        {
-            "geometry": {
-                "coordinates": [
-                    13.31322,
-                    52.4912
-                ],
-                "type": "Point"
-            },
-            "properties": {
-                "title": "Wochenmarkt Fehrbelliner Platz",
-                "location": "Fehrbelliner Platz, 10707",
-                "opening_hours": "Mo,Tu,Th 11:00-15:00",
-                "opening_hours_unclassified": null
-            },
-            "type": "Feature"
-        },
-        {
-            "geometry": {
-                "coordinates": [
-                    13.30815,
-                    52.61603
-                ],
-                "type": "Point"
-            },
-            "properties": {
-                "title": "Wochenmarkt Fellbacher Straße",
-                "location": "Fellbacher Str. 30a, 13467",
-                "opening_hours": "Fr 10:00-18:00",
-                "opening_hours_unclassified": null,
-                "details_url": "http://www.treffpunkt-wochenmarkt.de"
-            },
-            "type": "Feature"
-        },
-        {
-            "geometry": {
-                "coordinates": [
-                    13.48535,
-                    52.51225
-                ],
-                "type": "Point"
-            },
-            "properties": {
-                "title": "Wochenmarkt Frankfurter Allee 172",
-                "location": "Frankfurter Allee 172, 10365",
-                "opening_hours": "We 09:00-16:00",
-                "opening_hours_unclassified": null,
-                "details_url": "http://www.brandenburger-wochenmaerkte.de"
-            },
-            "type": "Feature"
-        },
-        {
-            "geometry": {
-                "coordinates": [
-                    13.52016,
-                    52.51358
-                ],
-                "type": "Point"
-            },
-            "properties": {
-                "title": "Wochenmarkt Friedrichsfelde Ost",
-                "location": "Seddiner Straße, 10315",
-                "opening_hours": "Mo-Fr 08:00-18:00",
-                "opening_hours_unclassified": null
-            },
-            "type": "Feature"
-        },
-        {
-            "geometry": {
-                "coordinates": [
-                    13.75265,
-                    52.42247
-                ],
-                "type": "Point"
-            },
-            "properties": {
-                "title": "Wochenmarkt Friedrichstraße Erkner",
-                "location": "Friedrichstraße, 15537",
-                "opening_hours": "Th 09:00-14:00",
-                "opening_hours_unclassified": null
-            },
-            "type": "Feature"
-        },
-        {
-            "geometry": {
-                "coordinates": [
-                    13.44073,
-                    52.54321
-                ],
-                "type": "Point"
-            },
-            "properties": {
-                "title": "Wochenmarkt Greifswalder Straße / Thomas-Mann-Straße",
-                "location": "Greifswalder Straße 157, 10409",
-                "opening_hours": "Tu 08:00-18:00;Th 08:00-18:00;Sa 08:00-14:00",
-                "opening_hours_unclassified": null
-            },
-            "type": "Feature"
-        },
-        {
-            "geometry": {
-                "coordinates": [
-                    13.20605,
-                    52.55923
-                ],
-                "type": "Point"
-            },
-            "properties": {
-                "title": "Wochenmarkt Hakenfelde",
-                "location": "Michelstadter Weg, 13587",
-                "opening_hours": "Th 08:00-13:00",
-                "opening_hours_unclassified": null
-            },
-            "type": "Feature"
-        },
-        {
-            "geometry": {
-                "coordinates": [
-                    13.36725,
-                    52.58554
-                ],
-                "type": "Point"
-            },
-            "properties": {
-                "title": "Wochenmarkt Hauptstraße / Goethestraße Wilhelmsruh",
-                "location": "Hauptstraße, 13158",
-                "opening_hours": "We,Fr 08:00-14:00",
-                "opening_hours_unclassified": null
-            },
-            "type": "Feature"
-        },
-        {
-            "geometry": {
-                "coordinates": [
-                    13.54223,
-                    52.52655
-                ],
-                "type": "Point"
-            },
-            "properties": {
-                "title": "Wochenmarkt Helene-Weigel-Platz",
-                "location": "Helene-Weigel-Platz, 12681",
-                "opening_hours": "Mo-Sa 09:00-17:00",
-                "opening_hours_unclassified": null,
-                "details_url": "http://www.markt-veranstaltungen.de"
-            },
-            "type": "Feature"
-        },
-        {
-            "geometry": {
-                "coordinates": [
-                    13.60735,
-                    52.53841
-                ],
-                "type": "Point"
-            },
-            "properties": {
-                "title": "Wochenmarkt Helle Mitte",
-                "location": "Peter-Weiss-Gasse, 12627",
-                "opening_hours": "We,Fr 08:00-17:00",
-                "opening_hours_unclassified": null
-            },
-            "type": "Feature"
-        },
-        {
-            "geometry": {
-                "coordinates": [
-                    13.32198,
-                    52.45681
-                ],
-                "type": "Point"
-            },
-            "properties": {
-                "title": "Wochenmarkt Hermann-Ehlers-Platz",
-                "location": "Hermann-Ehlers-Platz, 12165",
-                "opening_hours": "Tu 08:00-14:00;Sa 08:00-14:00;Th 08:00-18:00",
-                "opening_hours_unclassified": null
-            },
-            "type": "Feature"
-        },
-        {
-            "geometry": {
-                "coordinates": [
-                    13.48405,
-                    52.52633
-                ],
-                "type": "Point"
-            },
-            "properties": {
-                "title": "Wochenmarkt Herzbergstraße / Weißenseer Weg (Roedernplatz)",
-                "location": "Herzbergstraße, 10367",
-                "opening_hours": "Tu,Fr 08:00-17:00",
-                "opening_hours_unclassified": null
-            },
-            "type": "Feature"
-        },
-        {
-            "geometry": {
-                "coordinates": [
-                    13.32417,
-                    52.49389
-                ],
-                "type": "Point"
-            },
-            "properties": {
-                "title": "Wochenmarkt Hohenzollernplatz",
-                "location": "Hohenzollernplatz, 14129",
-                "opening_hours": "We,Sa 08:00-13:00",
-                "opening_hours_unclassified": null
-            },
-            "type": "Feature"
-        },
-        {
-            "geometry": {
-                "coordinates": [
-                    13.34362,
-                    52.48489
-                ],
-                "type": "Point"
-            },
-            "properties": {
-                "title": "Wochenmarkt John-F.-Kennedy-Platz",
-                "location": "John-F.-Kennedy-Platz 1, 10825",
-                "opening_hours": "Tu,Fr 08:00-13:00",
-                "opening_hours_unclassified": null,
-                "details_url": "http://www.berlin.de/ba-tempelhof-schoeneberg/politik-und-verwaltung/aemter/ordnungsamt/maerkte"
-            },
-            "type": "Feature"
-        },
-        {
-            "geometry": {
-                "coordinates": [
-                    13.31036,
-                    52.50848
-                ],
-                "type": "Point"
-            },
-            "properties": {
-                "title": "Wochenmarkt Karl-August-Platz",
-                "location": "Karl-August-Platz, 10625",
-                "opening_hours": "We 08:00-13:00;Sa 08:00-14:00",
-                "opening_hours_unclassified": null
-            },
-            "type": "Feature"
-        },
-        {
-            "geometry": {
-                "coordinates": [
-                    13.52866,
-                    52.48119
-                ],
-                "type": "Point"
-            },
-            "properties": {
-                "title": "Wochenmarkt Karlshorst",
-                "location": "Ehrenfelsstraße, 10318",
-                "opening_hours": "Tu,Fr 09:00-17:00",
-                "opening_hours_unclassified": null,
-                "details_url": "http://www.gakenholz-gellesch.de"
-            },
-            "type": "Feature"
-        },
-        {
-            "geometry": {
-                "coordinates": [
-                    13.29094,
-                    52.51765
-                ],
-                "type": "Point"
-            },
-            "properties": {
-                "title": "Wochenmarkt Klausenerplatz",
-                "location": "Klausenerplatz, 14059",
-                "opening_hours": "Tu,Fr 08:00-13:00",
-                "opening_hours_unclassified": null
-            },
-            "type": "Feature"
-        },
-        {
-            "geometry": {
-                "coordinates": [
-                    13.29052,
-                    52.4769
-                ],
-                "type": "Point"
-            },
-            "properties": {
-                "title": "Wochenmarkt Kolberger Platz",
-                "location": "Kolberger Platz, 14199",
-                "opening_hours": "We,Sa 06:00-15:00",
-                "opening_hours_unclassified": null
-            },
-            "type": "Feature"
-        },
-        {
-            "geometry": {
-                "coordinates": [
-                    13.35989,
-                    52.54752
-                ],
-                "type": "Point"
-            },
-            "properties": {
-                "title": "Wochenmarkt Leopoldplatz",
-                "location": "Leopoldplatz, 13353",
-                "opening_hours": "Th 11:00-17:00",
-                "opening_hours_unclassified": null,
-                "details_url": "http://www.bbm-maerkte.de"
-            },
-            "type": "Feature"
-        },
-        {
-            "geometry": {
-                "coordinates": [
-                    13.32686,
-                    52.42795
-                ],
-                "type": "Point"
-            },
-            "properties": {
-                "title": "Wochenmarkt Lichterfelde, Kranoldplatz",
-                "location": "Kranoldplatz, 12209",
-                "opening_hours": "We,Sa 08:00-14:00",
-                "opening_hours_unclassified": null
-            },
-            "type": "Feature"
-        },
-        {
-            "geometry": {
-                "coordinates": [
-                    13.31202,
-                    52.44286
-                ],
-                "type": "Point"
-            },
-            "properties": {
-                "title": "Wochenmarkt Ludwig-Beck-Platz",
-                "location": "Ludwig-Beck-Platz, 12203",
-                "opening_hours": "Fr,Sa 08:00-13:00",
-                "opening_hours_unclassified": null
-            },
-            "type": "Feature"
-        },
-        {
-            "geometry": {
-                "coordinates": [
-                    13.59142,
-                    52.48471
-                ],
-                "type": "Point"
-            },
-            "properties": {
-                "title": "Wochenmarkt Mahlsdorf Roedernstraße / Hultschiner Damm",
-                "location": "Roedernstraße, 12623",
-                "opening_hours": "Th 07:00-15:00",
-                "opening_hours_unclassified": null
-            },
-            "type": "Feature"
-        },
-        {
-            "geometry": {
-                "coordinates": [
-                    13.38107,
-                    52.4436
-                ],
-                "type": "Point"
-            },
-            "properties": {
-                "title": "Wochenmarkt Mariendorfer Damm / Prinzenstraße",
-                "location": "Prinzenstraße, 12109",
-                "opening_hours": "We,Sa 08:00-13:00",
-                "opening_hours_unclassified": null,
-                "details_url": "http://www.berlin.de/ba-tempelhof-schoeneberg/politik-und-verwaltung/aemter/ordnungsamt/maerkte"
-            },
-            "type": "Feature"
-        },
-        {
-            "geometry": {
-                "coordinates": [
-                    13.41965,
-                    52.54313
-                ],
-                "type": "Point"
-            },
-            "properties": {
-                "title": "Wochenmarkt Markt am Helmholtzplatz",
-                "location": "Helmholtzplatz, 10437",
-                "opening_hours": "Sa 09:00-16:00",
-                "opening_hours_unclassified": null
-            },
-            "type": "Feature"
-        },
-        {
-            "geometry": {
-                "coordinates": [
-                    13.42012,
-                    52.60728
-                ],
-                "type": "Point"
-            },
-            "properties": {
-                "title": "Wochenmarkt Markt am Hugenottenplatz",
-                "location": "Hugenottenplatz, 13127",
-                "opening_hours": "Sa 09:00-13:00",
-                "opening_hours_unclassified": null
-            },
-            "type": "Feature"
-        },
-        {
-            "geometry": {
-                "coordinates": [
-                    13.40219,
-                    52.51228
-                ],
-                "type": "Point"
-            },
-            "properties": {
-                "title": "Wochenmarkt Markt am Spittelmarkt",
-                "location": "Spittelmarkt, 10179",
-                "opening_hours": "We,Fr 10:00-15:00",
-                "opening_hours_unclassified": null,
-                "details_url": "http://www.bbm-maerkte.de"
-            },
-            "type": "Feature"
-        },
-        {
-            "geometry": {
-                "coordinates": [
-                    13.4358,
-                    52.5323
-                ],
-                "type": "Point"
-            },
-            "properties": {
-                "title": "Wochenmarkt Markt am Stierbrunnen",
-                "location": "Pasteurstraße 32, 10407",
-                "opening_hours": "Sa 09:00-15:00",
-                "opening_hours_unclassified": null
-            },
-            "type": "Feature"
-        },
-        {
-            "geometry": {
-                "coordinates": [
-                    13.55059,
-                    52.54396
-                ],
-                "type": "Point"
-            },
-            "properties": {
-                "title": "Wochenmarkt Marzahner Promenade",
-                "location": "Marzahner Promenade 30-33, 12679",
-                "opening_hours": "Mo,We,Fr 08:30-17:00",
-                "opening_hours_unclassified": null,
-                "details_url": "http://www.markt-veranstaltungen.de"
-            },
-            "type": "Feature"
-        },
-        {
-            "geometry": {
-                "coordinates": [
-                    13.23283,
-                    52.43756
-                ],
-                "type": "Point"
-            },
-            "properties": {
-                "title": "Wochenmarkt Mexikoplatz",
-                "location": "Mexikoplatz, 14163",
-                "opening_hours": "Sa 09:00-15:00",
-                "opening_hours_unclassified": null
-            },
-            "type": "Feature"
-        },
-        {
-            "geometry": {
-                "coordinates": [
-                    13.30481,
-                    52.5253
-                ],
-                "type": "Point"
-            },
-            "properties": {
-                "title": "Wochenmarkt Mierendorffplatz",
-                "location": "Mierendorffplatz, 10589",
-                "opening_hours": "We,Sa 08:00-13:00",
-                "opening_hours_unclassified": null
-            },
-            "type": "Feature"
-        },
-        {
-            "geometry": {
-                "coordinates": [
-                    13.29939,
-                    52.49725
-                ],
-                "type": "Point"
-            },
-            "properties": {
-                "title": "Wochenmarkt Nestorstraße",
-                "location": "Nestorstraße, 10709",
-                "opening_hours": "Tu,Fr 08:00-13:00",
-                "opening_hours_unclassified": null
-            },
-            "type": "Feature"
-        },
-        {
-            "geometry": {
-                "coordinates": [
-                    13.41693,
-                    52.53632
-                ],
-                "type": "Point"
-            },
-            "properties": {
-                "title": "Wochenmarkt Neuer Markt am Kollwitzplatz",
-                "location": "Kollwitzplatz, 10435",
-                "opening_hours": "Sa 10:30-16:30",
-                "opening_hours_unclassified": null
-            },
-            "type": "Feature"
-        },
-        {
-            "geometry": {
-                "coordinates": [
-                    13.25189,
-                    52.44959
-                ],
-                "type": "Point"
-            },
-            "properties": {
-                "title": "Wochenmarkt Onkel-Toms-Hütte",
-                "location": "Onkel-Tom-Str. 99, 14169",
-                "opening_hours": "Th 12:00-18:30",
-                "opening_hours_unclassified": null,
-                "details_url": "http://www.diemarktplaner.de"
-            },
-            "type": "Feature"
-        },
-        {
-            "geometry": {
-                "coordinates": [
-                    13.05868,
-                    52.40114
-                ],
-                "type": "Point"
-            },
-            "properties": {
-                "title": "Wochenmarkt Potsdam Bassinplatz",
-                "location": "Am Bassin 6, 14467",
-                "opening_hours": "Mo-Fr 07:00-16:00;Sa 07:00-13:00",
-                "opening_hours_unclassified": null
-            },
-            "type": "Feature"
-        },
-        {
-            "geometry": {
-                "coordinates": [
-                    13.50498,
-                    52.56518
-                ],
-                "type": "Point"
-            },
-            "properties": {
-                "title": "Wochenmarkt Prerower Platz",
-                "location": "Prerower Platz, 13051",
-                "opening_hours": "We 09:00-17:00",
-                "opening_hours_unclassified": null,
-                "details_url": "http://www.markt-veranstaltungen.de"
-            },
-            "type": "Feature"
-        },
-        {
-            "geometry": {
-                "coordinates": [
-                    13.2594,
-                    52.51112
-                ],
-                "type": "Point"
-            },
-            "properties": {
-                "title": "Wochenmarkt Preußenallee",
-                "location": "Preußenallee, 14052",
-                "opening_hours": "Tu,Fr 08:00-13:00",
-                "opening_hours_unclassified": null
-            },
-            "type": "Feature"
-        },
-        {
-            "geometry": {
-                "coordinates": [
-                    13.33783,
-                    52.44442
-                ],
-                "type": "Point"
-            },
-            "properties": {
-                "title": "Wochenmarkt Rathaus Lankwitz",
-                "location": "Leonorenstraße, 12247",
-                "opening_hours": "Mo,Fr 08:00-13:00",
-                "opening_hours_unclassified": null
-            },
-            "type": "Feature"
-        },
-        {
-            "geometry": {
-                "coordinates": [
-                    13.20429,
-                    52.537
-                ],
-                "type": "Point"
-            },
-            "properties": {
-                "title": "Wochenmarkt Rathausvorplatz",
-                "location": "Markt 3, 13597",
-                "opening_hours": "We 08:00-18:00;Sa 08:00-16:00",
-                "opening_hours_unclassified": null
-            },
-            "type": "Feature"
-        },
-        {
-            "geometry": {
-                "coordinates": [
-                    13.3058,
-                    52.51735
-                ],
-                "type": "Point"
-            },
-            "properties": {
-                "title": "Wochenmarkt Richard-Wagner-Platz",
-                "location": "Richard-Wagner-Platz, 10585",
-                "opening_hours": "Mo,Th 08:00-13:00",
-                "opening_hours_unclassified": null
-            },
-            "type": "Feature"
-        },
-        {
-            "geometry": {
-                "coordinates": [
-                    13.50246,
-                    52.46137
-                ],
-                "type": "Point"
-            },
-            "properties": {
-                "title": "Wochenmarkt Schellerstraße Ecke Spreestraße",
-                "location": "Schnellerstraße, 12439",
-                "opening_hours": "Th 08:00-16:00",
-                "opening_hours_unclassified": null,
-                "details_url": "http://www.gakenholz-gellesch.e"
-            },
-            "type": "Feature"
-        },
-        {
-            "geometry": {
-                "coordinates": [
-                    13.423,
-                    52.47698
-                ],
-                "type": "Point"
-            },
-            "properties": {
-                "title": "Wochenmarkt Schillermarkt am Herrfurthplatz",
-                "location": "Herrfurthplatz, 12049",
-                "opening_hours": "We 10:00-18:00",
-                "opening_hours_unclassified": null,
-                "details_url": "http://www.mv-perske.de"
+                "opening_hours_unclassified": "25.03.2023 13.05.2023 12:00 - 16:00",
+                "details_url": "https://www.kiezoase.de/aktuelle-angebote/"
             },
             "type": "Feature"
         },
@@ -2299,132 +2484,83 @@
         {
             "geometry": {
                 "coordinates": [
-                    13.41085,
-                    52.55215
+                    13.50246,
+                    52.46137
                 ],
                 "type": "Point"
             },
             "properties": {
-                "title": "Wochenmarkt Seelower Straße",
-                "location": "Seelower Straße, 10439",
-                "opening_hours": "Sa 09:00-16:00",
+                "title": "Wochenmarkt Schellerstraße Ecke Spreestraße",
+                "location": "Schnellerstraße, 12439",
+                "opening_hours": "Th 08:00-16:00",
                 "opening_hours_unclassified": null,
-                "details_url": "http://www.bbm-maerkte.de"
+                "details_url": "http://www.gakenholz-gellesch.e"
             },
             "type": "Feature"
         },
         {
             "geometry": {
                 "coordinates": [
-                    13.29583,
-                    52.50759
+                    13.62555,
+                    52.45754
                 ],
                 "type": "Point"
             },
             "properties": {
-                "title": "Wochenmarkt Suarezstraße",
-                "location": "Suarezstraße 48, 14057",
-                "opening_hours": "Th 08:00-14:00",
+                "title": "Flohmarkt am S-Bhf. Friedrichshagen",
+                "location": "Schöneicher Str./Dahlwitzer Landstr., 12587",
+                "opening_hours": "Su 08:00-16:00",
                 "opening_hours_unclassified": null,
-                "details_url": "http://www.treffpunkt-wochenmarkt.de"
+                "details_url": "http://www.oldthing.de/berlin"
             },
             "type": "Feature"
         },
         {
             "geometry": {
                 "coordinates": [
-                    13.35448,
-                    52.49574
+                    13.62555,
+                    52.45754
                 ],
                 "type": "Point"
             },
             "properties": {
-                "title": "Wochenmarkt Winterfeldtplatz",
-                "location": "Winterfeldtplatz, 10781",
-                "opening_hours": "We 08:00-14:00;Sa 08:00-16:00",
+                "title": "Flohmarkt am S-Bhf. Friedrichshagen",
+                "location": "Schöneicherstr./Dahlwitzer Landstraße, 12587",
+                "opening_hours": "Su 08:00-16:00",
                 "opening_hours_unclassified": null,
-                "details_url": "http://www.berlin.de/ba-tempelhof-schoeneberg/politik-und-verwaltung/aemter/ordnungsamt/maerkte"
+                "details_url": "http://www.oldthing.de"
             },
             "type": "Feature"
         },
         {
             "geometry": {
                 "coordinates": [
-                    13.34315,
-                    52.50213
+                    13.54452,
+                    52.39732
                 ],
                 "type": "Point"
             },
             "properties": {
-                "title": "Wochenmarkt Wittenbergplatz (Nordseite)",
-                "location": "Wittenbergplatz 5, 10789",
-                "opening_hours": "Tu,Fr 08:00-15:00",
+                "title": "Flohmarkt Schönefeld",
+                "location": "Grünbergallee 279, 12526",
+                "opening_hours": "Su 09:00-15:00",
                 "opening_hours_unclassified": null,
-                "details_url": "http://www.berlin.de/ba-tempelhof-schoeneberg/politik-und-verwaltung/aemter/ordnungsamt/maerkte"
+                "details_url": "http://www.ayvaz.de"
             },
             "type": "Feature"
         },
         {
             "geometry": {
                 "coordinates": [
-                    13.50211,
-                    52.56538
+                    13.52667,
+                    52.45864
                 ],
                 "type": "Point"
             },
             "properties": {
-                "title": "Wochenmarkt Zingster Straße",
-                "location": "Zingster Straße, 13051",
-                "opening_hours": "Sa 09:00-13:00",
-                "opening_hours_unclassified": null,
-                "details_url": "http://www.markt-veranstaltungen.de"
-            },
-            "type": "Feature"
-        },
-        {
-            "geometry": {
-                "coordinates": [
-                    13.40191,
-                    52.52348
-                ],
-                "type": "Point"
-            },
-            "properties": {
-                "title": "Wochenmarkt am Hackeschen Markt",
-                "location": "Hackescher Markt, 10178",
-                "opening_hours": "Th 09:00-18:00",
-                "opening_hours_unclassified": null
-            },
-            "type": "Feature"
-        },
-        {
-            "geometry": {
-                "coordinates": [
-                    13.40191,
-                    52.52348
-                ],
-                "type": "Point"
-            },
-            "properties": {
-                "title": "Wochenmarkt am Hackeschen Markt",
-                "location": "Hackescher Markt, 10178",
-                "opening_hours": "Sa 10:00-18:00",
-                "opening_hours_unclassified": null
-            },
-            "type": "Feature"
-        },
-        {
-            "geometry": {
-                "coordinates": [
-                    13.3516,
-                    52.54621
-                ],
-                "type": "Point"
-            },
-            "properties": {
-                "title": "Wochenmarkt am Rathaus Wedding",
-                "location": "Ostender Straße, 13353",
-                "opening_hours": "We,Sa 07:00-16:00",
+                "title": "Wochenmarkt Berlin-Oberschöneweide",
+                "location": "Rathenaustraße 2A (Rathenauplatz), 12459",
+                "opening_hours": "We 09:00-16:00",
                 "opening_hours_unclassified": null,
                 "details_url": "http://www.brandenburger-wochenmaerkte.de"
             },
@@ -2433,194 +2569,58 @@
         {
             "geometry": {
                 "coordinates": [
-                    13.25867,
-                    52.4311
+                    13.54325,
+                    52.43632
                 ],
                 "type": "Point"
             },
             "properties": {
-                "title": "Zehlendorf Frische Markt zwischen Teltower Damm und Postplatz direkt am S-Bahnhof Zehlendorf",
-                "location": "S-Bahnhof Zehlendorf, 14163",
-                "opening_hours": "Sa 09:00-16:00",
+                "title": "Wochenmarkt Adlershof",
+                "location": "Dörpfeldstraße, 12489",
+                "opening_hours": "We,Th 08:00-16:00",
                 "opening_hours_unclassified": null,
-                "details_url": "http://www.zehlendorfer-wochenmarkt.de"
+                "details_url": "http://www.gakenholz-gellesch.de"
             },
             "type": "Feature"
         },
         {
             "geometry": {
                 "coordinates": [
-                    13.30762,
-                    52.46698
+                    13.57442,
+                    52.4447
                 ],
                 "type": "Point"
             },
             "properties": {
-                "title": "anZiehmarkt",
-                "location": "Breitenbachplatz, 14195",
+                "title": "Grüner Wochenmarkt",
+                "location": "Schloßplatz Köpenick, 12557",
+                "opening_hours": "Tu,Th 09:00-16:00",
+                "opening_hours_unclassified": null,
+                "details_url": "http://www.markt-veranstaltungen.de"
+            },
+            "type": "Feature"
+        },
+        {
+            "geometry": {
+                "coordinates": [
+                    13.62475,
+                    52.44832
+                ],
+                "type": "Point"
+            },
+            "properties": {
+                "title": "Großer Trödeölmarkt am Bölschestraßenfest",
+                "location": "Bölschestraße, 12587",
                 "opening_hours": null,
-                "opening_hours_unclassified": "16.04., 21.05., 18.06., 16.07., 20.08., 17.09., 15.10., 12.11.2023 10:30-15:00",
-                "details_url": "http://www.markttag-berlin.de"
-            },
-            "type": "Feature"
-        },
-        {
-            "geometry": {
-                "coordinates": [
-                    13.2884,
-                    52.45871
-                ],
-                "type": "Point"
-            },
-            "properties": {
-                "title": "Öko-Wochenmarkt Domäne Dahlem",
-                "location": "Königin-Luise-Str. 49, 14195",
-                "opening_hours": "Sa 08:00-13:00",
-                "opening_hours_unclassified": null,
-                "details_url": "http://www.domaene-dahlem.de"
-            },
-            "type": "Feature"
-        },
-        {
-            "geometry": {
-                "coordinates": [
-                    13.3872,
-                    52.53245
-                ],
-                "type": "Point"
-            },
-            "properties": {
-                "title": "Ökomarkt & mehr am Nordbahnhof",
-                "location": "Elisabeth-Schwarzhaupt-Platz, 10115",
-                "opening_hours": "We 11:00-17:00",
-                "opening_hours_unclassified": null,
-                "details_url": "http://www.marktzeit.berlin"
-            },
-            "type": "Feature"
-        },
-        {
-            "geometry": {
-                "coordinates": [
-                    13.3537,
-                    52.48908
-                ],
-                "type": "Point"
-            },
-            "properties": {
-                "title": "Ökomarkt & mehr an der Akazienstraße",
-                "location": "Akazienstraße 15, 10823",
-                "opening_hours": "Th 12:00-18:00",
-                "opening_hours_unclassified": null,
-                "details_url": "http://www.marktzeit.berlin/"
-            },
-            "type": "Feature"
-        },
-        {
-            "geometry": {
-                "coordinates": [
-                    13.33984,
-                    52.52605
-                ],
-                "type": "Point"
-            },
-            "properties": {
-                "title": "Ökomarkt & mehr an der Thusnelda-Allee",
-                "location": "Thusnelda-Allee 1, 10555",
-                "opening_hours": "We 12:00-18:00",
-                "opening_hours_unclassified": null,
-                "details_url": "http://www.marktzeit.berlin/"
-            },
-            "type": "Feature"
-        },
-        {
-            "geometry": {
-                "coordinates": [
-                    13.39088,
-                    52.48845
-                ],
-                "type": "Point"
-            },
-            "properties": {
-                "title": "Ökomarkt - Chamissoplatz",
-                "location": "Chamissoplatz, 10965",
-                "opening_hours": "Sa 09:00-15:00",
-                "opening_hours_unclassified": null,
-                "details_url": "http://www.oekomarkt-chamissoplatz.de"
-            },
-            "type": "Feature"
-        },
-        {
-            "geometry": {
-                "coordinates": [
-                    13.42247,
-                    52.49113
-                ],
-                "type": "Point"
-            },
-            "properties": {
-                "title": "Ökomarkt Hohenstaufenplatz",
-                "location": "Zickenplatz, 10967",
-                "opening_hours": "Tu 12:00-18:00;Sa 09:00-15:00",
-                "opening_hours_unclassified": null,
-                "details_url": "http://www.mv-perske.de"
-            },
-            "type": "Feature"
-        },
-        {
-            "geometry": {
-                "coordinates": [
-                    13.43186,
-                    52.50044
-                ],
-                "type": "Point"
-            },
-            "properties": {
-                "title": "Ökomarkt Lausitzer Platz",
-                "location": "Lausitzer Platz, 10997",
-                "opening_hours": "Fr 12:00-18:00",
-                "opening_hours_unclassified": null,
-                "details_url": "http://www.mv-perske.de"
-            },
-            "type": "Feature"
-        },
-        {
-            "geometry": {
-                "coordinates": [
-                    13.41693,
-                    52.53632
-                ],
-                "type": "Point"
-            },
-            "properties": {
-                "title": "Ökomarkt am Kollwitzplatz der GRÜNEN LIGA Berlin e. V.",
-                "location": "Kollwitzplatz, 10435",
-                "opening_hours": "Th 12:00-19:00",
-                "opening_hours_unclassified": null,
-                "details_url": "http://www.grueneliga-berlin.de"
-            },
-            "type": "Feature"
-        },
-        {
-            "geometry": {
-                "coordinates": [
-                    13.34425,
-                    52.51775
-                ],
-                "type": "Point"
-            },
-            "properties": {
-                "title": "Ökomarkt im Hansaviertel",
-                "location": "Altonaer Straße, 10557",
-                "opening_hours": "Fr 12:00-18:30",
-                "opening_hours_unclassified": null,
-                "details_url": "http://www.marktzeit.berlin"
+                "opening_hours_unclassified": "13.-14.05.2023 10:00 - 18:00",
+                "details_url": "http://www.oldthing.de"
             },
             "type": "Feature"
         }
     ],
     "metadata": {
         "data_source": {
-            "title": "Stadt Berlin, CC BY 3.0 DE, aktualisiert am 19.09.2023",
+            "title": "Stadt Berlin, CC BY 3.0 DE, aktualisiert am 08.11.2023",
             "url": "https://daten.berlin.de/datensaetze/berliner-wochen-und-tr%C3%B6delm%C3%A4rkte"
         }
     },

--- a/preprocessing/berlin/raw/markets-berlin.json
+++ b/preprocessing/berlin/raw/markets-berlin.json
@@ -17,16 +17,16 @@
                     "bezeichnung": "11. Designbörse Berlin",
                     "bezirk": "Lichtenberg",
                     "email": "info@oldthing.de",
-                    "id": 449,
+                    "id": 450,
                     "plz": "10318",
                     "strasse": "Treskowallee 159",
                     "tage": "30.09.-03.10.2023",
                     "www": "http://design-boerse-berlin.de",
                     "zeiten": "Sa 17:00-21:00\nSo 11:00-17:00\nMo 11:00-17:00\nDi 11:00-17:00"
                 },
-                "description": "30.09.-03.10.2023<br />Sa 17:00-21:00&#10;So 11:00-17:00&#10;Mo 11:00-17:00&#10;Di 11:00-17:00<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/449\">Mehr...</a>",
-                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/449",
-                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/449",
+                "description": "30.09.-03.10.2023<br />Sa 17:00-21:00&#10;So 11:00-17:00&#10;Mo 11:00-17:00&#10;Di 11:00-17:00<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/450\">Mehr...</a>",
+                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/450",
+                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/450",
                 "title": "11. Designbörse Berlin"
             },
             "type": "Feature"
@@ -48,16 +48,16 @@
                     "bezeichnung": "19. Kinderflohmarkt in der Landstadt Gatow",
                     "bezirk": "Spandau",
                     "email": "kifloh.kladow@gmail.com",
-                    "id": 398,
+                    "id": 399,
                     "plz": "14089",
                     "strasse": "Leonardo-da-Vinci-Straße",
                     "tage": "29.04.2023",
                     "www": "",
                     "zeiten": "10:00 - 14:00"
                 },
-                "description": "29.04.2023<br />10:00 - 14:00<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/398\">Mehr...</a>",
-                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/398",
-                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/398",
+                "description": "29.04.2023<br />10:00 - 14:00<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/399\">Mehr...</a>",
+                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/399",
+                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/399",
                 "title": "19. Kinderflohmarkt in der Landstadt Gatow"
             },
             "type": "Feature"
@@ -79,16 +79,16 @@
                     "bezeichnung": "2. Antiquariatsmesse Bücherlust",
                     "bezirk": "Lichtenberg",
                     "email": "info@antiquariat-neumann.de",
-                    "id": 446,
+                    "id": 447,
                     "plz": "10318",
                     "strasse": "Treskowallee 159",
                     "tage": "09.09.-10.09.2023",
                     "www": "https://www.bücherlust.com",
                     "zeiten": "09:00 - 17:00"
                 },
-                "description": "09.09.-10.09.2023<br />09:00 - 17:00<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/446\">Mehr...</a>",
-                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/446",
-                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/446",
+                "description": "09.09.-10.09.2023<br />09:00 - 17:00<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/447\">Mehr...</a>",
+                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/447",
+                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/447",
                 "title": "2. Antiquariatsmesse Bücherlust"
             },
             "type": "Feature"
@@ -110,16 +110,16 @@
                     "bezeichnung": "22. Antikmeile Suarezstraße",
                     "bezirk": "Charlottenburg-Wilmersdorf",
                     "email": "mailto:info@oldthing.de",
-                    "id": 383,
+                    "id": 384,
                     "plz": "14057",
                     "strasse": "Suarezstraße",
                     "tage": "02.09.2023",
                     "www": "www.oldthing.de/suarezstrasse",
                     "zeiten": "12:00 - 20:00"
                 },
-                "description": "02.09.2023<br />12:00 - 20:00<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/383\">Mehr...</a>",
-                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/383",
-                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/383",
+                "description": "02.09.2023<br />12:00 - 20:00<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/384\">Mehr...</a>",
+                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/384",
+                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/384",
                 "title": "22. Antikmeile Suarezstraße"
             },
             "type": "Feature"
@@ -141,16 +141,16 @@
                     "bezeichnung": "Antik- & Designgroßflohmarkt Trabrennbahn Karlshorst",
                     "bezirk": "Lichtenberg",
                     "email": "mailto:info@oldthing.de",
-                    "id": 326,
+                    "id": 327,
                     "plz": "10318",
                     "strasse": "Treskowallee 159",
                     "tage": "01./02.04., 06./07.05., 27. - 29.05., 01./02.07., 05./06.08., 09./10.09., 01.-03.10., 04./05.11., 02. - 03.12.2023",
                     "www": "www.oldthing.de/riesenflohmarkt",
                     "zeiten": "09:00 - 17:00"
                 },
-                "description": "01./02.04., 06./07.05., 27. - 29.05., 01./02.07., 05./06.08., 09./10.09., 01.-03.10., 04./05.11., 02. - 03.12.2023<br />09:00 - 17:00<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/326\">Mehr...</a>",
-                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/326",
-                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/326",
+                "description": "01./02.04., 06./07.05., 27. - 29.05., 01./02.07., 05./06.08., 09./10.09., 01.-03.10., 04./05.11., 02. - 03.12.2023<br />09:00 - 17:00<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/327\">Mehr...</a>",
+                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/327",
+                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/327",
                 "title": "Antik- & Designgroßflohmarkt Trabrennbahn Karlshorst"
             },
             "type": "Feature"
@@ -172,16 +172,16 @@
                     "bezeichnung": "Antik- und Buchmarkt am Bodemuseum",
                     "bezirk": "Mitte",
                     "email": "",
-                    "id": 134,
+                    "id": 135,
                     "plz": "10117",
                     "strasse": "Am Kupfergraben",
                     "tage": "Sa, So, gesetzliche Feiertage",
                     "www": "",
                     "zeiten": "11:00 - 17:00"
                 },
-                "description": "Sa, So, gesetzliche Feiertage<br />11:00 - 17:00<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/134\">Mehr...</a>",
-                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/134",
-                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/134",
+                "description": "Sa, So, gesetzliche Feiertage<br />11:00 - 17:00<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/135\">Mehr...</a>",
+                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/135",
+                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/135",
                 "title": "Antik- und Buchmarkt am Bodemuseum"
             },
             "type": "Feature"
@@ -189,30 +189,30 @@
         {
             "geometry": {
                 "coordinates": [
-                    13.31896,
-                    52.47249
+                    13.31893,
+                    52.4725
                 ],
                 "type": "Point"
             },
             "properties": {
                 "data": {
-                    "_wgs84_lat": 52.4724915,
-                    "_wgs84_lon": 13.3189564,
+                    "_wgs84_lat": 52.4725001,
+                    "_wgs84_lon": 13.3189304,
                     "bemerkungen": "",
                     "betreiber": "Herr Hanisch, Tel.: 0177/856 65 98 und 58 91 69 05",
                     "bezeichnung": "Antik- und Kunstmarkt am Rüdi",
                     "bezirk": "Charlottenburg-Wilmersdorf",
                     "email": "info@markt-rix.de",
-                    "id": 425,
+                    "id": 426,
                     "plz": "14197",
                     "strasse": "Landauer Straße",
                     "tage": "27.05.2023",
                     "www": "www.markt-rix.de",
                     "zeiten": "12:00 - 19:00"
                 },
-                "description": "27.05.2023<br />12:00 - 19:00<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/425\">Mehr...</a>",
-                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/425",
-                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/425",
+                "description": "27.05.2023<br />12:00 - 19:00<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/426\">Mehr...</a>",
+                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/426",
+                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/426",
                 "title": "Antik- und Kunstmarkt am Rüdi"
             },
             "type": "Feature"
@@ -220,30 +220,30 @@
         {
             "geometry": {
                 "coordinates": [
-                    13.31896,
-                    52.47249
+                    13.31893,
+                    52.4725
                 ],
                 "type": "Point"
             },
             "properties": {
                 "data": {
-                    "_wgs84_lat": 52.4724915,
-                    "_wgs84_lon": 13.3189564,
+                    "_wgs84_lat": 52.4725001,
+                    "_wgs84_lon": 13.3189304,
                     "bemerkungen": "",
                     "betreiber": "Herr Hanisch, Tel.: 0177/856 65 98 und 58 91 69 05",
                     "bezeichnung": "Antik- und Kunstmarkt am Rüdi",
                     "bezirk": "Charlottenburg-Wilmersdorf",
                     "email": "info@markt-rix.de",
-                    "id": 428,
+                    "id": 429,
                     "plz": "14197",
                     "strasse": "Landauer Straße",
                     "tage": "28.05.2023",
                     "www": "www.markt-rix.de",
                     "zeiten": "11:00 - 19:00"
                 },
-                "description": "28.05.2023<br />11:00 - 19:00<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/428\">Mehr...</a>",
-                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/428",
-                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/428",
+                "description": "28.05.2023<br />11:00 - 19:00<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/429\">Mehr...</a>",
+                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/429",
+                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/429",
                 "title": "Antik- und Kunstmarkt am Rüdi"
             },
             "type": "Feature"
@@ -251,30 +251,30 @@
         {
             "geometry": {
                 "coordinates": [
-                    13.31896,
-                    52.47249
+                    13.31893,
+                    52.4725
                 ],
                 "type": "Point"
             },
             "properties": {
                 "data": {
-                    "_wgs84_lat": 52.4724915,
-                    "_wgs84_lon": 13.3189564,
+                    "_wgs84_lat": 52.4725001,
+                    "_wgs84_lon": 13.3189304,
                     "bemerkungen": "",
                     "betreiber": "Herr Hanisch, Tel.: 0177/856 65 98 und 58 91 69 05",
                     "bezeichnung": "Antik- und Kunstmarkt am Rüdi",
                     "bezirk": "Charlottenburg-Wilmersdorf",
                     "email": "info@markt-rix.de",
-                    "id": 431,
+                    "id": 432,
                     "plz": "14197",
                     "strasse": "Landauer Straße",
                     "tage": "16.09.2023",
                     "www": "www.markt-rix.de",
                     "zeiten": "12:00 - 19:00"
                 },
-                "description": "16.09.2023<br />12:00 - 19:00<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/431\">Mehr...</a>",
-                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/431",
-                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/431",
+                "description": "16.09.2023<br />12:00 - 19:00<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/432\">Mehr...</a>",
+                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/432",
+                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/432",
                 "title": "Antik- und Kunstmarkt am Rüdi"
             },
             "type": "Feature"
@@ -282,30 +282,30 @@
         {
             "geometry": {
                 "coordinates": [
-                    13.31896,
-                    52.47249
+                    13.31893,
+                    52.4725
                 ],
                 "type": "Point"
             },
             "properties": {
                 "data": {
-                    "_wgs84_lat": 52.4724915,
-                    "_wgs84_lon": 13.3189564,
+                    "_wgs84_lat": 52.4725001,
+                    "_wgs84_lon": 13.3189304,
                     "bemerkungen": "",
                     "betreiber": "Herr Hanisch, Tel.: 0177/856 65 98 und 58 91 69 05",
                     "bezeichnung": "Antik- und Kunstmarkt am Rüdi",
                     "bezirk": "Charlottenburg-Wilmersdorf",
                     "email": "info@markt-rix.de",
-                    "id": 434,
+                    "id": 435,
                     "plz": "14197",
                     "strasse": "Landauer Straße",
                     "tage": "17.09.2023",
                     "www": "www.markt-rix.de",
                     "zeiten": "11:00 - 19:00"
                 },
-                "description": "17.09.2023<br />11:00 - 19:00<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/434\">Mehr...</a>",
-                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/434",
-                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/434",
+                "description": "17.09.2023<br />11:00 - 19:00<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/435\">Mehr...</a>",
+                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/435",
+                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/435",
                 "title": "Antik- und Kunstmarkt am Rüdi"
             },
             "type": "Feature"
@@ -327,16 +327,16 @@
                     "bezeichnung": "Antik- und Kunstmarkt an der Villa Oppenheim",
                     "bezirk": "Charlottenburg-Wilmersdorf",
                     "email": "info@markt-rix.de",
-                    "id": 413,
+                    "id": 414,
                     "plz": "14059",
                     "strasse": "Schloßstr. 55",
                     "tage": "15.04.2023",
                     "www": "www.markt-rix.de",
                     "zeiten": "11:00 - 18:00"
                 },
-                "description": "15.04.2023<br />11:00 - 18:00<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/413\">Mehr...</a>",
-                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/413",
-                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/413",
+                "description": "15.04.2023<br />11:00 - 18:00<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/414\">Mehr...</a>",
+                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/414",
+                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/414",
                 "title": "Antik- und Kunstmarkt an der Villa Oppenheim"
             },
             "type": "Feature"
@@ -358,16 +358,16 @@
                     "bezeichnung": "Antik- und Kunstmarkt an der Villa Oppenheim",
                     "bezirk": "Charlottenburg-Wilmersdorf",
                     "email": "info@markt-rix.de",
-                    "id": 416,
+                    "id": 417,
                     "plz": "14059",
                     "strasse": "Schloßstr. 55",
                     "tage": "16.04.2023",
                     "www": "www.markt-rix.de",
                     "zeiten": "10:00 - 18:00"
                 },
-                "description": "16.04.2023<br />10:00 - 18:00<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/416\">Mehr...</a>",
-                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/416",
-                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/416",
+                "description": "16.04.2023<br />10:00 - 18:00<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/417\">Mehr...</a>",
+                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/417",
+                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/417",
                 "title": "Antik- und Kunstmarkt an der Villa Oppenheim"
             },
             "type": "Feature"
@@ -389,16 +389,16 @@
                     "bezeichnung": "Antik- und Kunstmarkt an der Villa Oppenheim",
                     "bezirk": "Charlottenburg-Wilmersdorf",
                     "email": "info@markt-rix.de",
-                    "id": 419,
+                    "id": 420,
                     "plz": "14059",
                     "strasse": "Schloßstr. 55",
                     "tage": "09.09.2023",
                     "www": "www.markt-rix.de",
                     "zeiten": "11:00 - 18:00"
                 },
-                "description": "09.09.2023<br />11:00 - 18:00<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/419\">Mehr...</a>",
-                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/419",
-                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/419",
+                "description": "09.09.2023<br />11:00 - 18:00<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/420\">Mehr...</a>",
+                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/420",
+                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/420",
                 "title": "Antik- und Kunstmarkt an der Villa Oppenheim"
             },
             "type": "Feature"
@@ -420,16 +420,16 @@
                     "bezeichnung": "Antik- und Kunstmarkt an der Villa Oppenheim",
                     "bezirk": "Charlottenburg-Wilmersdorf",
                     "email": "info@markt-rix.de",
-                    "id": 422,
+                    "id": 423,
                     "plz": "14059",
                     "strasse": "Schloßstr. 55",
                     "tage": "10.09.2023",
                     "www": "www.markt-rix.de",
                     "zeiten": "10:00 - 18:00"
                 },
-                "description": "10.09.2023<br />10:00 - 18:00<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/422\">Mehr...</a>",
-                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/422",
-                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/422",
+                "description": "10.09.2023<br />10:00 - 18:00<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/423\">Mehr...</a>",
+                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/423",
+                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/423",
                 "title": "Antik- und Kunstmarkt an der Villa Oppenheim"
             },
             "type": "Feature"
@@ -451,16 +451,16 @@
                     "bezeichnung": "Antik- und Trödelmarkt Biesdorf-Center",
                     "bezirk": "Marzahn-Hellersdorf",
                     "email": "anmeldung@troedelfreunde.de",
-                    "id": 365,
+                    "id": 366,
                     "plz": "12683",
                     "strasse": "Weißenhöher Str. 88 - 108",
                     "tage": "15.01., 29.01., 12.02., 26.02.2023",
                     "www": "www.troedelfreunde.de",
                     "zeiten": "08:00 - 15:00"
                 },
-                "description": "15.01., 29.01., 12.02., 26.02.2023<br />08:00 - 15:00<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/365\">Mehr...</a>",
-                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/365",
-                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/365",
+                "description": "15.01., 29.01., 12.02., 26.02.2023<br />08:00 - 15:00<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/366\">Mehr...</a>",
+                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/366",
+                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/366",
                 "title": "Antik- und Trödelmarkt Biesdorf-Center"
             },
             "type": "Feature"
@@ -482,16 +482,16 @@
                     "bezeichnung": "Antikgroßflohmarkt Trabrennbahn Karlshorst",
                     "bezirk": "Lichtenberg",
                     "email": "mailto:info@oldthing.de",
-                    "id": 374,
+                    "id": 375,
                     "plz": "10318",
                     "strasse": "Treskowallee 159",
                     "tage": "Sa, So",
                     "www": "http://www.oldthing.de",
                     "zeiten": "09:00 - 16:00"
                 },
-                "description": "Sa, So<br />09:00 - 16:00<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/374\">Mehr...</a>",
-                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/374",
-                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/374",
+                "description": "Sa, So<br />09:00 - 16:00<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/375\">Mehr...</a>",
+                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/375",
+                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/375",
                 "title": "Antikgroßflohmarkt Trabrennbahn Karlshorst"
             },
             "type": "Feature"
@@ -513,16 +513,16 @@
                     "bezeichnung": "Antikmarkt am Berliner Ostbahnhof",
                     "bezirk": "Friedrichsahin-Kreuzberg",
                     "email": "mailto:info@oldthing.de",
-                    "id": 380,
+                    "id": 381,
                     "plz": "10243",
                     "strasse": "Erich-Steinfurth-Str./Hermann-Stöhr-Park",
                     "tage": "So",
                     "www": "http://www.oldthing.de",
                     "zeiten": "09:00 - 17:00"
                 },
-                "description": "So<br />09:00 - 17:00<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/380\">Mehr...</a>",
-                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/380",
-                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/380",
+                "description": "So<br />09:00 - 17:00<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/381\">Mehr...</a>",
+                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/381",
+                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/381",
                 "title": "Antikmarkt am Berliner Ostbahnhof"
             },
             "type": "Feature"
@@ -544,16 +544,16 @@
                     "bezeichnung": "Antikmarkt am Berliner Ostbahnhof",
                     "bezirk": "Friedrichshain-Kreuzberg",
                     "email": "mailto:info@oldthing.de",
-                    "id": 65,
+                    "id": 66,
                     "plz": "10243",
                     "strasse": "Erich-Steinfurth-Straße/Hermann-Stöhr-Park",
                     "tage": "So",
                     "www": "http://www.oldthing.de",
                     "zeiten": "09:00 - 17:00"
                 },
-                "description": "So<br />09:00 - 17:00<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/65\">Mehr...</a>",
-                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/65",
-                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/65",
+                "description": "So<br />09:00 - 17:00<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/66\">Mehr...</a>",
+                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/66",
+                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/66",
                 "title": "Antikmarkt am Berliner Ostbahnhof"
             },
             "type": "Feature"
@@ -575,16 +575,16 @@
                     "bezeichnung": "Bauernmarkt Leopoldplatz",
                     "bezirk": "Mitte",
                     "email": "mailto:info@bbm-maerkte.de",
-                    "id": 311,
+                    "id": 312,
                     "plz": "13353",
                     "strasse": "Leopoldplatz",
                     "tage": "Di, Fr",
                     "www": "http://www.bbm-maerkte.de",
                     "zeiten": "10:00 - 17:00"
                 },
-                "description": "Di, Fr<br />10:00 - 17:00<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/311\">Mehr...</a>",
-                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/311",
-                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/311",
+                "description": "Di, Fr<br />10:00 - 17:00<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/312\">Mehr...</a>",
+                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/312",
+                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/312",
                 "title": "Bauernmarkt Leopoldplatz"
             },
             "type": "Feature"
@@ -606,16 +606,16 @@
                     "bezeichnung": "Berlin-Brandenburger-Bauernmarkt - \nSaisonmarkt auf dem Nikolaikirchplatz",
                     "bezirk": "Mitte",
                     "email": "mailto:info@bbm-maerkte.de",
-                    "id": 302,
+                    "id": 303,
                     "plz": "10178",
                     "strasse": "Nikolaikirchplatz",
                     "tage": "März - Oktober",
                     "www": "http://www.bbm-maerkte.de",
                     "zeiten": "10:00 - 17:00"
                 },
-                "description": "März - Oktober<br />10:00 - 17:00<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/302\">Mehr...</a>",
-                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/302",
-                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/302",
+                "description": "März - Oktober<br />10:00 - 17:00<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/303\">Mehr...</a>",
+                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/303",
+                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/303",
                 "title": "Berlin-Brandenburger-Bauernmarkt - \nSaisonmarkt auf dem Nikolaikirchplatz"
             },
             "type": "Feature"
@@ -637,16 +637,16 @@
                     "bezeichnung": "Berliner Spielzeugbörse für Modellbahn & altes Spielzeug",
                     "bezirk": "Lichtenberg",
                     "email": "info@oldthing.de",
-                    "id": 437,
+                    "id": 438,
                     "plz": "10318",
                     "strasse": "Treskowallee 159",
                     "tage": "01.04.2023",
                     "www": "http://berliner-spielzeugboerse.de",
                     "zeiten": "09:00 - 17:00"
                 },
-                "description": "01.04.2023<br />09:00 - 17:00<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/437\">Mehr...</a>",
-                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/437",
-                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/437",
+                "description": "01.04.2023<br />09:00 - 17:00<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/438\">Mehr...</a>",
+                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/438",
+                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/438",
                 "title": "Berliner Spielzeugbörse für Modellbahn & altes Spielzeug"
             },
             "type": "Feature"
@@ -668,16 +668,16 @@
                     "bezeichnung": "Berliner Spielzeugbörse für Modellbahn & altes Spielzeug",
                     "bezirk": "Lichtenberg",
                     "email": "info@oldthing.de",
-                    "id": 455,
+                    "id": 456,
                     "plz": "10318",
                     "strasse": "Treskowallee 159",
                     "tage": "02.12.-03.12.2023",
                     "www": "http://berliner-spielzeugboerse.de",
                     "zeiten": "09:00-16:00"
                 },
-                "description": "02.12.-03.12.2023<br />09:00-16:00<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/455\">Mehr...</a>",
-                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/455",
-                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/455",
+                "description": "02.12.-03.12.2023<br />09:00-16:00<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/456\">Mehr...</a>",
+                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/456",
+                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/456",
                 "title": "Berliner Spielzeugbörse für Modellbahn & altes Spielzeug"
             },
             "type": "Feature"
@@ -699,16 +699,16 @@
                     "bezeichnung": "Carossa-Markt",
                     "bezirk": "Spandau",
                     "email": "mailto:info@mv-perske.de",
-                    "id": 389,
+                    "id": 390,
                     "plz": "13587",
                     "strasse": "Streitstr. 13",
                     "tage": "Di, Fr",
                     "www": "http://www.mv-perske.de",
                     "zeiten": "10:00 - 18:00"
                 },
-                "description": "Di, Fr<br />10:00 - 18:00<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/389\">Mehr...</a>",
-                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/389",
-                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/389",
+                "description": "Di, Fr<br />10:00 - 18:00<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/390\">Mehr...</a>",
+                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/390",
+                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/390",
                 "title": "Carossa-Markt"
             },
             "type": "Feature"
@@ -730,16 +730,16 @@
                     "bezeichnung": "Die Dicke Linda",
                     "bezirk": "Neukölln",
                     "email": "mailto:info@diemarktplaner.de",
-                    "id": 299,
+                    "id": 300,
                     "plz": "12051",
                     "strasse": "Kranoldplatz",
                     "tage": "Sa",
                     "www": "http://www.dicke-linda-markt.de",
                     "zeiten": "10:00 - 16:00"
                 },
-                "description": "Sa<br />10:00 - 16:00<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/299\">Mehr...</a>",
-                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/299",
-                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/299",
+                "description": "Sa<br />10:00 - 16:00<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/300\">Mehr...</a>",
+                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/300",
+                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/300",
                 "title": "Die Dicke Linda"
             },
             "type": "Feature"
@@ -761,16 +761,16 @@
                     "bezeichnung": "Dorfmarkt Wannsee",
                     "bezirk": "Steglitz-Zehlendorf",
                     "email": "mailto:info@diemarktplaner.de",
-                    "id": 359,
+                    "id": 360,
                     "plz": "14109",
                     "strasse": "Wilhelmplatz",
                     "tage": "Fr",
                     "www": "http://www.diemarktplaner.de",
                     "zeiten": "14:00 - 18:00"
                 },
-                "description": "Fr<br />14:00 - 18:00<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/359\">Mehr...</a>",
-                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/359",
-                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/359",
+                "description": "Fr<br />14:00 - 18:00<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/360\">Mehr...</a>",
+                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/360",
+                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/360",
                 "title": "Dorfmarkt Wannsee"
             },
             "type": "Feature"
@@ -792,16 +792,16 @@
                     "bezeichnung": "Floh- und Bauernmarkt in Potsdam",
                     "bezirk": "Brandenburg",
                     "email": "mailto:koscholke@arcor.de",
-                    "id": 296,
+                    "id": 297,
                     "plz": "14482",
                     "strasse": "Weberplatz",
                     "tage": "Sa",
                     "www": "http://www.koscholke.de",
                     "zeiten": "07:00 - 13:00"
                 },
-                "description": "Sa<br />07:00 - 13:00<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/296\">Mehr...</a>",
-                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/296",
-                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/296",
+                "description": "Sa<br />07:00 - 13:00<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/297\">Mehr...</a>",
+                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/297",
+                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/297",
                 "title": "Floh- und Bauernmarkt in Potsdam"
             },
             "type": "Feature"
@@ -823,16 +823,16 @@
                     "bezeichnung": "Flohmarkt Falkenseer Chaussee, Siegener Straße",
                     "bezirk": "Spandau",
                     "email": "hallo@icktroedel.de",
-                    "id": 353,
+                    "id": 354,
                     "plz": "13583",
                     "strasse": "Falkenseer Chaussee 239",
                     "tage": "So",
                     "www": "https://icktroedel.de",
                     "zeiten": "08:00 - 16:00"
                 },
-                "description": "So<br />08:00 - 16:00<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/353\">Mehr...</a>",
-                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/353",
-                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/353",
+                "description": "So<br />08:00 - 16:00<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/354\">Mehr...</a>",
+                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/354",
+                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/354",
                 "title": "Flohmarkt Falkenseer Chaussee, Siegener Straße"
             },
             "type": "Feature"
@@ -854,16 +854,16 @@
                     "bezeichnung": "Flohmarkt Marienfelde, Hornbach-Parkplatz",
                     "bezirk": "Tempelhof-Schöneberg",
                     "email": "mailto:info@ayvaz.de",
-                    "id": 275,
+                    "id": 276,
                     "plz": "12107",
                     "strasse": "Großbeerenstr. 133",
                     "tage": "So",
                     "www": "http://www.ayvaz.de",
                     "zeiten": "09:00 - 15:00"
                 },
-                "description": "So<br />09:00 - 15:00<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/275\">Mehr...</a>",
-                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/275",
-                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/275",
+                "description": "So<br />09:00 - 15:00<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/276\">Mehr...</a>",
+                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/276",
+                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/276",
                 "title": "Flohmarkt Marienfelde, Hornbach-Parkplatz"
             },
             "type": "Feature"
@@ -885,16 +885,16 @@
                     "bezeichnung": "Flohmarkt Schönefeld",
                     "bezirk": "Treptow-Köpenick",
                     "email": "mailto:info@ayvaz.de",
-                    "id": 287,
+                    "id": 288,
                     "plz": "12526",
                     "strasse": "Grünbergallee 279",
                     "tage": "So",
                     "www": "http://www.ayvaz.de",
                     "zeiten": "09:00 - 15:00"
                 },
-                "description": "So<br />09:00 - 15:00<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/287\">Mehr...</a>",
-                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/287",
-                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/287",
+                "description": "So<br />09:00 - 15:00<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/288\">Mehr...</a>",
+                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/288",
+                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/288",
                 "title": "Flohmarkt Schönefeld"
             },
             "type": "Feature"
@@ -916,16 +916,16 @@
                     "bezeichnung": "Flohmarkt am S-Bhf. Friedrichshagen",
                     "bezirk": "Treptow-Köpenick",
                     "email": "mailto:info@oldthing.de",
-                    "id": 284,
+                    "id": 285,
                     "plz": "12587",
                     "strasse": "Schöneicher Str./Dahlwitzer Landstr.",
                     "tage": "So",
                     "www": "www.oldthing.de/berlin",
                     "zeiten": "08:00 - 16:00"
                 },
-                "description": "So<br />08:00 - 16:00<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/284\">Mehr...</a>",
-                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/284",
-                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/284",
+                "description": "So<br />08:00 - 16:00<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/285\">Mehr...</a>",
+                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/285",
+                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/285",
                 "title": "Flohmarkt am S-Bhf. Friedrichshagen"
             },
             "type": "Feature"
@@ -947,16 +947,16 @@
                     "bezeichnung": "Flohmarkt am S-Bhf. Friedrichshagen",
                     "bezirk": "Treptow-Köpenick",
                     "email": "mailto:info@oldthing.de",
-                    "id": 377,
+                    "id": 378,
                     "plz": "12587",
                     "strasse": "Schöneicherstr./Dahlwitzer Landstraße",
                     "tage": "So",
                     "www": "http://www.oldthing.de",
                     "zeiten": "08:00 - 16:00"
                 },
-                "description": "So<br />08:00 - 16:00<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/377\">Mehr...</a>",
-                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/377",
-                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/377",
+                "description": "So<br />08:00 - 16:00<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/378\">Mehr...</a>",
+                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/378",
+                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/378",
                 "title": "Flohmarkt am S-Bhf. Friedrichshagen"
             },
             "type": "Feature"
@@ -978,16 +978,16 @@
                     "bezeichnung": "Flohmarkt im Mauerpark",
                     "bezirk": "Mitte",
                     "email": "mailto:info@mv-perske.de",
-                    "id": 140,
+                    "id": 141,
                     "plz": "13355",
                     "strasse": "Bernauer Straße 63-64",
                     "tage": "So",
                     "www": "http://www.flohmarktimmauerpark.de",
                     "zeiten": "10:00 - 18:00"
                 },
-                "description": "So<br />10:00 - 18:00<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/140\">Mehr...</a>",
-                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/140",
-                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/140",
+                "description": "So<br />10:00 - 18:00<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/141\">Mehr...</a>",
+                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/141",
+                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/141",
                 "title": "Flohmarkt im Mauerpark"
             },
             "type": "Feature"
@@ -1009,16 +1009,16 @@
                     "bezeichnung": "Frauentrödel",
                     "bezirk": "Tempelhof-Schöneberg",
                     "email": "",
-                    "id": 407,
+                    "id": 408,
                     "plz": "10781",
                     "strasse": "Barbarossastr. 65",
                     "tage": "25.03.2023\n13.05.2023",
                     "www": "https://www.kiezoase.de/aktuelle-angebote/",
                     "zeiten": "12:00 - 16:00"
                 },
-                "description": "25.03.2023&#10;13.05.2023<br />12:00 - 16:00<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/407\">Mehr...</a>",
-                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/407",
-                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/407",
+                "description": "25.03.2023&#10;13.05.2023<br />12:00 - 16:00<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/408\">Mehr...</a>",
+                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/408",
+                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/408",
                 "title": "Frauentrödel"
             },
             "type": "Feature"
@@ -1040,16 +1040,16 @@
                     "bezeichnung": "Frischemarkt Andréezeile",
                     "bezirk": "Steglitz-Zehlendorf",
                     "email": "mailto:info@diemarktplaner.de",
-                    "id": 356,
+                    "id": 357,
                     "plz": "14165",
                     "strasse": "Ladiusstraße",
                     "tage": "Sa",
                     "www": "http://www.diemarktplaner.de",
                     "zeiten": "08:00 - 13:00"
                 },
-                "description": "Sa<br />08:00 - 13:00<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/356\">Mehr...</a>",
-                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/356",
-                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/356",
+                "description": "Sa<br />08:00 - 13:00<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/357\">Mehr...</a>",
+                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/357",
+                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/357",
                 "title": "Frischemarkt Andréezeile"
             },
             "type": "Feature"
@@ -1057,30 +1057,30 @@
         {
             "geometry": {
                 "coordinates": [
-                    13.32113,
-                    52.47535
+                    13.32139,
+                    52.47538
                 ],
                 "type": "Point"
             },
             "properties": {
                 "data": {
-                    "_wgs84_lat": 52.4753493,
-                    "_wgs84_lon": 13.3211325,
+                    "_wgs84_lat": 52.4753773,
+                    "_wgs84_lon": 13.3213865,
                     "bemerkungen": "Friedenau",
                     "betreiber": "Förderverein Ruppin Freunde",
                     "bezeichnung": "Frühjahrs-Trödelmarkt in der Ruppin Grundschule",
                     "bezirk": "Charlottenburg-Wilmersdorf",
                     "email": "troedelmarkt@ruppinfreunde.de",
-                    "id": 467,
+                    "id": 468,
                     "plz": "14197",
                     "strasse": "Offenbacher Str. 5a",
                     "tage": "25.03.2023",
                     "www": "www.ruppinfreunde.de",
                     "zeiten": "10:00-14:00"
                 },
-                "description": "25.03.2023<br />10:00-14:00<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/467\">Mehr...</a>",
-                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/467",
-                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/467",
+                "description": "25.03.2023<br />10:00-14:00<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/468\">Mehr...</a>",
+                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/468",
+                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/468",
                 "title": "Frühjahrs-Trödelmarkt in der Ruppin Grundschule"
             },
             "type": "Feature"
@@ -1102,16 +1102,16 @@
                     "bezeichnung": "Großer Trödelmarkt am Arkonaplatz",
                     "bezirk": "Mitte",
                     "email": "",
-                    "id": 131,
+                    "id": 132,
                     "plz": "10435",
                     "strasse": "Arkonaplatz",
                     "tage": "So",
                     "www": "http://www.troedelmarkt-arkonaplatz.de",
                     "zeiten": "10:00 - 16:00"
                 },
-                "description": "So<br />10:00 - 16:00<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/131\">Mehr...</a>",
-                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/131",
-                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/131",
+                "description": "So<br />10:00 - 16:00<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/132\">Mehr...</a>",
+                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/132",
+                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/132",
                 "title": "Großer Trödelmarkt am Arkonaplatz"
             },
             "type": "Feature"
@@ -1133,16 +1133,16 @@
                     "bezeichnung": "Großer Trödeölmarkt am Bölschestraßenfest",
                     "bezirk": "Treptow-Köpenick",
                     "email": "info@oldthing.de",
-                    "id": 473,
+                    "id": 474,
                     "plz": "12587",
                     "strasse": "Bölschestraße",
                     "tage": "13.-14.05.2023",
                     "www": "www.oldthing.de",
                     "zeiten": "10:00 - 18:00"
                 },
-                "description": "13.-14.05.2023<br />10:00 - 18:00<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/473\">Mehr...</a>",
-                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/473",
-                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/473",
+                "description": "13.-14.05.2023<br />10:00 - 18:00<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/474\">Mehr...</a>",
+                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/474",
+                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/474",
                 "title": "Großer Trödeölmarkt am Bölschestraßenfest"
             },
             "type": "Feature"
@@ -1164,16 +1164,16 @@
                     "bezeichnung": "Grüner Wochenmarkt",
                     "bezirk": "Treptow-Köpenick",
                     "email": "mailto:markt-veranstaltungen@web.de",
-                    "id": 386,
+                    "id": 387,
                     "plz": "12557",
                     "strasse": "Schloßplatz Köpenick",
                     "tage": "Di, Do",
                     "www": "http://www.markt-veranstaltungen.de",
                     "zeiten": "09:00 - 16:00"
                 },
-                "description": "Di, Do<br />09:00 - 16:00<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/386\">Mehr...</a>",
-                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/386",
-                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/386",
+                "description": "Di, Do<br />09:00 - 16:00<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/387\">Mehr...</a>",
+                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/387",
+                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/387",
                 "title": "Grüner Wochenmarkt"
             },
             "type": "Feature"
@@ -1195,16 +1195,16 @@
                     "bezeichnung": "Karl-Marx-Allee vor Nr. 93",
                     "bezirk": "Friedrichshain-Kreuzberg",
                     "email": "",
-                    "id": 47,
+                    "id": 48,
                     "plz": "10243",
                     "strasse": "Karl-Marx-Allee 93",
                     "tage": "Di, Do",
                     "www": "",
                     "zeiten": "10:00 - 16:00"
                 },
-                "description": "Di, Do<br />10:00 - 16:00<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/47\">Mehr...</a>",
-                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/47",
-                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/47",
+                "description": "Di, Do<br />10:00 - 16:00<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/48\">Mehr...</a>",
+                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/48",
+                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/48",
                 "title": "Karl-Marx-Allee vor Nr. 93"
             },
             "type": "Feature"
@@ -1212,30 +1212,30 @@
         {
             "geometry": {
                 "coordinates": [
-                    13.48169,
-                    52.46256
+                    10.45153,
+                    51.16569
                 ],
                 "type": "Point"
             },
             "properties": {
                 "data": {
-                    "_wgs84_lat": 52.4625563,
-                    "_wgs84_lon": 13.4816903,
+                    "_wgs84_lat": 51.165691,
+                    "_wgs84_lon": 10.451526,
                     "bemerkungen": "für Anbieter ab 13:00",
                     "betreiber": "Kiezoase Schöneberg, K.-Schrader-Str. 7 - 8, Anmeldung Tel.: 21 73 02 02",
                     "bezeichnung": "Kinder-Baby-Trödel",
                     "bezirk": "Tempelhof-Schöneberg",
                     "email": "",
-                    "id": 404,
+                    "id": 405,
                     "plz": "10781",
                     "strasse": "K.-Schrader-Str. 7 - 8",
                     "tage": "25.03.2023\n13.05.2023",
                     "www": "https://www.kiezoase.de/aktuelle-angebote/",
                     "zeiten": "14:00 - 17:00"
                 },
-                "description": "25.03.2023&#10;13.05.2023<br />14:00 - 17:00<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/404\">Mehr...</a>",
-                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/404",
-                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/404",
+                "description": "25.03.2023&#10;13.05.2023<br />14:00 - 17:00<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/405\">Mehr...</a>",
+                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/405",
+                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/405",
                 "title": "Kinder-Baby-Trödel"
             },
             "type": "Feature"
@@ -1257,16 +1257,16 @@
                     "bezeichnung": "Kunst- und Trödelmarkt \nStraße des 17. Juni",
                     "bezirk": "Charlottenburg-Wilmersdorf",
                     "email": "mailto:info@berliner-troedelmarkt.de",
-                    "id": 38,
+                    "id": 39,
                     "plz": "10785",
                     "strasse": "Straße des 17. Juni",
                     "tage": "Sa, So",
                     "www": "http://www.berliner-troedelmarkt.de",
                     "zeiten": "10:00 - 17:00"
                 },
-                "description": "Sa, So<br />10:00 - 17:00<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/38\">Mehr...</a>",
-                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/38",
-                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/38",
+                "description": "Sa, So<br />10:00 - 17:00<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/39\">Mehr...</a>",
+                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/39",
+                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/39",
                 "title": "Kunst- und Trödelmarkt \nStraße des 17. Juni"
             },
             "type": "Feature"
@@ -1288,16 +1288,16 @@
                     "bezeichnung": "Kunst- und Trödelmarkt Fehrbelliner Platz",
                     "bezirk": "Charlottenburg-Wilmersdorf",
                     "email": "mailto:info@burdack-maerkte.de",
-                    "id": 41,
+                    "id": 42,
                     "plz": "10707",
                     "strasse": "Fehrbelliner Platz",
                     "tage": "Sa, So",
                     "www": "http://www.burdack-maerkte.de",
                     "zeiten": "10:00 - 16:00"
                 },
-                "description": "Sa, So<br />10:00 - 16:00<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/41\">Mehr...</a>",
-                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/41",
-                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/41",
+                "description": "Sa, So<br />10:00 - 16:00<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/42\">Mehr...</a>",
+                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/42",
+                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/42",
                 "title": "Kunst- und Trödelmarkt Fehrbelliner Platz"
             },
             "type": "Feature"
@@ -1305,30 +1305,30 @@
         {
             "geometry": {
                 "coordinates": [
-                    13.48169,
-                    52.46256
+                    10.45153,
+                    51.16569
                 ],
                 "type": "Point"
             },
             "properties": {
                 "data": {
-                    "_wgs84_lat": 52.4625563,
-                    "_wgs84_lon": 13.4816903,
+                    "_wgs84_lat": 51.165691,
+                    "_wgs84_lon": 10.451526,
                     "bemerkungen": "für Anbieter ab 12:00",
                     "betreiber": "Kiezoase Schöneberg, K.-Schrader-Str. 7 - 8, Anmeldung Tel.: 21 73 02 02",
                     "bezeichnung": "Kunst-Kreativ-Markt",
                     "bezirk": "Tempelhof-Schöneberg",
                     "email": "",
-                    "id": 410,
+                    "id": 411,
                     "plz": "10781",
                     "strasse": "K.-Schrader-Str. 7 - 8",
                     "tage": "13.06.2023",
                     "www": "https://www.kiezoase.de/aktuelle-angebote/",
                     "zeiten": "13:00 - 17:00"
                 },
-                "description": "13.06.2023<br />13:00 - 17:00<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/410\">Mehr...</a>",
-                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/410",
-                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/410",
+                "description": "13.06.2023<br />13:00 - 17:00<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/411\">Mehr...</a>",
+                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/411",
+                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/411",
                 "title": "Kunst-Kreativ-Markt"
             },
             "type": "Feature"
@@ -1350,16 +1350,16 @@
                     "bezeichnung": "Kunstmarkt am Zeughaus",
                     "bezirk": "Mitte",
                     "email": "",
-                    "id": 143,
+                    "id": 144,
                     "plz": "10117",
                     "strasse": "Unter den Linden 2",
                     "tage": "Sa, So, gesetzliche Feiertage",
                     "www": "",
                     "zeiten": "11:00 - 17:00"
                 },
-                "description": "Sa, So, gesetzliche Feiertage<br />11:00 - 17:00<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/143\">Mehr...</a>",
-                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/143",
-                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/143",
+                "description": "Sa, So, gesetzliche Feiertage<br />11:00 - 17:00<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/144\">Mehr...</a>",
+                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/144",
+                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/144",
                 "title": "Kunstmarkt am Zeughaus"
             },
             "type": "Feature"
@@ -1381,16 +1381,16 @@
                     "bezeichnung": "Markt Schlachtensee (Wochenmarkt)",
                     "bezirk": "Steglitz-Zehlendorf",
                     "email": "",
-                    "id": 236,
+                    "id": 237,
                     "plz": "14129",
                     "strasse": "Matterhornstr. 52/54",
                     "tage": "Di, Fr",
                     "www": "",
                     "zeiten": "08:00 - 14:00"
                 },
-                "description": "Di, Fr<br />08:00 - 14:00<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/236\">Mehr...</a>",
-                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/236",
-                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/236",
+                "description": "Di, Fr<br />08:00 - 14:00<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/237\">Mehr...</a>",
+                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/237",
+                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/237",
                 "title": "Markt Schlachtensee (Wochenmarkt)"
             },
             "type": "Feature"
@@ -1412,16 +1412,16 @@
                     "bezeichnung": "Markthalle Neun",
                     "bezirk": "Friedrichshain-Kreuzberg",
                     "email": "mailto:info@markthalleneun.de",
-                    "id": 59,
+                    "id": 60,
                     "plz": "10997",
                     "strasse": "Eisenbahnstraße 42/43",
                     "tage": "Fr\nSa",
                     "www": "http://www.markthalleneun.de",
                     "zeiten": "12:00 - 18:00\n10:00 - 18:00"
                 },
-                "description": "Fr&#10;Sa<br />12:00 - 18:00&#10;10:00 - 18:00<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/59\">Mehr...</a>",
-                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/59",
-                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/59",
+                "description": "Fr&#10;Sa<br />12:00 - 18:00&#10;10:00 - 18:00<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/60\">Mehr...</a>",
+                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/60",
+                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/60",
                 "title": "Markthalle Neun"
             },
             "type": "Feature"
@@ -1443,16 +1443,16 @@
                     "bezeichnung": "Modern Art & Design",
                     "bezirk": "Lichtenberg",
                     "email": "info@oldthing.de",
-                    "id": 443,
+                    "id": 444,
                     "plz": "10318",
                     "strasse": "Treskowallee 159",
                     "tage": "06.05.-07.05.2023",
                     "www": "http://www.oldthing.de",
                     "zeiten": "09:00 - 17:00"
                 },
-                "description": "06.05.-07.05.2023<br />09:00 - 17:00<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/443\">Mehr...</a>",
-                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/443",
-                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/443",
+                "description": "06.05.-07.05.2023<br />09:00 - 17:00<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/444\">Mehr...</a>",
+                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/444",
+                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/444",
                 "title": "Modern Art & Design"
             },
             "type": "Feature"
@@ -1474,16 +1474,16 @@
                     "bezeichnung": "Neuer Markt am Südstern",
                     "bezirk": "Friedrichshain-Kreuzberg",
                     "email": "mailto:info@diemarktplaner.de",
-                    "id": 62,
+                    "id": 63,
                     "plz": "10961",
                     "strasse": "Südstern",
                     "tage": "Sa",
                     "www": "http://www.diemarktplaner.de",
                     "zeiten": "10:00 - 16:00"
                 },
-                "description": "Sa<br />10:00 - 16:00<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/62\">Mehr...</a>",
-                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/62",
-                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/62",
+                "description": "Sa<br />10:00 - 16:00<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/63\">Mehr...</a>",
+                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/63",
+                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/63",
                 "title": "Neuer Markt am Südstern"
             },
             "type": "Feature"
@@ -1505,16 +1505,16 @@
                     "bezeichnung": "Neuköllner Wochenmärkte Britz-Süd \"Frisches vom Markt\"",
                     "bezirk": "Neukölln",
                     "email": "mailto:info@diemarktplaner.de",
-                    "id": 152,
+                    "id": 153,
                     "plz": "12359",
                     "strasse": "Gutschmidtstraße",
                     "tage": "Mo\nDo\nSa",
                     "www": "http://www.diemarktplaner.de",
                     "zeiten": "08:00 - 13:00\n08:00 - 13:00\n08:00 - 14:00"
                 },
-                "description": "Mo&#10;Do&#10;Sa<br />08:00 - 13:00&#10;08:00 - 13:00&#10;08:00 - 14:00<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/152\">Mehr...</a>",
-                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/152",
-                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/152",
+                "description": "Mo&#10;Do&#10;Sa<br />08:00 - 13:00&#10;08:00 - 13:00&#10;08:00 - 14:00<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/153\">Mehr...</a>",
+                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/153",
+                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/153",
                 "title": "Neuköllner Wochenmärkte Britz-Süd \"Frisches vom Markt\""
             },
             "type": "Feature"
@@ -1536,16 +1536,16 @@
                     "bezeichnung": "Neuköllner Wochenmärkte Hermannplatz \"Marktfood - vor Ort und für Zuhause\"",
                     "bezirk": "Neukölln",
                     "email": "mailto:info@diemarktplaner.de",
-                    "id": 155,
+                    "id": 156,
                     "plz": "10967",
                     "strasse": "Hermannplatz",
                     "tage": "Mo - Fr",
                     "www": "http://www.diemarktplaner.de",
                     "zeiten": "10:00 - 18:00"
                 },
-                "description": "Mo - Fr<br />10:00 - 18:00<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/155\">Mehr...</a>",
-                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/155",
-                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/155",
+                "description": "Mo - Fr<br />10:00 - 18:00<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/156\">Mehr...</a>",
+                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/156",
+                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/156",
                 "title": "Neuköllner Wochenmärkte Hermannplatz \"Marktfood - vor Ort und für Zuhause\""
             },
             "type": "Feature"
@@ -1567,16 +1567,16 @@
                     "bezeichnung": "Neuköllner Wochenmärkte Maybachufer",
                     "bezirk": "Neukölln",
                     "email": "mailto:info@diemarktplaner.de",
-                    "id": 158,
+                    "id": 159,
                     "plz": "12047",
                     "strasse": "Maybachufer 1 - 13",
                     "tage": "Di, Fr",
                     "www": "http://www.diemarktplaner.de",
                     "zeiten": "11:00 - 18:30"
                 },
-                "description": "Di, Fr<br />11:00 - 18:30<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/158\">Mehr...</a>",
-                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/158",
-                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/158",
+                "description": "Di, Fr<br />11:00 - 18:30<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/159\">Mehr...</a>",
+                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/159",
+                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/159",
                 "title": "Neuköllner Wochenmärkte Maybachufer"
             },
             "type": "Feature"
@@ -1598,16 +1598,16 @@
                     "bezeichnung": "Neuköllner Wochenmärkte Parchimer Allee \"Freitagsmarkt bis abends!\"",
                     "bezirk": "Neukölln",
                     "email": "mailto:info@diemarktplaner.de",
-                    "id": 161,
+                    "id": 162,
                     "plz": "12359",
                     "strasse": "Fritz-Reuter-Allee 73",
                     "tage": "Fr",
                     "www": "http://www.diemarktplaner.de",
                     "zeiten": "10:00 - 18:00"
                 },
-                "description": "Fr<br />10:00 - 18:00<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/161\">Mehr...</a>",
-                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/161",
-                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/161",
+                "description": "Fr<br />10:00 - 18:00<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/162\">Mehr...</a>",
+                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/162",
+                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/162",
                 "title": "Neuköllner Wochenmärkte Parchimer Allee \"Freitagsmarkt bis abends!\""
             },
             "type": "Feature"
@@ -1629,16 +1629,16 @@
                     "bezeichnung": "Neuköllner Wochenmärkte Rixdorf \"Gesunder Genuss auf dem Rixdorfer Markt\"",
                     "bezirk": "Neukölln",
                     "email": "mailto:info@diemarktplaner.de",
-                    "id": 146,
+                    "id": 147,
                     "plz": "12043",
                     "strasse": "Karl-Marx-Platz",
                     "tage": "Mi\nSa",
                     "www": "http://www.diemarktplaner.de",
                     "zeiten": "11:00 - 18:00\n08:00 - 15:00"
                 },
-                "description": "Mi&#10;Sa<br />11:00 - 18:00&#10;08:00 - 15:00<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/146\">Mehr...</a>",
-                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/146",
-                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/146",
+                "description": "Mi&#10;Sa<br />11:00 - 18:00&#10;08:00 - 15:00<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/147\">Mehr...</a>",
+                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/147",
+                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/147",
                 "title": "Neuköllner Wochenmärkte Rixdorf \"Gesunder Genuss auf dem Rixdorfer Markt\""
             },
             "type": "Feature"
@@ -1660,16 +1660,16 @@
                     "bezeichnung": "Neuköllner Wochenmärkte Rudow \"Regionale Qualität in Rudow\"",
                     "bezirk": "Neukölln",
                     "email": "mailto:info@diemarktplaner.de",
-                    "id": 149,
+                    "id": 150,
                     "plz": "12355",
                     "strasse": "Prierosser Straße",
                     "tage": "Mi, Sa",
                     "www": "http://www.diemarktplaner.de",
                     "zeiten": "08:00 - 13:00"
                 },
-                "description": "Mi, Sa<br />08:00 - 13:00<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/149\">Mehr...</a>",
-                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/149",
-                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/149",
+                "description": "Mi, Sa<br />08:00 - 13:00<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/150\">Mehr...</a>",
+                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/150",
+                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/150",
                 "title": "Neuköllner Wochenmärkte Rudow \"Regionale Qualität in Rudow\""
             },
             "type": "Feature"
@@ -1691,16 +1691,16 @@
                     "bezeichnung": "Neuköllner Wochenmärkte Wutzkyallee",
                     "bezirk": "Neukölln",
                     "email": "mailto:info@diemarktplaner.de",
-                    "id": 164,
+                    "id": 165,
                     "plz": "12353",
                     "strasse": "Rotraut-Richter-Platz",
                     "tage": "Mi\nSa",
                     "www": "http://www.diemarktplaner.de",
                     "zeiten": "08:00 - 14:00\n08:00 - 13:00"
                 },
-                "description": "Mi&#10;Sa<br />08:00 - 14:00&#10;08:00 - 13:00<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/164\">Mehr...</a>",
-                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/164",
-                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/164",
+                "description": "Mi&#10;Sa<br />08:00 - 14:00&#10;08:00 - 13:00<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/165\">Mehr...</a>",
+                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/165",
+                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/165",
                 "title": "Neuköllner Wochenmärkte Wutzkyallee"
             },
             "type": "Feature"
@@ -1722,16 +1722,16 @@
                     "bezeichnung": "Nowkoelln Flowmarkt",
                     "bezirk": "Neukölln",
                     "email": "mailto:info@nowkoelln.de",
-                    "id": 344,
+                    "id": 345,
                     "plz": "12047",
                     "strasse": "Maybachufer",
                     "tage": "26.03., 09.04., 23.04., 07.05., 21.05., 04.06., 18.06., 02.07., 16.07., 30.07., 13.08., 27.08., 10.09., 24.09., 08.10., 22.10., 10.12.2023",
                     "www": "http://www.flowmarkt.de/nowkoelln.de",
                     "zeiten": "10:00 - 17:00"
                 },
-                "description": "26.03., 09.04., 23.04., 07.05., 21.05., 04.06., 18.06., 02.07., 16.07., 30.07., 13.08., 27.08., 10.09., 24.09., 08.10., 22.10., 10.12.2023<br />10:00 - 17:00<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/344\">Mehr...</a>",
-                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/344",
-                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/344",
+                "description": "26.03., 09.04., 23.04., 07.05., 21.05., 04.06., 18.06., 02.07., 16.07., 30.07., 13.08., 27.08., 10.09., 24.09., 08.10., 22.10., 10.12.2023<br />10:00 - 17:00<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/345\">Mehr...</a>",
+                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/345",
+                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/345",
                 "title": "Nowkoelln Flowmarkt"
             },
             "type": "Feature"
@@ -1753,16 +1753,16 @@
                     "bezeichnung": "Oldthing Sammlerbörse für Ansichtskarten, Briefmarken & Münzen",
                     "bezirk": "Lichtenberg",
                     "email": "info@oldthing.de",
-                    "id": 452,
+                    "id": 453,
                     "plz": "10318",
                     "strasse": "Treskowallee 159",
                     "tage": "04.11.-05.11.2023",
                     "www": "www.oldthing.de/riesenflohmarkt",
                     "zeiten": "09:00-16:00"
                 },
-                "description": "04.11.-05.11.2023<br />09:00-16:00<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/452\">Mehr...</a>",
-                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/452",
-                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/452",
+                "description": "04.11.-05.11.2023<br />09:00-16:00<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/453\">Mehr...</a>",
+                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/453",
+                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/453",
                 "title": "Oldthing Sammlerbörse für Ansichtskarten, Briefmarken & Münzen"
             },
             "type": "Feature"
@@ -1784,16 +1784,16 @@
                     "bezeichnung": "Oldthing Sammlerbörse für Ansichtskarten, Briefmarken und Münzen",
                     "bezirk": "Lichtenberg",
                     "email": "info@oldthing.de",
-                    "id": 440,
+                    "id": 441,
                     "plz": "10318",
                     "strasse": "Treskowallee 159",
                     "tage": "02.04.2023",
                     "www": "www.oldthing.de/riesenflohmarkt",
                     "zeiten": "09:00 - 17:00"
                 },
-                "description": "02.04.2023<br />09:00 - 17:00<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/440\">Mehr...</a>",
-                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/440",
-                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/440",
+                "description": "02.04.2023<br />09:00 - 17:00<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/441\">Mehr...</a>",
+                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/441",
+                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/441",
                 "title": "Oldthing Sammlerbörse für Ansichtskarten, Briefmarken und Münzen"
             },
             "type": "Feature"
@@ -1815,16 +1815,16 @@
                     "bezeichnung": "Riesenflohmarkt Event",
                     "bezirk": "Lichtenberg",
                     "email": "info@oldthing.de",
-                    "id": 470,
+                    "id": 471,
                     "plz": "10318",
                     "strasse": "Treskowallee 159",
                     "tage": "27.-29.05., 01.-03.10.2023",
                     "www": "www.oldthing.de/riesenflohmarkt",
                     "zeiten": "09:00 - 17:00"
                 },
-                "description": "27.-29.05., 01.-03.10.2023<br />09:00 - 17:00<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/470\">Mehr...</a>",
-                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/470",
-                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/470",
+                "description": "27.-29.05., 01.-03.10.2023<br />09:00 - 17:00<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/471\">Mehr...</a>",
+                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/471",
+                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/471",
                 "title": "Riesenflohmarkt Event"
             },
             "type": "Feature"
@@ -1846,16 +1846,16 @@
                     "bezeichnung": "Schoeneboerg Flowmarkt",
                     "bezirk": "Tempelhof-Schöneberg",
                     "email": "mailto:info@nowkoelln.de",
-                    "id": 362,
+                    "id": 363,
                     "plz": "10827",
                     "strasse": "Crellestr. 25",
                     "tage": "16.04., 30.04., 14.05., 28.05., 11.06., 25.06., 09.07., 20.08., 03.09., 17.09., 01.10., 15.10.2023",
                     "www": "http://www.flowmarkt.de/nowkoelln.de",
                     "zeiten": "10:30 - 17:00"
                 },
-                "description": "16.04., 30.04., 14.05., 28.05., 11.06., 25.06., 09.07., 20.08., 03.09., 17.09., 01.10., 15.10.2023<br />10:30 - 17:00<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/362\">Mehr...</a>",
-                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/362",
-                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/362",
+                "description": "16.04., 30.04., 14.05., 28.05., 11.06., 25.06., 09.07., 20.08., 03.09., 17.09., 01.10., 15.10.2023<br />10:30 - 17:00<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/363\">Mehr...</a>",
+                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/363",
+                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/363",
                 "title": "Schoeneboerg Flowmarkt"
             },
             "type": "Feature"
@@ -1877,16 +1877,16 @@
                     "bezeichnung": "Trödel<164 Markt",
                     "bezirk": "Steglitz-Zehlendorf",
                     "email": "markttag@web.de",
-                    "id": 461,
+                    "id": 462,
                     "plz": "14195",
                     "strasse": "Breitenbachplatz",
                     "tage": "02./09.04., 01./04.05., 04./11.06., 09.07., 13.08., 03./10.09., 01./08.10., 05.11.2023",
                     "www": "www.markttag-berlin.de",
                     "zeiten": "10:00-14:00"
                 },
-                "description": "02./09.04., 01./04.05., 04./11.06., 09.07., 13.08., 03./10.09., 01./08.10., 05.11.2023<br />10:00-14:00<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/461\">Mehr...</a>",
-                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/461",
-                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/461",
+                "description": "02./09.04., 01./04.05., 04./11.06., 09.07., 13.08., 03./10.09., 01./08.10., 05.11.2023<br />10:00-14:00<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/462\">Mehr...</a>",
+                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/462",
+                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/462",
                 "title": "Trödel<164 Markt"
             },
             "type": "Feature"
@@ -1908,16 +1908,16 @@
                     "bezeichnung": "Trödelmarkt Bergmannstraße",
                     "bezirk": "Friedrichshain-Kreuzberg",
                     "email": "",
-                    "id": 68,
+                    "id": 69,
                     "plz": "10961",
                     "strasse": "Marheinekeplatz",
                     "tage": "Sa\nSo",
                     "www": "",
                     "zeiten": "10:00 - 16:00\n11:00 - 17:00"
                 },
-                "description": "Sa&#10;So<br />10:00 - 16:00&#10;11:00 - 17:00<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/68\">Mehr...</a>",
-                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/68",
-                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/68",
+                "description": "Sa&#10;So<br />10:00 - 16:00&#10;11:00 - 17:00<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/69\">Mehr...</a>",
+                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/69",
+                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/69",
                 "title": "Trödelmarkt Bergmannstraße"
             },
             "type": "Feature"
@@ -1939,16 +1939,16 @@
                     "bezeichnung": "Trödelmarkt Boxhagener Platz",
                     "bezirk": "Friedrichshain-Kreuzberg",
                     "email": "",
-                    "id": 329,
+                    "id": 330,
                     "plz": "10245",
                     "strasse": "Grünberger Straße 75",
                     "tage": "So",
                     "www": "",
                     "zeiten": "10:00 - 18:00"
                 },
-                "description": "So<br />10:00 - 18:00<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/329\">Mehr...</a>",
-                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/329",
-                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/329",
+                "description": "So<br />10:00 - 18:00<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/330\">Mehr...</a>",
+                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/330",
+                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/330",
                 "title": "Trödelmarkt Boxhagener Platz"
             },
             "type": "Feature"
@@ -1970,16 +1970,16 @@
                     "bezeichnung": "Trödelmarkt Landsberger Allee auf dem IKEA Parkplatz",
                     "bezirk": "Lichtenberg",
                     "email": "mailto:info@bbm-maerkte.de",
-                    "id": 347,
+                    "id": 348,
                     "plz": "10365",
                     "strasse": "Landsberger Allee 364",
                     "tage": "So",
                     "www": "http://www.bbm-maerkte.de",
                     "zeiten": "09:00 - 15:00"
                 },
-                "description": "So<br />09:00 - 15:00<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/347\">Mehr...</a>",
-                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/347",
-                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/347",
+                "description": "So<br />09:00 - 15:00<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/348\">Mehr...</a>",
+                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/348",
+                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/348",
                 "title": "Trödelmarkt Landsberger Allee auf dem IKEA Parkplatz"
             },
             "type": "Feature"
@@ -2001,16 +2001,16 @@
                     "bezeichnung": "Trödelmarkt METRO Marienfelde",
                     "bezirk": "Tempelhof-Schöneberg",
                     "email": "",
-                    "id": 272,
+                    "id": 273,
                     "plz": "12277",
                     "strasse": "Buckower Chaussee 25-35",
                     "tage": "So",
                     "www": "http://www.hoefges.de",
                     "zeiten": "07:00 - 14:00"
                 },
-                "description": "So<br />07:00 - 14:00<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/272\">Mehr...</a>",
-                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/272",
-                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/272",
+                "description": "So<br />07:00 - 14:00<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/273\">Mehr...</a>",
+                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/273",
+                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/273",
                 "title": "Trödelmarkt METRO Marienfelde"
             },
             "type": "Feature"
@@ -2032,16 +2032,16 @@
                     "bezeichnung": "Trödelmarkt METRO Spandau",
                     "bezirk": "Spandau",
                     "email": "",
-                    "id": 221,
+                    "id": 222,
                     "plz": "13599",
                     "strasse": "Nonnendammallee 135",
                     "tage": "So",
                     "www": "http://www.hoefges.de",
                     "zeiten": "07:00 - 14:00"
                 },
-                "description": "So<br />07:00 - 14:00<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/221\">Mehr...</a>",
-                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/221",
-                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/221",
+                "description": "So<br />07:00 - 14:00<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/222\">Mehr...</a>",
+                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/222",
+                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/222",
                 "title": "Trödelmarkt METRO Spandau"
             },
             "type": "Feature"
@@ -2063,16 +2063,16 @@
                     "bezeichnung": "Trödelmarkt OBI Steglitz",
                     "bezirk": "Steglitz-Zehlendorf",
                     "email": "",
-                    "id": 401,
+                    "id": 402,
                     "plz": "14167",
                     "strasse": "Goerzallee 189 - 223",
                     "tage": "So ab 05.03.2023",
                     "www": "www.hoefges.de",
                     "zeiten": "07:00 - 14:00"
                 },
-                "description": "So ab 05.03.2023<br />07:00 - 14:00<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/401\">Mehr...</a>",
-                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/401",
-                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/401",
+                "description": "So ab 05.03.2023<br />07:00 - 14:00<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/402\">Mehr...</a>",
+                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/402",
+                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/402",
                 "title": "Trödelmarkt OBI Steglitz"
             },
             "type": "Feature"
@@ -2094,16 +2094,16 @@
                     "bezeichnung": "Trödelmarkt Ollenhauerstraße",
                     "bezirk": "Reinickendorf",
                     "email": "hallo@icktroedel.de",
-                    "id": 350,
+                    "id": 351,
                     "plz": "13403",
                     "strasse": "Ollenhauerstraße 107",
                     "tage": "So",
                     "www": "https://icktroedel.de",
                     "zeiten": "08:00 - 16:00"
                 },
-                "description": "So<br />08:00 - 16:00<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/350\">Mehr...</a>",
-                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/350",
-                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/350",
+                "description": "So<br />08:00 - 16:00<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/351\">Mehr...</a>",
+                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/351",
+                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/351",
                 "title": "Trödelmarkt Ollenhauerstraße"
             },
             "type": "Feature"
@@ -2125,16 +2125,16 @@
                     "bezeichnung": "Trödelmarkt Wilhelmstraße",
                     "bezirk": "Spandau",
                     "email": "hallo@icktroedel.de",
-                    "id": 458,
+                    "id": 459,
                     "plz": "13595",
                     "strasse": "Wilhelmstr. 8",
                     "tage": "So",
                     "www": "https://icktroedel.de",
                     "zeiten": "08:00-16:00"
                 },
-                "description": "So<br />08:00-16:00<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/458\">Mehr...</a>",
-                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/458",
-                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/458",
+                "description": "So<br />08:00-16:00<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/459\">Mehr...</a>",
+                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/459",
+                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/459",
                 "title": "Trödelmarkt Wilhelmstraße"
             },
             "type": "Feature"
@@ -2156,16 +2156,16 @@
                     "bezeichnung": "Trödelmarkt an der Mecklenburgischen Straße",
                     "bezirk": "Charlottenburg-Wilmersdorf",
                     "email": "",
-                    "id": 44,
+                    "id": 45,
                     "plz": "14197",
                     "strasse": "Mecklenburgische Straße",
                     "tage": "So",
                     "www": "http://www.der-mecklenburger-troedelmarkt.de",
                     "zeiten": "08:00 - 16:00"
                 },
-                "description": "So<br />08:00 - 16:00<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/44\">Mehr...</a>",
-                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/44",
-                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/44",
+                "description": "So<br />08:00 - 16:00<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/45\">Mehr...</a>",
+                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/45",
+                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/45",
                 "title": "Trödelmarkt an der Mecklenburgischen Straße"
             },
             "type": "Feature"
@@ -2187,16 +2187,16 @@
                     "bezeichnung": "Trödelmarkt auf dem Hermann-Ehlers-Platz",
                     "bezirk": "Steglitz-Zehlendorf",
                     "email": "",
-                    "id": 245,
+                    "id": 246,
                     "plz": "12165",
                     "strasse": "Hermann-Ehlers-Platz",
                     "tage": "So",
                     "www": "",
                     "zeiten": "07:00 - 16:00"
                 },
-                "description": "So<br />07:00 - 16:00<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/245\">Mehr...</a>",
-                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/245",
-                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/245",
+                "description": "So<br />07:00 - 16:00<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/246\">Mehr...</a>",
+                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/246",
+                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/246",
                 "title": "Trödelmarkt auf dem Hermann-Ehlers-Platz"
             },
             "type": "Feature"
@@ -2218,16 +2218,16 @@
                     "bezeichnung": "Trödelmarkt auf dem John-F.-Kennedy-Platz",
                     "bezirk": "Tempelhof-Schöneberg",
                     "email": "mailto:j.thurmann@tts-wc.de",
-                    "id": 269,
+                    "id": 270,
                     "plz": "10825",
                     "strasse": "John-F.-Kennedy-Platz 1",
                     "tage": "Sa, So",
                     "www": "http://www.berlin-flohmaerkte.de",
                     "zeiten": "08:00 - 16:00"
                 },
-                "description": "Sa, So<br />08:00 - 16:00<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/269\">Mehr...</a>",
-                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/269",
-                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/269",
+                "description": "Sa, So<br />08:00 - 16:00<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/270\">Mehr...</a>",
+                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/270",
+                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/270",
                 "title": "Trödelmarkt auf dem John-F.-Kennedy-Platz"
             },
             "type": "Feature"
@@ -2249,16 +2249,16 @@
                     "bezeichnung": "Trödelmarkt auf dem Leopoldplatz",
                     "bezirk": "Mitte",
                     "email": "mailto:info@bbm-maerkte.de",
-                    "id": 137,
+                    "id": 138,
                     "plz": "13353",
                     "strasse": "Leopoldplatz",
                     "tage": "Sa",
                     "www": "http://www.bbm-maerkte.de",
                     "zeiten": "10:00 - 16:00"
                 },
-                "description": "Sa<br />10:00 - 16:00<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/137\">Mehr...</a>",
-                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/137",
-                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/137",
+                "description": "Sa<br />10:00 - 16:00<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/138\">Mehr...</a>",
+                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/138",
+                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/138",
                 "title": "Trödelmarkt auf dem Leopoldplatz"
             },
             "type": "Feature"
@@ -2280,16 +2280,16 @@
                     "bezeichnung": "Wittenbergplatz (Nordseite)\nBrandenburger Bauernmarkt",
                     "bezirk": "Tempelhof-Schöneberg",
                     "email": "mailto:info@bbm-maerkte.de",
-                    "id": 266,
+                    "id": 267,
                     "plz": "10789",
                     "strasse": "Wittenbergplatz 5",
                     "tage": "Do",
                     "www": "http://www.bbm-maerkte.de",
                     "zeiten": "09:00 - 17:00"
                 },
-                "description": "Do<br />09:00 - 17:00<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/266\">Mehr...</a>",
-                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/266",
-                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/266",
+                "description": "Do<br />09:00 - 17:00<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/267\">Mehr...</a>",
+                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/267",
+                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/267",
                 "title": "Wittenbergplatz (Nordseite)\nBrandenburger Bauernmarkt"
             },
             "type": "Feature"
@@ -2311,16 +2311,16 @@
                     "bezeichnung": "Wochenmarkt Adlershof",
                     "bezirk": "Treptow-Köpenick",
                     "email": "mailto:berndgellesch@t-online.de",
-                    "id": 332,
+                    "id": 333,
                     "plz": "12489",
                     "strasse": "Dörpfeldstraße",
                     "tage": "Mi, Do",
                     "www": "http://www.gakenholz-gellesch.de",
                     "zeiten": "08:00 - 16:00"
                 },
-                "description": "Mi, Do<br />08:00 - 16:00<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/332\">Mehr...</a>",
-                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/332",
-                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/332",
+                "description": "Mi, Do<br />08:00 - 16:00<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/333\">Mehr...</a>",
+                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/333",
+                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/333",
                 "title": "Wochenmarkt Adlershof"
             },
             "type": "Feature"
@@ -2342,16 +2342,16 @@
                     "bezeichnung": "Wochenmarkt Altstadt Spandau - Markt\nHavelländischer Land- und Bauernmarkt",
                     "bezirk": "Spandau",
                     "email": "mailto:info@wirtschaftshof-spandau.de",
-                    "id": 212,
+                    "id": 213,
                     "plz": "13597",
                     "strasse": "Markt 3",
                     "tage": "Mo, Di, Do, Fr",
                     "www": "http://www.wirtschaftshof-spandau.de",
                     "zeiten": "ab 09:00"
                 },
-                "description": "Mo, Di, Do, Fr<br />ab 09:00<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/212\">Mehr...</a>",
-                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/212",
-                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/212",
+                "description": "Mo, Di, Do, Fr<br />ab 09:00<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/213\">Mehr...</a>",
+                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/213",
+                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/213",
                 "title": "Wochenmarkt Altstadt Spandau - Markt\nHavelländischer Land- und Bauernmarkt"
             },
             "type": "Feature"
@@ -2373,16 +2373,16 @@
                     "bezeichnung": "Wochenmarkt Am Kaufhof Ostbahnhof\n(Erich-Steinfurth-Straße)",
                     "bezirk": "Friedrichshain-Kreuzberg",
                     "email": "",
-                    "id": 53,
+                    "id": 54,
                     "plz": "10243",
                     "strasse": "Ostbahnhof",
                     "tage": "Mo - Sa",
                     "www": "",
                     "zeiten": "09:00 - 18:00"
                 },
-                "description": "Mo - Sa<br />09:00 - 18:00<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/53\">Mehr...</a>",
-                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/53",
-                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/53",
+                "description": "Mo - Sa<br />09:00 - 18:00<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/54\">Mehr...</a>",
+                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/54",
+                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/54",
                 "title": "Wochenmarkt Am Kaufhof Ostbahnhof\n(Erich-Steinfurth-Straße)"
             },
             "type": "Feature"
@@ -2404,16 +2404,16 @@
                     "bezeichnung": "Wochenmarkt Am Nauener Tor\n14467 Potsdam",
                     "bezirk": "Brandenburg",
                     "email": "mailto:marktamnauenertor@web.de",
-                    "id": 290,
+                    "id": 291,
                     "plz": "14467",
                     "strasse": "Hegelallee 55",
                     "tage": "Mi, Sa",
                     "www": "http://www.markt-am-nauener-tor.de",
                     "zeiten": "09:00 - 16:00"
                 },
-                "description": "Mi, Sa<br />09:00 - 16:00<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/290\">Mehr...</a>",
-                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/290",
-                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/290",
+                "description": "Mi, Sa<br />09:00 - 16:00<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/291\">Mehr...</a>",
+                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/291",
+                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/291",
                 "title": "Wochenmarkt Am Nauener Tor\n14467 Potsdam"
             },
             "type": "Feature"
@@ -2435,16 +2435,16 @@
                     "bezeichnung": "Wochenmarkt Anton-Saefkow-Platz",
                     "bezirk": "Lichtenberg",
                     "email": "mailto:j-rueckert@kabelmail.de",
-                    "id": 71,
+                    "id": 72,
                     "plz": "10369",
                     "strasse": "Anton-Saefkow-Platz",
                     "tage": "Di, Do",
                     "www": "",
                     "zeiten": "09:00 - 18:00"
                 },
-                "description": "Di, Do<br />09:00 - 18:00<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/71\">Mehr...</a>",
-                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/71",
-                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/71",
+                "description": "Di, Do<br />09:00 - 18:00<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/72\">Mehr...</a>",
+                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/72",
+                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/72",
                 "title": "Wochenmarkt Anton-Saefkow-Platz"
             },
             "type": "Feature"
@@ -2466,16 +2466,16 @@
                     "bezeichnung": "Wochenmarkt Antonplatz",
                     "bezirk": "Pankow",
                     "email": "mailto:info@mv-perske.de",
-                    "id": 194,
+                    "id": 195,
                     "plz": "13086",
                     "strasse": "Antonplatz",
                     "tage": "Mo, Di, Do, Fr",
                     "www": "http://www.mv-perske.de",
                     "zeiten": "09:00 - 18:00"
                 },
-                "description": "Mo, Di, Do, Fr<br />09:00 - 18:00<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/194\">Mehr...</a>",
-                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/194",
-                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/194",
+                "description": "Mo, Di, Do, Fr<br />09:00 - 18:00<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/195\">Mehr...</a>",
+                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/195",
+                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/195",
                 "title": "Wochenmarkt Antonplatz"
             },
             "type": "Feature"
@@ -2497,16 +2497,16 @@
                     "bezeichnung": "Wochenmarkt Berlin-Oberschöneweide",
                     "bezirk": "Treptow-Köpenick",
                     "email": "mailto:berndgellesch@t-online.de",
-                    "id": 314,
+                    "id": 315,
                     "plz": "12459",
                     "strasse": "Rathenaustraße 2A (Rathenauplatz)",
                     "tage": "Mi",
                     "www": "http://www.brandenburger-wochenmaerkte.de",
                     "zeiten": "09:00 - 16:00"
                 },
-                "description": "Mi<br />09:00 - 16:00<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/314\">Mehr...</a>",
-                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/314",
-                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/314",
+                "description": "Mi<br />09:00 - 16:00<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/315\">Mehr...</a>",
+                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/315",
+                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/315",
                 "title": "Wochenmarkt Berlin-Oberschöneweide"
             },
             "type": "Feature"
@@ -2528,16 +2528,16 @@
                     "bezeichnung": "Wochenmarkt Boxhagener Platz",
                     "bezirk": "Friedrichshain-Kreuzberg",
                     "email": "",
-                    "id": 50,
+                    "id": 51,
                     "plz": "10245",
                     "strasse": "Boxhagener Platz",
                     "tage": "Sa",
                     "www": "",
                     "zeiten": "09:00 - 15:30"
                 },
-                "description": "Sa<br />09:00 - 15:30<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/50\">Mehr...</a>",
-                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/50",
-                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/50",
+                "description": "Sa<br />09:00 - 15:30<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/51\">Mehr...</a>",
+                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/51",
+                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/51",
                 "title": "Wochenmarkt Boxhagener Platz"
             },
             "type": "Feature"
@@ -2559,16 +2559,16 @@
                     "bezeichnung": "Wochenmarkt Breite Straße",
                     "bezirk": "Pankow",
                     "email": "",
-                    "id": 173,
+                    "id": 174,
                     "plz": "13187",
                     "strasse": "Breite Str. 17",
                     "tage": "Di\nMi\nFr\nSa",
                     "www": "",
                     "zeiten": "08:00 - 14:00\n09:00 - 17:00\n08:00 - 16:00\n08:00 - 15:00"
                 },
-                "description": "Di&#10;Mi&#10;Fr&#10;Sa<br />08:00 - 14:00&#10;09:00 - 17:00&#10;08:00 - 16:00&#10;08:00 - 15:00<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/173\">Mehr...</a>",
-                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/173",
-                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/173",
+                "description": "Di&#10;Mi&#10;Fr&#10;Sa<br />08:00 - 14:00&#10;09:00 - 17:00&#10;08:00 - 16:00&#10;08:00 - 15:00<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/174\">Mehr...</a>",
+                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/174",
+                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/174",
                 "title": "Wochenmarkt Breite Straße"
             },
             "type": "Feature"
@@ -2590,16 +2590,16 @@
                     "bezeichnung": "Wochenmarkt Breslauer Platz",
                     "bezirk": "Tempelhof-Schöneberg",
                     "email": "mailto:marktverwaltung@ba-ts.berlin.de",
-                    "id": 257,
+                    "id": 258,
                     "plz": "12159",
                     "strasse": "Breslauer Platz",
                     "tage": "Mi, Sa\nDo",
                     "www": "http://www.berlin.de/ba-tempelhof-schoeneberg/politik-und-verwaltung/aemter/ordnungsamt/maerkte",
                     "zeiten": "08:00 - 14:00\n12:00 - 18:00"
                 },
-                "description": "Mi, Sa&#10;Do<br />08:00 - 14:00&#10;12:00 - 18:00<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/257\">Mehr...</a>",
-                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/257",
-                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/257",
+                "description": "Mi, Sa&#10;Do<br />08:00 - 14:00&#10;12:00 - 18:00<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/258\">Mehr...</a>",
+                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/258",
+                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/258",
                 "title": "Wochenmarkt Breslauer Platz"
             },
             "type": "Feature"
@@ -2621,16 +2621,16 @@
                     "bezeichnung": "Wochenmarkt Brunsbütteler Damm 265",
                     "bezirk": "Spandau",
                     "email": "mailto:berndgellesch@t-online.de",
-                    "id": 215,
+                    "id": 216,
                     "plz": "13591",
                     "strasse": "Brunsbütteler Damm 265",
                     "tage": "Fr",
                     "www": "http://www.brandenburger-wochenmaerkte.de",
                     "zeiten": "08:00 - 15:00"
                 },
-                "description": "Fr<br />08:00 - 15:00<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/215\">Mehr...</a>",
-                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/215",
-                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/215",
+                "description": "Fr<br />08:00 - 15:00<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/216\">Mehr...</a>",
+                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/216",
+                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/216",
                 "title": "Wochenmarkt Brunsbütteler Damm 265"
             },
             "type": "Feature"
@@ -2652,16 +2652,16 @@
                     "bezeichnung": "Wochenmarkt Bucher Chaussee / Achillesstraße",
                     "bezirk": "Pankow",
                     "email": "",
-                    "id": 191,
+                    "id": 192,
                     "plz": "13125",
                     "strasse": "Bucher Chaussee",
                     "tage": "Do\nSa",
                     "www": "",
                     "zeiten": "08:00 - 16:30\n08:00 - 14:30"
                 },
-                "description": "Do&#10;Sa<br />08:00 - 16:30&#10;08:00 - 14:30<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/191\">Mehr...</a>",
-                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/191",
-                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/191",
+                "description": "Do&#10;Sa<br />08:00 - 16:30&#10;08:00 - 14:30<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/192\">Mehr...</a>",
+                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/192",
+                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/192",
                 "title": "Wochenmarkt Bucher Chaussee / Achillesstraße"
             },
             "type": "Feature"
@@ -2683,16 +2683,16 @@
                     "bezeichnung": "Wochenmarkt Bundesplatz",
                     "bezirk": "Charlottenburg-Wilmersdorf",
                     "email": "",
-                    "id": 29,
+                    "id": 30,
                     "plz": "10715",
                     "strasse": "Bundesplatz",
                     "tage": "Mo, Do",
                     "www": "",
                     "zeiten": "08:00 - 13:00"
                 },
-                "description": "Mo, Do<br />08:00 - 13:00<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/29\">Mehr...</a>",
-                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/29",
-                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/29",
+                "description": "Mo, Do<br />08:00 - 13:00<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/30\">Mehr...</a>",
+                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/30",
+                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/30",
                 "title": "Wochenmarkt Bundesplatz"
             },
             "type": "Feature"
@@ -2714,16 +2714,16 @@
                     "bezeichnung": "Wochenmarkt Burgfrauenstraße",
                     "bezirk": "Reinickendorf",
                     "email": "",
-                    "id": 203,
+                    "id": 204,
                     "plz": "13465",
                     "strasse": "Burgfrauenstraße",
                     "tage": "Do - Sa",
                     "www": "",
                     "zeiten": "08:00 - 13:00"
                 },
-                "description": "Do - Sa<br />08:00 - 13:00<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/203\">Mehr...</a>",
-                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/203",
-                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/203",
+                "description": "Do - Sa<br />08:00 - 13:00<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/204\">Mehr...</a>",
+                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/204",
+                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/204",
                 "title": "Wochenmarkt Burgfrauenstraße"
             },
             "type": "Feature"
@@ -2731,30 +2731,30 @@
         {
             "geometry": {
                 "coordinates": [
-                    13.51857,
-                    52.508
+                    13.5184,
+                    52.50801
                 ],
                 "type": "Point"
             },
             "properties": {
                 "data": {
-                    "_wgs84_lat": 52.5079966,
-                    "_wgs84_lon": 13.5185683,
+                    "_wgs84_lat": 52.5080057,
+                    "_wgs84_lon": 13.5184003,
                     "bemerkungen": "",
                     "betreiber": "Marktleitung: \nGakenholz und Gellesch GmbH\nTel.: 03322/121 77 32, 0171/602 42 04",
                     "bezeichnung": "Wochenmarkt Bärenschaufenster\n(öffentl. Straßenland)",
                     "bezirk": "Lichtenberg",
                     "email": "mailto:berndgellesch@t-online.de",
-                    "id": 74,
+                    "id": 75,
                     "plz": "10319",
                     "strasse": "Am Tierpark",
                     "tage": "Mo, \nDo, \nFr",
                     "www": "http://www.brandenburger-wochenmaerkte.de",
                     "zeiten": "08:00 - 18:00"
                 },
-                "description": "Mo, &#10;Do, &#10;Fr<br />08:00 - 18:00<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/74\">Mehr...</a>",
-                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/74",
-                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/74",
+                "description": "Mo, &#10;Do, &#10;Fr<br />08:00 - 18:00<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/75\">Mehr...</a>",
+                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/75",
+                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/75",
                 "title": "Wochenmarkt Bärenschaufenster\n(öffentl. Straßenland)"
             },
             "type": "Feature"
@@ -2776,16 +2776,16 @@
                     "bezeichnung": "Wochenmarkt Caligariplatz",
                     "bezirk": "Pankow",
                     "email": "",
-                    "id": 197,
+                    "id": 198,
                     "plz": "10119",
                     "strasse": "Caligariplatz",
                     "tage": "Mi, Fr",
                     "www": "",
                     "zeiten": "08:00 - 18:00"
                 },
-                "description": "Mi, Fr<br />08:00 - 18:00<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/197\">Mehr...</a>",
-                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/197",
-                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/197",
+                "description": "Mi, Fr<br />08:00 - 18:00<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/198\">Mehr...</a>",
+                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/198",
+                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/198",
                 "title": "Wochenmarkt Caligariplatz"
             },
             "type": "Feature"
@@ -2807,16 +2807,16 @@
                     "bezeichnung": "Wochenmarkt Cecilienplatz",
                     "bezirk": "Marzahn-Hellersdorf",
                     "email": "mailto:mifri100@gmx.de",
-                    "id": 107,
+                    "id": 108,
                     "plz": "12619",
                     "strasse": "Ernst-Bloch-Straße",
                     "tage": "Mo, Mi, Fr",
                     "www": "",
                     "zeiten": "09:00 - 18:00"
                 },
-                "description": "Mo, Mi, Fr<br />09:00 - 18:00<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/107\">Mehr...</a>",
-                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/107",
-                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/107",
+                "description": "Mo, Mi, Fr<br />09:00 - 18:00<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/108\">Mehr...</a>",
+                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/108",
+                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/108",
                 "title": "Wochenmarkt Cecilienplatz"
             },
             "type": "Feature"
@@ -2824,30 +2824,30 @@
         {
             "geometry": {
                 "coordinates": [
-                    13.29365,
-                    52.48864
+                    13.29256,
+                    52.48858
                 ],
                 "type": "Point"
             },
             "properties": {
                 "data": {
-                    "_wgs84_lat": 52.4886434,
-                    "_wgs84_lon": 13.2936528,
+                    "_wgs84_lat": 52.4885827,
+                    "_wgs84_lon": 13.2925612,
                     "bemerkungen": "",
                     "betreiber": "Bezirksamt Charlottenburg-Wilmersdorf, Marktverwaltung, Hohenzollerndamm 174-177, 10713 Berlin\nTel.: 9029 - 290 72/3",
                     "bezeichnung": "Wochenmarkt Charlottenbrunner Straße",
                     "bezirk": "Charlottenburg-Wilmersdorf",
                     "email": "",
-                    "id": 17,
+                    "id": 18,
                     "plz": "14193",
                     "strasse": "Charlottenbrunner Straße",
                     "tage": "Mo, Do",
                     "www": "",
                     "zeiten": "09:00 - 14:00"
                 },
-                "description": "Mo, Do<br />09:00 - 14:00<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/17\">Mehr...</a>",
-                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/17",
-                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/17",
+                "description": "Mo, Do<br />09:00 - 14:00<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/18\">Mehr...</a>",
+                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/18",
+                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/18",
                 "title": "Wochenmarkt Charlottenbrunner Straße"
             },
             "type": "Feature"
@@ -2869,16 +2869,16 @@
                     "bezeichnung": "Wochenmarkt Crellestraße",
                     "bezirk": "Tempelhof-Schöneberg",
                     "email": "mailto:marktverwaltung@ba-ts.berlin.de",
-                    "id": 260,
+                    "id": 261,
                     "plz": "10827",
                     "strasse": "Crellestraße 24",
                     "tage": "Mi, Sa",
                     "www": "http://www.berlin.de/ba-tempelhof-schoeneberg/politik-und-verwaltung/aemter/ordnungsamt/maerkte",
                     "zeiten": "10:00 - 15:00"
                 },
-                "description": "Mi, Sa<br />10:00 - 15:00<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/260\">Mehr...</a>",
-                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/260",
-                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/260",
+                "description": "Mi, Sa<br />10:00 - 15:00<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/261\">Mehr...</a>",
+                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/261",
+                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/261",
                 "title": "Wochenmarkt Crellestraße"
             },
             "type": "Feature"
@@ -2900,16 +2900,16 @@
                     "bezeichnung": "Wochenmarkt Dorfaue Schöneiche",
                     "bezirk": "Brandenburg",
                     "email": "mailto:markt-hirche@web.de",
-                    "id": 341,
+                    "id": 342,
                     "plz": "15566",
                     "strasse": "Dorfaue",
                     "tage": "Do",
                     "www": "",
                     "zeiten": "09:00 - 14:00"
                 },
-                "description": "Do<br />09:00 - 14:00<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/341\">Mehr...</a>",
-                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/341",
-                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/341",
+                "description": "Do<br />09:00 - 14:00<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/342\">Mehr...</a>",
+                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/342",
+                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/342",
                 "title": "Wochenmarkt Dorfaue Schöneiche"
             },
             "type": "Feature"
@@ -2931,16 +2931,16 @@
                     "bezeichnung": "Wochenmarkt Eberbacher Straße",
                     "bezirk": "Charlottenburg-Wilmersdorf",
                     "email": "",
-                    "id": 20,
+                    "id": 21,
                     "plz": "14197",
                     "strasse": "Eberbacher Straße",
                     "tage": "Di, Fr",
                     "www": "",
                     "zeiten": "08:00 - 13:00"
                 },
-                "description": "Di, Fr<br />08:00 - 13:00<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/20\">Mehr...</a>",
-                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/20",
-                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/20",
+                "description": "Di, Fr<br />08:00 - 13:00<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/21\">Mehr...</a>",
+                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/21",
+                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/21",
                 "title": "Wochenmarkt Eberbacher Straße"
             },
             "type": "Feature"
@@ -2962,16 +2962,16 @@
                     "bezeichnung": "Wochenmarkt Einkaufscenter Staaken",
                     "bezirk": "Spandau",
                     "email": "",
-                    "id": 218,
+                    "id": 219,
                     "plz": "13593",
                     "strasse": "Obstallee 28",
                     "tage": "Di, Fr",
                     "www": "",
                     "zeiten": "09:00 - 15:00"
                 },
-                "description": "Di, Fr<br />09:00 - 15:00<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/218\">Mehr...</a>",
-                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/218",
-                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/218",
+                "description": "Di, Fr<br />09:00 - 15:00<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/219\">Mehr...</a>",
+                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/219",
+                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/219",
                 "title": "Wochenmarkt Einkaufscenter Staaken"
             },
             "type": "Feature"
@@ -2993,16 +2993,16 @@
                     "bezeichnung": "Wochenmarkt Fehrbelliner Platz",
                     "bezirk": "Charlottenburg-Wilmersdorf",
                     "email": "",
-                    "id": 32,
+                    "id": 33,
                     "plz": "10707",
                     "strasse": "Fehrbelliner Platz",
                     "tage": "Mo, Di, Do",
                     "www": "",
                     "zeiten": "11:00 - 15:00"
                 },
-                "description": "Mo, Di, Do<br />11:00 - 15:00<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/32\">Mehr...</a>",
-                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/32",
-                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/32",
+                "description": "Mo, Di, Do<br />11:00 - 15:00<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/33\">Mehr...</a>",
+                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/33",
+                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/33",
                 "title": "Wochenmarkt Fehrbelliner Platz"
             },
             "type": "Feature"
@@ -3024,16 +3024,16 @@
                     "bezeichnung": "Wochenmarkt Fellbacher Straße",
                     "bezirk": "Reinickendorf",
                     "email": "d.dieter@marktgilde.de",
-                    "id": 368,
+                    "id": 369,
                     "plz": "13467",
                     "strasse": "Fellbacher Str. 30a",
                     "tage": "Fr",
                     "www": "www.treffpunkt-wochenmarkt.de",
                     "zeiten": "10:00 - 18:00"
                 },
-                "description": "Fr<br />10:00 - 18:00<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/368\">Mehr...</a>",
-                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/368",
-                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/368",
+                "description": "Fr<br />10:00 - 18:00<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/369\">Mehr...</a>",
+                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/369",
+                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/369",
                 "title": "Wochenmarkt Fellbacher Straße"
             },
             "type": "Feature"
@@ -3041,30 +3041,30 @@
         {
             "geometry": {
                 "coordinates": [
-                    13.48535,
-                    52.51225
+                    13.48555,
+                    52.51224
                 ],
                 "type": "Point"
             },
             "properties": {
                 "data": {
-                    "_wgs84_lat": 52.5122456,
-                    "_wgs84_lon": 13.485346,
+                    "_wgs84_lat": 52.5122364,
+                    "_wgs84_lon": 13.4855544,
                     "bemerkungen": "Auf dem Gelände der HoWoGe",
                     "betreiber": "Marktleitung: \nGakenholz und Gellesch GmbH\nTel.: 03322/121 77 32, 0171/602 42 04",
                     "bezeichnung": "Wochenmarkt Frankfurter Allee 172",
                     "bezirk": "Lichtenberg",
                     "email": "mailto:berndgellesch@t-online.de",
-                    "id": 80,
+                    "id": 81,
                     "plz": "10365",
                     "strasse": "Frankfurter Allee 172",
                     "tage": "Mi",
                     "www": "http://www.brandenburger-wochenmaerkte.de",
                     "zeiten": "09:00 - 16:00"
                 },
-                "description": "Mi<br />09:00 - 16:00<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/80\">Mehr...</a>",
-                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/80",
-                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/80",
+                "description": "Mi<br />09:00 - 16:00<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/81\">Mehr...</a>",
+                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/81",
+                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/81",
                 "title": "Wochenmarkt Frankfurter Allee 172"
             },
             "type": "Feature"
@@ -3086,16 +3086,16 @@
                     "bezeichnung": "Wochenmarkt Friedrichsfelde Ost",
                     "bezirk": "Lichtenberg",
                     "email": "mailto:gebrueder.kuehl.gmbh@arcor.de",
-                    "id": 86,
+                    "id": 87,
                     "plz": "10315",
                     "strasse": "Seddiner Straße",
                     "tage": "Mo - Fr",
                     "www": "",
                     "zeiten": "08:00 - 18:00"
                 },
-                "description": "Mo - Fr<br />08:00 - 18:00<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/86\">Mehr...</a>",
-                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/86",
-                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/86",
+                "description": "Mo - Fr<br />08:00 - 18:00<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/87\">Mehr...</a>",
+                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/87",
+                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/87",
                 "title": "Wochenmarkt Friedrichsfelde Ost"
             },
             "type": "Feature"
@@ -3103,30 +3103,30 @@
         {
             "geometry": {
                 "coordinates": [
-                    13.75265,
-                    52.42247
+                    13.75281,
+                    52.42248
                 ],
                 "type": "Point"
             },
             "properties": {
                 "data": {
-                    "_wgs84_lat": 52.42247,
-                    "_wgs84_lon": 13.75265,
+                    "_wgs84_lat": 52.4224801,
+                    "_wgs84_lon": 13.7528071,
                     "bemerkungen": "",
                     "betreiber": "Marktleitung: Herr Hirche\nTel.: 0334/397 79 79, 0172/309 49 77, \nFax: 0334/397 79 80",
                     "bezeichnung": "Wochenmarkt Friedrichstraße Erkner",
                     "bezirk": "Brandenburg",
                     "email": "mailto:markt-hirche@web.de",
-                    "id": 338,
+                    "id": 339,
                     "plz": "15537",
                     "strasse": "Friedrichstraße",
                     "tage": "Do",
                     "www": "",
                     "zeiten": "09:00 - 14:00"
                 },
-                "description": "Do<br />09:00 - 14:00<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/338\">Mehr...</a>",
-                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/338",
-                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/338",
+                "description": "Do<br />09:00 - 14:00<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/339\">Mehr...</a>",
+                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/339",
+                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/339",
                 "title": "Wochenmarkt Friedrichstraße Erkner"
             },
             "type": "Feature"
@@ -3148,16 +3148,16 @@
                     "bezeichnung": "Wochenmarkt Greifswalder Straße / Thomas-Mann-Straße",
                     "bezirk": "Pankow",
                     "email": "mailto:t-borchert@web.de",
-                    "id": 320,
+                    "id": 321,
                     "plz": "10409",
                     "strasse": "Greifswalder Straße 157",
                     "tage": "Di\nDo\nSa",
                     "www": "",
                     "zeiten": "08:00 - 18:00\n08:00 - 18:00\n08:00 - 14:00"
                 },
-                "description": "Di&#10;Do&#10;Sa<br />08:00 - 18:00&#10;08:00 - 18:00&#10;08:00 - 14:00<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/320\">Mehr...</a>",
-                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/320",
-                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/320",
+                "description": "Di&#10;Do&#10;Sa<br />08:00 - 18:00&#10;08:00 - 18:00&#10;08:00 - 14:00<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/321\">Mehr...</a>",
+                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/321",
+                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/321",
                 "title": "Wochenmarkt Greifswalder Straße / Thomas-Mann-Straße"
             },
             "type": "Feature"
@@ -3179,16 +3179,16 @@
                     "bezeichnung": "Wochenmarkt Hakenfelde",
                     "bezirk": "Spandau",
                     "email": "mailto:marktverwaltung@ba-spandau.berlin.de",
-                    "id": 209,
+                    "id": 210,
                     "plz": "13587",
                     "strasse": "Michelstadter Weg",
                     "tage": "Do",
                     "www": "",
                     "zeiten": "08:00 - 13:00"
                 },
-                "description": "Do<br />08:00 - 13:00<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/209\">Mehr...</a>",
-                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/209",
-                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/209",
+                "description": "Do<br />08:00 - 13:00<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/210\">Mehr...</a>",
+                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/210",
+                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/210",
                 "title": "Wochenmarkt Hakenfelde"
             },
             "type": "Feature"
@@ -3210,16 +3210,16 @@
                     "bezeichnung": "Wochenmarkt Hauptstraße / Goethestraße\nWilhelmsruh",
                     "bezirk": "Pankow",
                     "email": "",
-                    "id": 179,
+                    "id": 180,
                     "plz": "13158",
                     "strasse": "Hauptstraße",
                     "tage": "Mi, Fr",
                     "www": "",
                     "zeiten": "08:00 - 14:00"
                 },
-                "description": "Mi, Fr<br />08:00 - 14:00<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/179\">Mehr...</a>",
-                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/179",
-                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/179",
+                "description": "Mi, Fr<br />08:00 - 14:00<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/180\">Mehr...</a>",
+                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/180",
+                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/180",
                 "title": "Wochenmarkt Hauptstraße / Goethestraße\nWilhelmsruh"
             },
             "type": "Feature"
@@ -3241,16 +3241,16 @@
                     "bezeichnung": "Wochenmarkt Helene-Weigel-Platz",
                     "bezirk": "Marzahn-Hellersdorf",
                     "email": "mailto:markt-veranstaltungen@web.de",
-                    "id": 101,
+                    "id": 102,
                     "plz": "12681",
                     "strasse": "Helene-Weigel-Platz",
                     "tage": "Mo - Sa",
                     "www": "http://www.markt-veranstaltungen.de",
                     "zeiten": "09:00 - 17:00"
                 },
-                "description": "Mo - Sa<br />09:00 - 17:00<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/101\">Mehr...</a>",
-                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/101",
-                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/101",
+                "description": "Mo - Sa<br />09:00 - 17:00<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/102\">Mehr...</a>",
+                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/102",
+                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/102",
                 "title": "Wochenmarkt Helene-Weigel-Platz"
             },
             "type": "Feature"
@@ -3272,16 +3272,16 @@
                     "bezeichnung": "Wochenmarkt Helle Mitte",
                     "bezirk": "Marzahn-Hellersdorf",
                     "email": "mailto:lme_berlin@gmx.de",
-                    "id": 95,
+                    "id": 96,
                     "plz": "12627",
                     "strasse": "Peter-Weiss-Gasse",
                     "tage": "Mi, Fr",
                     "www": "",
                     "zeiten": "08:00 - 17:00"
                 },
-                "description": "Mi, Fr<br />08:00 - 17:00<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/95\">Mehr...</a>",
-                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/95",
-                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/95",
+                "description": "Mi, Fr<br />08:00 - 17:00<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/96\">Mehr...</a>",
+                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/96",
+                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/96",
                 "title": "Wochenmarkt Helle Mitte"
             },
             "type": "Feature"
@@ -3303,16 +3303,16 @@
                     "bezeichnung": "Wochenmarkt Hermann-Ehlers-Platz",
                     "bezirk": "Steglitz-Zehlendorf",
                     "email": "",
-                    "id": 224,
+                    "id": 225,
                     "plz": "12165",
                     "strasse": "Hermann-Ehlers-Platz",
                     "tage": "Di\nSa\nDo",
                     "www": "",
                     "zeiten": "08:00 - 14:00\n08:00 - 14:00\n08:00 - 18:00"
                 },
-                "description": "Di&#10;Sa&#10;Do<br />08:00 - 14:00&#10;08:00 - 14:00&#10;08:00 - 18:00<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/224\">Mehr...</a>",
-                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/224",
-                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/224",
+                "description": "Di&#10;Sa&#10;Do<br />08:00 - 14:00&#10;08:00 - 14:00&#10;08:00 - 18:00<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/225\">Mehr...</a>",
+                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/225",
+                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/225",
                 "title": "Wochenmarkt Hermann-Ehlers-Platz"
             },
             "type": "Feature"
@@ -3334,16 +3334,16 @@
                     "bezeichnung": "Wochenmarkt Herzbergstraße / Weißenseer Weg\n(Roedernplatz)",
                     "bezirk": "Lichtenberg",
                     "email": "mailto:berndgellesch@t-online.de",
-                    "id": 77,
+                    "id": 78,
                     "plz": "10367",
                     "strasse": "Herzbergstraße",
                     "tage": "Di, \nFr",
                     "www": "",
                     "zeiten": "08:00 - 17:00"
                 },
-                "description": "Di, &#10;Fr<br />08:00 - 17:00<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/77\">Mehr...</a>",
-                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/77",
-                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/77",
+                "description": "Di, &#10;Fr<br />08:00 - 17:00<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/78\">Mehr...</a>",
+                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/78",
+                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/78",
                 "title": "Wochenmarkt Herzbergstraße / Weißenseer Weg\n(Roedernplatz)"
             },
             "type": "Feature"
@@ -3351,30 +3351,30 @@
         {
             "geometry": {
                 "coordinates": [
-                    13.32417,
-                    52.49389
+                    10.45153,
+                    51.16569
                 ],
                 "type": "Point"
             },
             "properties": {
                 "data": {
-                    "_wgs84_lat": 52.4938879,
-                    "_wgs84_lon": 13.3241711,
+                    "_wgs84_lat": 51.165691,
+                    "_wgs84_lon": 10.451526,
                     "bemerkungen": "",
                     "betreiber": "Bezirksamt Charlottenburg-Wilmersdorf, Marktverwaltung, Hohenzollerndamm 174-177, 10713 Berlin\nTel.: 9029 - 290 72/3",
                     "bezeichnung": "Wochenmarkt Hohenzollernplatz",
                     "bezirk": "Charlottenburg-Wilmersdorf",
                     "email": "",
-                    "id": 26,
+                    "id": 27,
                     "plz": "14129",
                     "strasse": "Hohenzollernplatz",
                     "tage": "Mi, Sa",
                     "www": "",
                     "zeiten": "08:00 - 13:00"
                 },
-                "description": "Mi, Sa<br />08:00 - 13:00<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/26\">Mehr...</a>",
-                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/26",
-                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/26",
+                "description": "Mi, Sa<br />08:00 - 13:00<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/27\">Mehr...</a>",
+                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/27",
+                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/27",
                 "title": "Wochenmarkt Hohenzollernplatz"
             },
             "type": "Feature"
@@ -3396,16 +3396,16 @@
                     "bezeichnung": "Wochenmarkt John-F.-Kennedy-Platz",
                     "bezirk": "Tempelhof-Schöneberg",
                     "email": "mailto:marktverwaltung@ba-ts.berlin.de",
-                    "id": 254,
+                    "id": 255,
                     "plz": "10825",
                     "strasse": "John-F.-Kennedy-Platz 1",
                     "tage": "Di, Fr",
                     "www": "http://www.berlin.de/ba-tempelhof-schoeneberg/politik-und-verwaltung/aemter/ordnungsamt/maerkte",
                     "zeiten": "08:00 - 13:00"
                 },
-                "description": "Di, Fr<br />08:00 - 13:00<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/254\">Mehr...</a>",
-                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/254",
-                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/254",
+                "description": "Di, Fr<br />08:00 - 13:00<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/255\">Mehr...</a>",
+                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/255",
+                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/255",
                 "title": "Wochenmarkt John-F.-Kennedy-Platz"
             },
             "type": "Feature"
@@ -3427,16 +3427,16 @@
                     "bezeichnung": "Wochenmarkt Karl-August-Platz",
                     "bezirk": "Charlottenburg-Wilmersdorf",
                     "email": "",
-                    "id": 11,
+                    "id": 12,
                     "plz": "10625",
                     "strasse": "Karl-August-Platz",
                     "tage": "Mi\nSa",
                     "www": "",
                     "zeiten": "08:00 - 13:00\n08:00 - 14:00"
                 },
-                "description": "Mi&#10;Sa<br />08:00 - 13:00&#10;08:00 - 14:00<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/11\">Mehr...</a>",
-                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/11",
-                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/11",
+                "description": "Mi&#10;Sa<br />08:00 - 13:00&#10;08:00 - 14:00<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/12\">Mehr...</a>",
+                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/12",
+                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/12",
                 "title": "Wochenmarkt Karl-August-Platz"
             },
             "type": "Feature"
@@ -3458,16 +3458,16 @@
                     "bezeichnung": "Wochenmarkt Karlshorst",
                     "bezirk": "Lichtenberg",
                     "email": "mailto:berndgellesch@t-online.de",
-                    "id": 83,
+                    "id": 84,
                     "plz": "10318",
                     "strasse": "Ehrenfelsstraße",
                     "tage": "Di, \nFr",
                     "www": "http://www.gakenholz-gellesch.de",
                     "zeiten": "09:00 - 17:00"
                 },
-                "description": "Di, &#10;Fr<br />09:00 - 17:00<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/83\">Mehr...</a>",
-                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/83",
-                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/83",
+                "description": "Di, &#10;Fr<br />09:00 - 17:00<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/84\">Mehr...</a>",
+                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/84",
+                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/84",
                 "title": "Wochenmarkt Karlshorst"
             },
             "type": "Feature"
@@ -3489,16 +3489,16 @@
                     "bezeichnung": "Wochenmarkt Klausenerplatz",
                     "bezirk": "Charlottenburg-Wilmersdorf",
                     "email": "",
-                    "id": 5,
+                    "id": 6,
                     "plz": "14059",
                     "strasse": "Klausenerplatz",
                     "tage": "Di, Fr",
                     "www": "",
                     "zeiten": "08:00 - 13:00"
                 },
-                "description": "Di, Fr<br />08:00 - 13:00<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/5\">Mehr...</a>",
-                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/5",
-                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/5",
+                "description": "Di, Fr<br />08:00 - 13:00<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/6\">Mehr...</a>",
+                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/6",
+                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/6",
                 "title": "Wochenmarkt Klausenerplatz"
             },
             "type": "Feature"
@@ -3520,16 +3520,16 @@
                     "bezeichnung": "Wochenmarkt Kolberger Platz",
                     "bezirk": "Charlottenburg-Wilmersdorf",
                     "email": "",
-                    "id": 35,
+                    "id": 36,
                     "plz": "14199",
                     "strasse": "Kolberger Platz",
                     "tage": "Mi, Sa",
                     "www": "",
                     "zeiten": "06:00 - 15:00"
                 },
-                "description": "Mi, Sa<br />06:00 - 15:00<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/35\">Mehr...</a>",
-                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/35",
-                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/35",
+                "description": "Mi, Sa<br />06:00 - 15:00<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/36\">Mehr...</a>",
+                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/36",
+                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/36",
                 "title": "Wochenmarkt Kolberger Platz"
             },
             "type": "Feature"
@@ -3551,16 +3551,16 @@
                     "bezeichnung": "Wochenmarkt Leopoldplatz",
                     "bezirk": "Mitte",
                     "email": "mailto:info@bbm-maerkte.de",
-                    "id": 116,
+                    "id": 117,
                     "plz": "13353",
                     "strasse": "Leopoldplatz",
                     "tage": "Do",
                     "www": "http://www.bbm-maerkte.de",
                     "zeiten": "11:00 - 17:00"
                 },
-                "description": "Do<br />11:00 - 17:00<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/116\">Mehr...</a>",
-                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/116",
-                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/116",
+                "description": "Do<br />11:00 - 17:00<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/117\">Mehr...</a>",
+                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/117",
+                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/117",
                 "title": "Wochenmarkt Leopoldplatz"
             },
             "type": "Feature"
@@ -3582,16 +3582,16 @@
                     "bezeichnung": "Wochenmarkt Lichterfelde, Kranoldplatz",
                     "bezirk": "Steglitz-Zehlendorf",
                     "email": "",
-                    "id": 227,
+                    "id": 228,
                     "plz": "12209",
                     "strasse": "Kranoldplatz",
                     "tage": "Mi, Sa",
                     "www": "",
                     "zeiten": "08:00 - 14:00"
                 },
-                "description": "Mi, Sa<br />08:00 - 14:00<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/227\">Mehr...</a>",
-                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/227",
-                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/227",
+                "description": "Mi, Sa<br />08:00 - 14:00<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/228\">Mehr...</a>",
+                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/228",
+                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/228",
                 "title": "Wochenmarkt Lichterfelde, Kranoldplatz"
             },
             "type": "Feature"
@@ -3613,16 +3613,16 @@
                     "bezeichnung": "Wochenmarkt Ludwig-Beck-Platz",
                     "bezirk": "Steglitz-Zehlendorf",
                     "email": "",
-                    "id": 233,
+                    "id": 234,
                     "plz": "12203",
                     "strasse": "Ludwig-Beck-Platz",
                     "tage": "Fr, Sa",
                     "www": "",
                     "zeiten": "08:00 - 13:00"
                 },
-                "description": "Fr, Sa<br />08:00 - 13:00<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/233\">Mehr...</a>",
-                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/233",
-                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/233",
+                "description": "Fr, Sa<br />08:00 - 13:00<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/234\">Mehr...</a>",
+                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/234",
+                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/234",
                 "title": "Wochenmarkt Ludwig-Beck-Platz"
             },
             "type": "Feature"
@@ -3644,16 +3644,16 @@
                     "bezeichnung": "Wochenmarkt Mahlsdorf\nRoedernstraße / Hultschiner Damm",
                     "bezirk": "Marzahn-Hellersdorf",
                     "email": "mailto:lme_berlin@gmx.de",
-                    "id": 98,
+                    "id": 99,
                     "plz": "12623",
                     "strasse": "Roedernstraße",
                     "tage": "Do",
                     "www": "",
                     "zeiten": "07:00 - 15:00"
                 },
-                "description": "Do<br />07:00 - 15:00<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/98\">Mehr...</a>",
-                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/98",
-                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/98",
+                "description": "Do<br />07:00 - 15:00<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/99\">Mehr...</a>",
+                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/99",
+                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/99",
                 "title": "Wochenmarkt Mahlsdorf\nRoedernstraße / Hultschiner Damm"
             },
             "type": "Feature"
@@ -3675,16 +3675,16 @@
                     "bezeichnung": "Wochenmarkt Mariendorfer Damm / Prinzenstraße",
                     "bezirk": "Tempelhof-Schöneberg",
                     "email": "mailto:marktverwaltung@ba-ts.berlin.de",
-                    "id": 248,
+                    "id": 249,
                     "plz": "12109",
                     "strasse": "Prinzenstraße",
                     "tage": "Mi, Sa",
                     "www": "http://www.berlin.de/ba-tempelhof-schoeneberg/politik-und-verwaltung/aemter/ordnungsamt/maerkte",
                     "zeiten": "08:00 - 13:00"
                 },
-                "description": "Mi, Sa<br />08:00 - 13:00<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/248\">Mehr...</a>",
-                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/248",
-                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/248",
+                "description": "Mi, Sa<br />08:00 - 13:00<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/249\">Mehr...</a>",
+                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/249",
+                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/249",
                 "title": "Wochenmarkt Mariendorfer Damm / Prinzenstraße"
             },
             "type": "Feature"
@@ -3706,16 +3706,16 @@
                     "bezeichnung": "Wochenmarkt Markt am Helmholtzplatz",
                     "bezirk": "Pankow",
                     "email": "",
-                    "id": 188,
+                    "id": 189,
                     "plz": "10437",
                     "strasse": "Helmholtzplatz",
                     "tage": "Sa",
                     "www": "",
                     "zeiten": "09:00 - 16:00"
                 },
-                "description": "Sa<br />09:00 - 16:00<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/188\">Mehr...</a>",
-                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/188",
-                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/188",
+                "description": "Sa<br />09:00 - 16:00<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/189\">Mehr...</a>",
+                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/189",
+                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/189",
                 "title": "Wochenmarkt Markt am Helmholtzplatz"
             },
             "type": "Feature"
@@ -3737,16 +3737,16 @@
                     "bezeichnung": "Wochenmarkt Markt am Hugenottenplatz",
                     "bezirk": "Pankow",
                     "email": "",
-                    "id": 176,
+                    "id": 177,
                     "plz": "13127",
                     "strasse": "Hugenottenplatz",
                     "tage": "Sa",
                     "www": "",
                     "zeiten": "09:00 - 13:00"
                 },
-                "description": "Sa<br />09:00 - 13:00<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/176\">Mehr...</a>",
-                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/176",
-                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/176",
+                "description": "Sa<br />09:00 - 13:00<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/177\">Mehr...</a>",
+                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/177",
+                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/177",
                 "title": "Wochenmarkt Markt am Hugenottenplatz"
             },
             "type": "Feature"
@@ -3754,30 +3754,30 @@
         {
             "geometry": {
                 "coordinates": [
-                    13.40219,
-                    52.51228
+                    13.40221,
+                    52.51234
                 ],
                 "type": "Point"
             },
             "properties": {
                 "data": {
-                    "_wgs84_lat": 52.5122795,
-                    "_wgs84_lon": 13.4021879,
+                    "_wgs84_lat": 52.5123359,
+                    "_wgs84_lon": 13.4022077,
                     "bemerkungen": "",
                     "betreiber": "Marktleitung: B-B-M Berlin-Brandenburger Markt Veranstaltungs- und Service GmbH, \nFrau Hintsche, Tel.: 23 63 63 60 (Di-Fr 10:00-16:00, Mo, So Ruhetag) und 0172/188 31 57 (Di-Sa 06:00-18:00, Mo, So Ruhetag), Fax: 23 63 63 61 (24h täglich)",
                     "bezeichnung": "Wochenmarkt Markt am Spittelmarkt",
                     "bezirk": "Mitte",
                     "email": "mailto:info@bbm-maerkte.de",
-                    "id": 110,
+                    "id": 111,
                     "plz": "10179",
                     "strasse": "Spittelmarkt",
                     "tage": "Mi, Fr",
                     "www": "http://www.bbm-maerkte.de",
                     "zeiten": "10:00 - 15:00"
                 },
-                "description": "Mi, Fr<br />10:00 - 15:00<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/110\">Mehr...</a>",
-                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/110",
-                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/110",
+                "description": "Mi, Fr<br />10:00 - 15:00<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/111\">Mehr...</a>",
+                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/111",
+                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/111",
                 "title": "Wochenmarkt Markt am Spittelmarkt"
             },
             "type": "Feature"
@@ -3799,16 +3799,16 @@
                     "bezeichnung": "Wochenmarkt Markt am Stierbrunnen",
                     "bezirk": "Pankow",
                     "email": "",
-                    "id": 185,
+                    "id": 186,
                     "plz": "10407",
                     "strasse": "Pasteurstraße 32",
                     "tage": "Sa",
                     "www": "",
                     "zeiten": "09:00 - 15:00"
                 },
-                "description": "Sa<br />09:00 - 15:00<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/185\">Mehr...</a>",
-                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/185",
-                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/185",
+                "description": "Sa<br />09:00 - 15:00<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/186\">Mehr...</a>",
+                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/186",
+                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/186",
                 "title": "Wochenmarkt Markt am Stierbrunnen"
             },
             "type": "Feature"
@@ -3830,16 +3830,16 @@
                     "bezeichnung": "Wochenmarkt Marzahner Promenade",
                     "bezirk": "Marzahn-Hellersdorf",
                     "email": "mailto:markt-veranstaltungen@web.de",
-                    "id": 104,
+                    "id": 105,
                     "plz": "12679",
                     "strasse": "Marzahner Promenade 30-33",
                     "tage": "Mo, Mi, Fr",
                     "www": "http://www.markt-veranstaltungen.de",
                     "zeiten": "08:30 - 17:00"
                 },
-                "description": "Mo, Mi, Fr<br />08:30 - 17:00<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/104\">Mehr...</a>",
-                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/104",
-                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/104",
+                "description": "Mo, Mi, Fr<br />08:30 - 17:00<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/105\">Mehr...</a>",
+                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/105",
+                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/105",
                 "title": "Wochenmarkt Marzahner Promenade"
             },
             "type": "Feature"
@@ -3861,16 +3861,16 @@
                     "bezeichnung": "Wochenmarkt Mexikoplatz",
                     "bezirk": "Steglitz-Zehlendorf",
                     "email": "",
-                    "id": 242,
+                    "id": 243,
                     "plz": "14163",
                     "strasse": "Mexikoplatz",
                     "tage": "Sa",
                     "www": "",
                     "zeiten": "09:00 - 15:00"
                 },
-                "description": "Sa<br />09:00 - 15:00<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/242\">Mehr...</a>",
-                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/242",
-                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/242",
+                "description": "Sa<br />09:00 - 15:00<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/243\">Mehr...</a>",
+                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/243",
+                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/243",
                 "title": "Wochenmarkt Mexikoplatz"
             },
             "type": "Feature"
@@ -3892,16 +3892,16 @@
                     "bezeichnung": "Wochenmarkt Mierendorffplatz",
                     "bezirk": "Charlottenburg-Wilmersdorf",
                     "email": "",
-                    "id": 14,
+                    "id": 15,
                     "plz": "10589",
                     "strasse": "Mierendorffplatz",
                     "tage": "Mi, Sa",
                     "www": "",
                     "zeiten": "08:00 - 13:00"
                 },
-                "description": "Mi, Sa<br />08:00 - 13:00<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/14\">Mehr...</a>",
-                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/14",
-                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/14",
+                "description": "Mi, Sa<br />08:00 - 13:00<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/15\">Mehr...</a>",
+                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/15",
+                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/15",
                 "title": "Wochenmarkt Mierendorffplatz"
             },
             "type": "Feature"
@@ -3923,16 +3923,16 @@
                     "bezeichnung": "Wochenmarkt Nestorstraße",
                     "bezirk": "Charlottenburg-Wilmersdorf",
                     "email": "",
-                    "id": 23,
+                    "id": 24,
                     "plz": "10709",
                     "strasse": "Nestorstraße",
                     "tage": "Di, Fr",
                     "www": "",
                     "zeiten": "08:00 - 13:00"
                 },
-                "description": "Di, Fr<br />08:00 - 13:00<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/23\">Mehr...</a>",
-                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/23",
-                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/23",
+                "description": "Di, Fr<br />08:00 - 13:00<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/24\">Mehr...</a>",
+                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/24",
+                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/24",
                 "title": "Wochenmarkt Nestorstraße"
             },
             "type": "Feature"
@@ -3954,16 +3954,16 @@
                     "bezeichnung": "Wochenmarkt Neuer Markt am Kollwitzplatz",
                     "bezirk": "Pankow",
                     "email": "",
-                    "id": 200,
+                    "id": 201,
                     "plz": "10435",
                     "strasse": "Kollwitzplatz",
                     "tage": "Sa",
                     "www": "",
                     "zeiten": "10:30 - 16:30"
                 },
-                "description": "Sa<br />10:30 - 16:30<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/200\">Mehr...</a>",
-                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/200",
-                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/200",
+                "description": "Sa<br />10:30 - 16:30<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/201\">Mehr...</a>",
+                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/201",
+                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/201",
                 "title": "Wochenmarkt Neuer Markt am Kollwitzplatz"
             },
             "type": "Feature"
@@ -3972,29 +3972,29 @@
             "geometry": {
                 "coordinates": [
                     13.25189,
-                    52.44959
+                    52.44943
                 ],
                 "type": "Point"
             },
             "properties": {
                 "data": {
-                    "_wgs84_lat": 52.44959,
-                    "_wgs84_lon": 13.25189,
+                    "_wgs84_lat": 52.4494289,
+                    "_wgs84_lon": 13.2518907,
                     "bemerkungen": "U-Onkel-Toms-Hütte",
                     "betreiber": "DIEMARKTPLANER (Märkte & Marktstandverleih), Dipl.-Ing. Nikolaus Fink, Sanderstr. 4, 12047 Berlin, Tel.: 29 30 96 01, Fax: 29 00 96 23",
                     "bezeichnung": "Wochenmarkt Onkel-Toms-Hütte",
                     "bezirk": "Steglitz-Zehlendorf",
                     "email": "mailto:info@diemarktplaner.de",
-                    "id": 305,
+                    "id": 306,
                     "plz": "14169",
                     "strasse": "Onkel-Tom-Str. 99",
                     "tage": "Do",
                     "www": "http://www.diemarktplaner.de",
                     "zeiten": "12:00 - 18:30"
                 },
-                "description": "Do<br />12:00 - 18:30<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/305\">Mehr...</a>",
-                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/305",
-                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/305",
+                "description": "Do<br />12:00 - 18:30<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/306\">Mehr...</a>",
+                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/306",
+                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/306",
                 "title": "Wochenmarkt Onkel-Toms-Hütte"
             },
             "type": "Feature"
@@ -4016,16 +4016,16 @@
                     "bezeichnung": "Wochenmarkt Potsdam Bassinplatz",
                     "bezirk": "Brandenburg",
                     "email": "mailto:Wochenmarkt@Rathaus.Potsdam.de",
-                    "id": 293,
+                    "id": 294,
                     "plz": "14467",
                     "strasse": "Am Bassin 6",
                     "tage": "Mo - Fr\nSa",
                     "www": "",
                     "zeiten": "07:00 - 16:00\n07:00 - 13:00"
                 },
-                "description": "Mo - Fr&#10;Sa<br />07:00 - 16:00&#10;07:00 - 13:00<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/293\">Mehr...</a>",
-                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/293",
-                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/293",
+                "description": "Mo - Fr&#10;Sa<br />07:00 - 16:00&#10;07:00 - 13:00<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/294\">Mehr...</a>",
+                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/294",
+                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/294",
                 "title": "Wochenmarkt Potsdam Bassinplatz"
             },
             "type": "Feature"
@@ -4047,16 +4047,16 @@
                     "bezeichnung": "Wochenmarkt Prerower Platz",
                     "bezirk": "Lichtenberg",
                     "email": "mailto:markt-veranstaltungen@web.de",
-                    "id": 92,
+                    "id": 93,
                     "plz": "13051",
                     "strasse": "Prerower Platz",
                     "tage": "Mi",
                     "www": "http://www.markt-veranstaltungen.de",
                     "zeiten": "09:00 - 17:00"
                 },
-                "description": "Mi<br />09:00 - 17:00<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/92\">Mehr...</a>",
-                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/92",
-                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/92",
+                "description": "Mi<br />09:00 - 17:00<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/93\">Mehr...</a>",
+                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/93",
+                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/93",
                 "title": "Wochenmarkt Prerower Platz"
             },
             "type": "Feature"
@@ -4078,16 +4078,16 @@
                     "bezeichnung": "Wochenmarkt Preußenallee",
                     "bezirk": "Charlottenburg-Wilmersdorf",
                     "email": "",
-                    "id": 8,
+                    "id": 9,
                     "plz": "14052",
                     "strasse": "Preußenallee",
                     "tage": "Di, Fr",
                     "www": "",
                     "zeiten": "08:00 - 13:00"
                 },
-                "description": "Di, Fr<br />08:00 - 13:00<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/8\">Mehr...</a>",
-                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/8",
-                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/8",
+                "description": "Di, Fr<br />08:00 - 13:00<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/9\">Mehr...</a>",
+                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/9",
+                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/9",
                 "title": "Wochenmarkt Preußenallee"
             },
             "type": "Feature"
@@ -4109,16 +4109,16 @@
                     "bezeichnung": "Wochenmarkt Rathaus Lankwitz",
                     "bezirk": "Steglitz-Zehlendorf",
                     "email": "",
-                    "id": 230,
+                    "id": 231,
                     "plz": "12247",
                     "strasse": "Leonorenstraße",
                     "tage": "Mo, Fr",
                     "www": "",
                     "zeiten": "08:00 - 13:00"
                 },
-                "description": "Mo, Fr<br />08:00 - 13:00<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/230\">Mehr...</a>",
-                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/230",
-                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/230",
+                "description": "Mo, Fr<br />08:00 - 13:00<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/231\">Mehr...</a>",
+                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/231",
+                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/231",
                 "title": "Wochenmarkt Rathaus Lankwitz"
             },
             "type": "Feature"
@@ -4140,16 +4140,16 @@
                     "bezeichnung": "Wochenmarkt Rathausvorplatz",
                     "bezirk": "Spandau",
                     "email": "mailto:marktverwaltung@ba-spandau.berlin.de",
-                    "id": 206,
+                    "id": 207,
                     "plz": "13597",
                     "strasse": "Markt 3",
                     "tage": "Mi\nSa",
                     "www": "",
                     "zeiten": "08:00 - 18:00\n08:00 - 16:00"
                 },
-                "description": "Mi&#10;Sa<br />08:00 - 18:00&#10;08:00 - 16:00<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/206\">Mehr...</a>",
-                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/206",
-                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/206",
+                "description": "Mi&#10;Sa<br />08:00 - 18:00&#10;08:00 - 16:00<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/207\">Mehr...</a>",
+                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/207",
+                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/207",
                 "title": "Wochenmarkt Rathausvorplatz"
             },
             "type": "Feature"
@@ -4157,30 +4157,30 @@
         {
             "geometry": {
                 "coordinates": [
-                    13.3058,
-                    52.51735
+                    13.30568,
+                    52.51731
                 ],
                 "type": "Point"
             },
             "properties": {
                 "data": {
-                    "_wgs84_lat": 52.5173483,
-                    "_wgs84_lon": 13.3057964,
+                    "_wgs84_lat": 52.5173124,
+                    "_wgs84_lon": 13.3056758,
                     "bemerkungen": "",
                     "betreiber": "Bezirksamt Charlottenburg-Wilmersdorf, Marktverwaltung, Hohenzollerndamm 174-177, 10713 Berlin\nTel.: 9029 - 290 72/3",
                     "bezeichnung": "Wochenmarkt Richard-Wagner-Platz",
                     "bezirk": "Charlottenburg-Wilmersdorf",
                     "email": "",
-                    "id": 2,
+                    "id": 3,
                     "plz": "10585",
                     "strasse": "Richard-Wagner-Platz",
                     "tage": "Mo, Do",
                     "www": "",
                     "zeiten": "08:00 - 13:00"
                 },
-                "description": "Mo, Do<br />08:00 - 13:00<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/2\">Mehr...</a>",
-                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/2",
-                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/2",
+                "description": "Mo, Do<br />08:00 - 13:00<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/3\">Mehr...</a>",
+                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/3",
+                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/3",
                 "title": "Wochenmarkt Richard-Wagner-Platz"
             },
             "type": "Feature"
@@ -4202,16 +4202,16 @@
                     "bezeichnung": "Wochenmarkt Schellerstraße Ecke Spreestraße",
                     "bezirk": "Treptow-Köpenick",
                     "email": "mailto:berndgellesch@t-online.de",
-                    "id": 335,
+                    "id": 336,
                     "plz": "12439",
                     "strasse": "Schnellerstraße",
                     "tage": "Do",
                     "www": "http://www.gakenholz-gellesch.e",
                     "zeiten": "08:00 - 16:00"
                 },
-                "description": "Do<br />08:00 - 16:00<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/335\">Mehr...</a>",
-                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/335",
-                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/335",
+                "description": "Do<br />08:00 - 16:00<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/336\">Mehr...</a>",
+                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/336",
+                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/336",
                 "title": "Wochenmarkt Schellerstraße Ecke Spreestraße"
             },
             "type": "Feature"
@@ -4233,16 +4233,16 @@
                     "bezeichnung": "Wochenmarkt Schillermarkt am Herrfurthplatz",
                     "bezirk": "Neukölln",
                     "email": "mailto:info@mv-perske.de",
-                    "id": 167,
+                    "id": 168,
                     "plz": "12049",
                     "strasse": "Herrfurthplatz",
                     "tage": "Mi",
                     "www": "http://www.mv-perske.de",
                     "zeiten": "10:00 - 18:00"
                 },
-                "description": "Mi<br />10:00 - 18:00<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/167\">Mehr...</a>",
-                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/167",
-                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/167",
+                "description": "Mi<br />10:00 - 18:00<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/168\">Mehr...</a>",
+                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/168",
+                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/168",
                 "title": "Wochenmarkt Schillermarkt am Herrfurthplatz"
             },
             "type": "Feature"
@@ -4264,16 +4264,16 @@
                     "bezeichnung": "Wochenmarkt Schlossplatz Alt-Köpenick",
                     "bezirk": "Treptow-Köpenick",
                     "email": "mailto:s.stahl@marktgilde.de",
-                    "id": 278,
+                    "id": 279,
                     "plz": "12555",
                     "strasse": "Grünstraße 1",
                     "tage": "Di, Do",
                     "www": "",
                     "zeiten": "08:30 - 17:00"
                 },
-                "description": "Di, Do<br />08:30 - 17:00<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/278\">Mehr...</a>",
-                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/278",
-                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/278",
+                "description": "Di, Do<br />08:30 - 17:00<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/279\">Mehr...</a>",
+                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/279",
+                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/279",
                 "title": "Wochenmarkt Schlossplatz Alt-Köpenick"
             },
             "type": "Feature"
@@ -4295,16 +4295,16 @@
                     "bezeichnung": "Wochenmarkt Schnellerstraße",
                     "bezirk": "Treptow-Köpenick",
                     "email": "mailto:berndgellesch@t-online.de",
-                    "id": 281,
+                    "id": 282,
                     "plz": "12439",
                     "strasse": "Schnellerstraße",
                     "tage": "Do",
                     "www": "http://www.brandenburger-wochenmaerkte.de",
                     "zeiten": "08:00 - 16:00"
                 },
-                "description": "Do<br />08:00 - 16:00<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/281\">Mehr...</a>",
-                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/281",
-                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/281",
+                "description": "Do<br />08:00 - 16:00<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/282\">Mehr...</a>",
+                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/282",
+                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/282",
                 "title": "Wochenmarkt Schnellerstraße"
             },
             "type": "Feature"
@@ -4326,16 +4326,16 @@
                     "bezeichnung": "Wochenmarkt Seelower Straße",
                     "bezirk": "Pankow",
                     "email": "mailto:info@bbm-maerkte.de",
-                    "id": 182,
+                    "id": 183,
                     "plz": "10439",
                     "strasse": "Seelower Straße",
                     "tage": "Sa",
                     "www": "http://www.bbm-maerkte.de",
                     "zeiten": "09:00 - 16:00"
                 },
-                "description": "Sa<br />09:00 - 16:00<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/182\">Mehr...</a>",
-                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/182",
-                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/182",
+                "description": "Sa<br />09:00 - 16:00<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/183\">Mehr...</a>",
+                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/183",
+                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/183",
                 "title": "Wochenmarkt Seelower Straße"
             },
             "type": "Feature"
@@ -4343,30 +4343,30 @@
         {
             "geometry": {
                 "coordinates": [
-                    13.29583,
-                    52.50759
+                    13.2957,
+                    52.5074
                 ],
                 "type": "Point"
             },
             "properties": {
                 "data": {
-                    "_wgs84_lat": 52.5075923,
-                    "_wgs84_lon": 13.2958334,
+                    "_wgs84_lat": 52.5074044,
+                    "_wgs84_lon": 13.2956976,
                     "bemerkungen": "",
                     "betreiber": "Deutsche Marktgilde eG, Ansprechpartner: Dirk Dieter, Tel.: 0160/99 07 58 54",
                     "bezeichnung": "Wochenmarkt Suarezstraße",
                     "bezirk": "Charlottenburg-Wilmersdorf",
                     "email": "d.dieter@marktgilde.de",
-                    "id": 371,
+                    "id": 372,
                     "plz": "14057",
                     "strasse": "Suarezstraße 48",
                     "tage": "Do",
                     "www": "www.treffpunkt-wochenmarkt.de",
                     "zeiten": "08:00 - 14:00"
                 },
-                "description": "Do<br />08:00 - 14:00<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/371\">Mehr...</a>",
-                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/371",
-                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/371",
+                "description": "Do<br />08:00 - 14:00<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/372\">Mehr...</a>",
+                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/372",
+                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/372",
                 "title": "Wochenmarkt Suarezstraße"
             },
             "type": "Feature"
@@ -4388,16 +4388,16 @@
                     "bezeichnung": "Wochenmarkt Winterfeldtplatz",
                     "bezirk": "Tempelhof-Schöneberg",
                     "email": "mailto:marktverwaltung@ba-ts.berlin.de",
-                    "id": 251,
+                    "id": 252,
                     "plz": "10781",
                     "strasse": "Winterfeldtplatz",
                     "tage": "Mi\nSa",
                     "www": "http://www.berlin.de/ba-tempelhof-schoeneberg/politik-und-verwaltung/aemter/ordnungsamt/maerkte",
                     "zeiten": "08:00 - 14:00\n08:00 - 16:00"
                 },
-                "description": "Mi&#10;Sa<br />08:00 - 14:00&#10;08:00 - 16:00<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/251\">Mehr...</a>",
-                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/251",
-                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/251",
+                "description": "Mi&#10;Sa<br />08:00 - 14:00&#10;08:00 - 16:00<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/252\">Mehr...</a>",
+                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/252",
+                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/252",
                 "title": "Wochenmarkt Winterfeldtplatz"
             },
             "type": "Feature"
@@ -4419,16 +4419,16 @@
                     "bezeichnung": "Wochenmarkt Wittenbergplatz (Nordseite)",
                     "bezirk": "Tempelhof-Schöneberg",
                     "email": "mailto:marktverwaltung@ba-ts.berlin.de",
-                    "id": 263,
+                    "id": 264,
                     "plz": "10789",
                     "strasse": "Wittenbergplatz 5",
                     "tage": "Di, Fr",
                     "www": "http://www.berlin.de/ba-tempelhof-schoeneberg/politik-und-verwaltung/aemter/ordnungsamt/maerkte",
                     "zeiten": "08:00 - 15:00"
                 },
-                "description": "Di, Fr<br />08:00 - 15:00<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/263\">Mehr...</a>",
-                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/263",
-                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/263",
+                "description": "Di, Fr<br />08:00 - 15:00<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/264\">Mehr...</a>",
+                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/264",
+                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/264",
                 "title": "Wochenmarkt Wittenbergplatz (Nordseite)"
             },
             "type": "Feature"
@@ -4450,16 +4450,16 @@
                     "bezeichnung": "Wochenmarkt Zingster Straße",
                     "bezirk": "Lichtenberg",
                     "email": "mailto:markt-veranstaltungen@web.de",
-                    "id": 89,
+                    "id": 90,
                     "plz": "13051",
                     "strasse": "Zingster Straße",
                     "tage": "Sa",
                     "www": "http://www.markt-veranstaltungen.de",
                     "zeiten": "09:00 - 13:00"
                 },
-                "description": "Sa<br />09:00 - 13:00<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/89\">Mehr...</a>",
-                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/89",
-                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/89",
+                "description": "Sa<br />09:00 - 13:00<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/90\">Mehr...</a>",
+                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/90",
+                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/90",
                 "title": "Wochenmarkt Zingster Straße"
             },
             "type": "Feature"
@@ -4481,16 +4481,16 @@
                     "bezeichnung": "Wochenmarkt am Hackeschen Markt",
                     "bezirk": "Mitte",
                     "email": "",
-                    "id": 119,
+                    "id": 120,
                     "plz": "10178",
                     "strasse": "Hackescher Markt",
                     "tage": "Do",
                     "www": "",
                     "zeiten": "09:00 - 18:00"
                 },
-                "description": "Do<br />09:00 - 18:00<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/119\">Mehr...</a>",
-                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/119",
-                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/119",
+                "description": "Do<br />09:00 - 18:00<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/120\">Mehr...</a>",
+                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/120",
+                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/120",
                 "title": "Wochenmarkt am Hackeschen Markt"
             },
             "type": "Feature"
@@ -4512,16 +4512,16 @@
                     "bezeichnung": "Wochenmarkt am Hackeschen Markt",
                     "bezirk": "Mitte",
                     "email": "mailto:hackescherwochenmarktsamstag@hotmail.de",
-                    "id": 122,
+                    "id": 123,
                     "plz": "10178",
                     "strasse": "Hackescher Markt",
                     "tage": "Sa",
                     "www": "",
                     "zeiten": "10:00 - 18:00"
                 },
-                "description": "Sa<br />10:00 - 18:00<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/122\">Mehr...</a>",
-                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/122",
-                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/122",
+                "description": "Sa<br />10:00 - 18:00<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/123\">Mehr...</a>",
+                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/123",
+                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/123",
                 "title": "Wochenmarkt am Hackeschen Markt"
             },
             "type": "Feature"
@@ -4543,16 +4543,16 @@
                     "bezeichnung": "Wochenmarkt am Rathaus Wedding",
                     "bezirk": "Mitte",
                     "email": "mailto:berndgellesch@t-online.de",
-                    "id": 113,
+                    "id": 114,
                     "plz": "13353",
                     "strasse": "Ostender Straße",
                     "tage": "Mi, Sa",
                     "www": "http://www.brandenburger-wochenmaerkte.de",
                     "zeiten": "07:00 - 16:00"
                 },
-                "description": "Mi, Sa<br />07:00 - 16:00<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/113\">Mehr...</a>",
-                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/113",
-                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/113",
+                "description": "Mi, Sa<br />07:00 - 16:00<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/114\">Mehr...</a>",
+                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/114",
+                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/114",
                 "title": "Wochenmarkt am Rathaus Wedding"
             },
             "type": "Feature"
@@ -4574,16 +4574,16 @@
                     "bezeichnung": "Zehlendorf Frische Markt zwischen Teltower Damm und Postplatz direkt am S-Bahnhof Zehlendorf",
                     "bezirk": "Steglitz-Zehlendorf",
                     "email": "mailto:markt-zehlendorf@gmx.de",
-                    "id": 308,
+                    "id": 309,
                     "plz": "14163",
                     "strasse": "S-Bahnhof Zehlendorf",
                     "tage": "Sa",
                     "www": "http://www.zehlendorfer-wochenmarkt.de",
                     "zeiten": "09:00 - 16:00"
                 },
-                "description": "Sa<br />09:00 - 16:00<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/308\">Mehr...</a>",
-                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/308",
-                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/308",
+                "description": "Sa<br />09:00 - 16:00<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/309\">Mehr...</a>",
+                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/309",
+                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/309",
                 "title": "Zehlendorf Frische Markt zwischen Teltower Damm und Postplatz direkt am S-Bahnhof Zehlendorf"
             },
             "type": "Feature"
@@ -4605,16 +4605,16 @@
                     "bezeichnung": "anZiehmarkt",
                     "bezirk": "Steglitz-Zehlendorf",
                     "email": "markttag@web.de",
-                    "id": 464,
+                    "id": 465,
                     "plz": "14195",
                     "strasse": "Breitenbachplatz",
                     "tage": "16.04., 21.05., 18.06., 16.07., 20.08., 17.09., 15.10., 12.11.2023",
                     "www": "www.markttag-berlin.de",
                     "zeiten": "10:30-15:00"
                 },
-                "description": "16.04., 21.05., 18.06., 16.07., 20.08., 17.09., 15.10., 12.11.2023<br />10:30-15:00<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/464\">Mehr...</a>",
-                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/464",
-                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/464",
+                "description": "16.04., 21.05., 18.06., 16.07., 20.08., 17.09., 15.10., 12.11.2023<br />10:30-15:00<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/465\">Mehr...</a>",
+                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/465",
+                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/465",
                 "title": "anZiehmarkt"
             },
             "type": "Feature"
@@ -4636,16 +4636,16 @@
                     "bezeichnung": "Öko-Wochenmarkt Domäne Dahlem",
                     "bezirk": "Steglitz-Zehlendorf",
                     "email": "mailto:oekomarkt@domaene-dahlem.de",
-                    "id": 239,
+                    "id": 240,
                     "plz": "14195",
                     "strasse": "Königin-Luise-Str. 49",
                     "tage": "Sa",
                     "www": "http://www.domaene-dahlem.de",
                     "zeiten": "08:00 - 13:00"
                 },
-                "description": "Sa<br />08:00 - 13:00<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/239\">Mehr...</a>",
-                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/239",
-                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/239",
+                "description": "Sa<br />08:00 - 13:00<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/240\">Mehr...</a>",
+                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/240",
+                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/240",
                 "title": "Öko-Wochenmarkt Domäne Dahlem"
             },
             "type": "Feature"
@@ -4667,16 +4667,16 @@
                     "bezeichnung": "Ökomarkt & mehr am Nordbahnhof",
                     "bezirk": "Mitte",
                     "email": "mailto:marktzeit@posteo.de",
-                    "id": 128,
+                    "id": 129,
                     "plz": "10115",
                     "strasse": "Elisabeth-Schwarzhaupt-Platz",
                     "tage": "Mi",
                     "www": "http://www.marktzeit.berlin",
                     "zeiten": "11:00 - 17:00"
                 },
-                "description": "Mi<br />11:00 - 17:00<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/128\">Mehr...</a>",
-                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/128",
-                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/128",
+                "description": "Mi<br />11:00 - 17:00<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/129\">Mehr...</a>",
+                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/129",
+                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/129",
                 "title": "Ökomarkt & mehr am Nordbahnhof"
             },
             "type": "Feature"
@@ -4698,16 +4698,16 @@
                     "bezeichnung": "Ökomarkt & mehr an der Akazienstraße",
                     "bezirk": "Tempelhof-Schöneberg",
                     "email": "mailto:marktzeit@posteo.de",
-                    "id": 323,
+                    "id": 324,
                     "plz": "10823",
                     "strasse": "Akazienstraße 15",
                     "tage": "Do",
                     "www": "http://www.marktzeit.berlin/",
                     "zeiten": "12:00 - 18:00"
                 },
-                "description": "Do<br />12:00 - 18:00<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/323\">Mehr...</a>",
-                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/323",
-                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/323",
+                "description": "Do<br />12:00 - 18:00<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/324\">Mehr...</a>",
+                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/324",
+                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/324",
                 "title": "Ökomarkt & mehr an der Akazienstraße"
             },
             "type": "Feature"
@@ -4729,16 +4729,16 @@
                     "bezeichnung": "Ökomarkt & mehr an der Thusnelda-Allee",
                     "bezirk": "Mitte",
                     "email": "mailto:marktzeit@posteo.de",
-                    "id": 317,
+                    "id": 318,
                     "plz": "10555",
                     "strasse": "Thusnelda-Allee 1",
                     "tage": "Mi",
                     "www": "http://www.marktzeit.berlin/",
                     "zeiten": "12:00 - 18:00"
                 },
-                "description": "Mi<br />12:00 - 18:00<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/317\">Mehr...</a>",
-                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/317",
-                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/317",
+                "description": "Mi<br />12:00 - 18:00<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/318\">Mehr...</a>",
+                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/318",
+                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/318",
                 "title": "Ökomarkt & mehr an der Thusnelda-Allee"
             },
             "type": "Feature"
@@ -4760,16 +4760,16 @@
                     "bezeichnung": "Ökomarkt - Chamissoplatz",
                     "bezirk": "Friedrichshain-Kreuzberg",
                     "email": "mailto:info@oekomarkt-chamissoplatz.de",
-                    "id": 56,
+                    "id": 57,
                     "plz": "10965",
                     "strasse": "Chamissoplatz",
                     "tage": "Sa",
                     "www": "http://www.oekomarkt-chamissoplatz.de",
                     "zeiten": "09:00 - 15:00"
                 },
-                "description": "Sa<br />09:00 - 15:00<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/56\">Mehr...</a>",
-                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/56",
-                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/56",
+                "description": "Sa<br />09:00 - 15:00<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/57\">Mehr...</a>",
+                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/57",
+                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/57",
                 "title": "Ökomarkt - Chamissoplatz"
             },
             "type": "Feature"
@@ -4777,30 +4777,30 @@
         {
             "geometry": {
                 "coordinates": [
-                    13.42247,
-                    52.49113
+                    13.42188,
+                    52.49118
                 ],
                 "type": "Point"
             },
             "properties": {
                 "data": {
-                    "_wgs84_lat": 52.4911309,
-                    "_wgs84_lon": 13.4224693,
+                    "_wgs84_lat": 52.4911804,
+                    "_wgs84_lon": 13.4218807,
                     "bemerkungen": "Graefekiez Kreuzberg",
                     "betreiber": "Marktverwaltung \nRainer Perske\nTel.: 29 77 24 86, \nFax: 29 77 25 91",
                     "bezeichnung": "Ökomarkt Hohenstaufenplatz",
                     "bezirk": "Friedrichshain-Kreuzberg",
                     "email": "mailto:info@mv-perske.de",
-                    "id": 392,
+                    "id": 393,
                     "plz": "10967",
                     "strasse": "Zickenplatz",
                     "tage": "Di\nSa",
                     "www": "http://www.mv-perske.de",
                     "zeiten": "12:00 - 18:00\n09:00 - 15:00"
                 },
-                "description": "Di&#10;Sa<br />12:00 - 18:00&#10;09:00 - 15:00<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/392\">Mehr...</a>",
-                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/392",
-                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/392",
+                "description": "Di&#10;Sa<br />12:00 - 18:00&#10;09:00 - 15:00<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/393\">Mehr...</a>",
+                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/393",
+                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/393",
                 "title": "Ökomarkt Hohenstaufenplatz"
             },
             "type": "Feature"
@@ -4822,16 +4822,16 @@
                     "bezeichnung": "Ökomarkt Lausitzer Platz",
                     "bezirk": "Friedrichshain-Kreuzberg",
                     "email": "mailto:info@mv-perske.de",
-                    "id": 395,
+                    "id": 396,
                     "plz": "10997",
                     "strasse": "Lausitzer Platz",
                     "tage": "Fr",
                     "www": "http://www.mv-perske.de",
                     "zeiten": "12:00 - 18:00"
                 },
-                "description": "Fr<br />12:00 - 18:00<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/395\">Mehr...</a>",
-                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/395",
-                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/395",
+                "description": "Fr<br />12:00 - 18:00<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/396\">Mehr...</a>",
+                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/396",
+                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/396",
                 "title": "Ökomarkt Lausitzer Platz"
             },
             "type": "Feature"
@@ -4853,16 +4853,16 @@
                     "bezeichnung": "Ökomarkt am Kollwitzplatz der GRÜNEN LIGA Berlin e. V.",
                     "bezirk": "Pankow",
                     "email": "mailto:oekomarkt.kollwitzplatz@grueneliga-berlin.de",
-                    "id": 170,
+                    "id": 171,
                     "plz": "10435",
                     "strasse": "Kollwitzplatz",
                     "tage": "Do",
                     "www": "http://www.grueneliga-berlin.de",
                     "zeiten": "12:00 - 19:00"
                 },
-                "description": "Do<br />12:00 - 19:00<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/170\">Mehr...</a>",
-                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/170",
-                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/170",
+                "description": "Do<br />12:00 - 19:00<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/171\">Mehr...</a>",
+                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/171",
+                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/171",
                 "title": "Ökomarkt am Kollwitzplatz der GRÜNEN LIGA Berlin e. V."
             },
             "type": "Feature"
@@ -4884,16 +4884,16 @@
                     "bezeichnung": "Ökomarkt im Hansaviertel",
                     "bezirk": "Mitte",
                     "email": "mailto:marktzeit@posteo.de",
-                    "id": 125,
+                    "id": 126,
                     "plz": "10557",
                     "strasse": "Altonaer Straße",
                     "tage": "Fr",
                     "www": "http://www.marktzeit.berlin",
                     "zeiten": "12:00 - 18:30"
                 },
-                "description": "Fr<br />12:00 - 18:30<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/125\">Mehr...</a>",
-                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/125",
-                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/125",
+                "description": "Fr<br />12:00 - 18:30<br /> <a href=\"/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/126\">Mehr...</a>",
+                "href": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/126",
+                "id": "/sen/web/service/maerkte-feste/wochen-troedelmaerkte/index.php/detail/126",
                 "title": "Ökomarkt im Hansaviertel"
             },
             "type": "Feature"


### PR DESCRIPTION
# Known issues
At least three markets are mapped to wrong coordinates:
- Kunst-Kreativ-Markt
- Wochenmarkt Hohenzollernplatz
- Kinder-Baby-Trödel

:heavy_check_mark: These have been fixed manually in this commit.

These have been reported to the data publisher.