### PR TITLE
Fix broken website (leaflet.locatecontrol).

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "jquery": "^3.7.1",
         "leaflet": "^1.9.4",
         "leaflet.awesome-markers": "^2.0.5",
-        "leaflet.locatecontrol": "^0.82.0",
+        "leaflet.locatecontrol": "^0.81.1",
         "normalize.css": "^8.0.1",
         "opening_hours": "^3.8.0",
         "select2": "^4.0.13"
@@ -1442,9 +1442,9 @@
       "integrity": "sha512-Ne/xDjkGyaujwNVVkv2tyXQUV0ZW7gZ0Mo0FuQY4jp2qWrvXi0hwDBvmZyF/8YOvybyMabTMM/mFWCTd1jZIQA=="
     },
     "node_modules/leaflet.locatecontrol": {
-      "version": "0.82.0",
-      "resolved": "https://registry.npmjs.org/leaflet.locatecontrol/-/leaflet.locatecontrol-0.82.0.tgz",
-      "integrity": "sha512-+lvtZ7tfqgWoUvTYRqDggw50HUZJGvaSgSU5JYvl5H4WtlnHek2R0TsL0EqROhT3igPFwYVV87bFT/ps1SqyGA=="
+      "version": "0.81.1",
+      "resolved": "https://registry.npmjs.org/leaflet.locatecontrol/-/leaflet.locatecontrol-0.81.1.tgz",
+      "integrity": "sha512-ZtsdScGufPw330X3UIaGGjnfQ1NrhLySnlruWufIMnfzsHgQPz0+mSxsCQMVh7QgOBoefCGb/lioSejiaNx1EQ=="
     },
     "node_modules/lodash": {
       "version": "4.17.21",
@@ -3430,9 +3430,9 @@
       "integrity": "sha512-Ne/xDjkGyaujwNVVkv2tyXQUV0ZW7gZ0Mo0FuQY4jp2qWrvXi0hwDBvmZyF/8YOvybyMabTMM/mFWCTd1jZIQA=="
     },
     "leaflet.locatecontrol": {
-      "version": "0.82.0",
-      "resolved": "https://registry.npmjs.org/leaflet.locatecontrol/-/leaflet.locatecontrol-0.82.0.tgz",
-      "integrity": "sha512-+lvtZ7tfqgWoUvTYRqDggw50HUZJGvaSgSU5JYvl5H4WtlnHek2R0TsL0EqROhT3igPFwYVV87bFT/ps1SqyGA=="
+      "version": "0.81.1",
+      "resolved": "https://registry.npmjs.org/leaflet.locatecontrol/-/leaflet.locatecontrol-0.81.1.tgz",
+      "integrity": "sha512-ZtsdScGufPw330X3UIaGGjnfQ1NrhLySnlruWufIMnfzsHgQPz0+mSxsCQMVh7QgOBoefCGb/lioSejiaNx1EQ=="
     },
     "lodash": {
       "version": "4.17.21",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "jquery": "^3.7.1",
     "leaflet": "^1.9.4",
     "leaflet.awesome-markers": "^2.0.5",
-    "leaflet.locatecontrol": "^0.82.0",
+    "leaflet.locatecontrol": "^0.81.1",
     "normalize.css": "^8.0.1",
     "opening_hours": "^3.8.0",
     "select2": "^4.0.13"


### PR DESCRIPTION
+ Error: `Uncaught TypeError: L.control.locate is not a function`
+ Revert "build(deps): bump leaflet.locatecontrol from 0.81.1 to 0.82.0"
+ This reverts commit 8f31e14c491ba4d1abb8bdc8b314b362f49bca5a.

# Related
- https://github.com/wo-ist-markt/wo-ist-markt.github.io/pull/680