### PR TITLE
Handle SSL verification issue due to incomplete certificate chain.

### DIFF
--- a/validation/markets-validator.js
+++ b/validation/markets-validator.js
@@ -57,7 +57,7 @@ var ACCEPTABLE_WARNINGS_COUNT = 2; // Marl IPv6, Chemnitz user agent
 var exitCode = 0;
 
 var asyncWarnings = [];
-var asyncExpiredCertificateIssues = [];
+var asyncCertificateIssues = [];
 var asyncErrors = [];
 
 colors.setTheme({
@@ -135,7 +135,7 @@ process.on('beforeExit', function () {
     });
 
     console.log("\n");
-    asyncExpiredCertificateIssues.forEach(function (issue) {
+    asyncCertificateIssues.forEach(function (issue) {
         console.log("Info: ".info + getFormattedText(issue.toString()));
     });
 
@@ -627,7 +627,7 @@ function MetadataValidator(metadata, cityName) {
 
         function handleError(error) {
             if (error == "Error: certificate has expired") {
-                asyncExpiredCertificateIssues.push(new ExpiredCertificateIssue(cityName));
+                asyncCertificateIssues.push(new ExpiredCertificateIssue(cityName));
             } else {
                 asyncWarnings.push(new HttpRequestErrorIssue(cityName, error));
             }


### PR DESCRIPTION
# Description
+ The webserver of [München](https://maerkte-muenchen.de/unsere-maerkte/wochenmaerkte.html) uses an incomplete certificate chain.
+ Checked with https://www.ssllabs.com/ssltest/.
+ To get rid of the validation error SSL verification is disabled for that request.

# Error log
``` bash
Detailed error: Error: unable to verify the first certificate
    at TLSSocket.onConnectSecure (node:_tls_wrap:1674:34)
    at TLSSocket.emit (node:events:519:28)
    at TLSSocket._finishInit (node:_tls_wrap:1085:8)
    at ssl.onhandshakedone (node:_tls_wrap:871:12) {
  code: 'UNABLE_TO_VERIFY_LEAF_SIGNATURE'
}
```